### PR TITLE
docs: fix incorrect workflow references and broken example links

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Unified security scanning for GitHub Actions — SAST, containers, IaC, secrets,
 
 ## Quick Start
 
-Create `.github/workflows/security-scan.yml`:
+Create `.github/workflows/security.yml`:
 
 ```yaml
 name: Security Scan
@@ -41,7 +41,7 @@ on: [pull_request, push]
 
 jobs:
   security:
-    uses: huntridge-labs/argus/.github/workflows/security-scan.yml@0.6.2
+    uses: huntridge-labs/argus/.github/workflows/reusable-security-hardening.yml@0.6.2
     with:
       scanners: all
       enable_code_security: true
@@ -168,7 +168,7 @@ permissions:
 
 jobs:
   security:
-    uses: huntridge-labs/argus/.github/workflows/security-scan.yml@0.6.2
+    uses: huntridge-labs/argus/.github/workflows/reusable-security-hardening.yml@0.6.2
     with:
       scanners: all
       enable_code_security: true
@@ -189,7 +189,7 @@ on: [pull_request]
 
 jobs:
   sast:
-    uses: huntridge-labs/argus/.github/workflows/security-scan.yml@0.6.2
+    uses: huntridge-labs/argus/.github/workflows/reusable-security-hardening.yml@0.6.2
     with:
       scanners: codeql,bandit,opengrep,gitleaks
       codeql_languages: 'python,javascript'
@@ -213,7 +213,7 @@ on:
 
 jobs:
   scan-image:
-    uses: huntridge-labs/argus/.github/workflows/security-scan.yml@0.6.2
+    uses: huntridge-labs/argus/.github/workflows/reusable-security-hardening.yml@0.6.2
     with:
       scanners: trivy-container,grype,sbom
       image_ref: 'ghcr.io/myorg/myapp:${{ github.ref_name }}'
@@ -285,7 +285,7 @@ on:
 
 jobs:
   iac:
-    uses: huntridge-labs/argus/.github/workflows/security-scan.yml@0.6.2
+    uses: huntridge-labs/argus/.github/workflows/reusable-security-hardening.yml@0.6.2
     with:
       scanners: trivy-iac,checkov
       iac_path: 'terraform/'
@@ -307,7 +307,7 @@ on:
 
 jobs:
   security:
-    uses: huntridge-labs/argus/.github/workflows/security-scan.yml@0.6.2
+    uses: huntridge-labs/argus/.github/workflows/reusable-security-hardening.yml@0.6.2
     with:
       scanners: all
       enable_code_security: true

--- a/docs/failure-control.md
+++ b/docs/failure-control.md
@@ -118,7 +118,7 @@ on:
 
 jobs:
   security:
-    uses: huntridge-labs/argus/.github/workflows/security-scan.yml@0.6.2
+    uses: huntridge-labs/argus/.github/workflows/reusable-security-hardening.yml@0.6.2
     with:
       scanners: all
       fail_on_severity: none  # Report only
@@ -136,7 +136,7 @@ on:
 
 jobs:
   security:
-    uses: huntridge-labs/argus/.github/workflows/security-scan.yml@0.6.2
+    uses: huntridge-labs/argus/.github/workflows/reusable-security-hardening.yml@0.6.2
     with:
       scanners: all
       fail_on_severity: high
@@ -154,7 +154,7 @@ on:
 
 jobs:
   security:
-    uses: huntridge-labs/argus/.github/workflows/security-scan.yml@0.6.2
+    uses: huntridge-labs/argus/.github/workflows/reusable-security-hardening.yml@0.6.2
     with:
       scanners: all
       fail_on_severity: medium
@@ -172,7 +172,7 @@ on:
 
 jobs:
   security:
-    uses: huntridge-labs/argus/.github/workflows/security-scan.yml@0.6.2
+    uses: huntridge-labs/argus/.github/workflows/reusable-security-hardening.yml@0.6.2
     with:
       scanners: all
       fail_on_severity: none
@@ -198,19 +198,19 @@ Configure different thresholds for different scanners by running them in separat
 ```yaml
 jobs:
   code-scan:
-    uses: huntridge-labs/argus/.github/workflows/security-scan.yml@0.6.2
+    uses: huntridge-labs/argus/.github/workflows/reusable-security-hardening.yml@0.6.2
     with:
       scanners: codeql,bandit
       fail_on_severity: high
 
   secret-scan:
-    uses: huntridge-labs/argus/.github/workflows/security-scan.yml@0.6.2
+    uses: huntridge-labs/argus/.github/workflows/reusable-security-hardening.yml@0.6.2
     with:
       scanners: gitleaks
       fail_on_severity: critical
 
   container-scan:
-    uses: huntridge-labs/argus/.github/workflows/security-scan.yml@0.6.2
+    uses: huntridge-labs/argus/.github/workflows/reusable-security-hardening.yml@0.6.2
     with:
       scanners: trivy-container
       image_ref: 'myapp:latest'
@@ -267,7 +267,7 @@ Use GitHub branch protection to require manual review:
 # .github/workflows/security.yml
 jobs:
   security:
-    uses: huntridge-labs/argus/.github/workflows/security-scan.yml@0.6.2
+    uses: huntridge-labs/argus/.github/workflows/reusable-security-hardening.yml@0.6.2
     with:
       fail_on_severity: high
     continue-on-error: true  # Don't block merge

--- a/examples/README.md
+++ b/examples/README.md
@@ -114,10 +114,10 @@ jobs:
 |--------------|-------------|----------|
 | [`composite-actions-example.yml`](workflows/composite-actions-example.yml) | Full example using composite actions | Most flexible approach |
 | [`use-reusable-workflow.yml`](workflows/use-reusable-workflow.yml) | Simple reusable workflow call | Quick setup |
-| [`individual-scanner-workflows.yml`](individual-scanner-workflows.yml) | Individual scanner workflow calls | Granular control |
+| [`individual-scanner-workflows.yml`](workflows/individual-scanner-workflows.yml) | Individual scanner workflow calls | Granular control |
 | [`container-config.example.yml`](configs/container-config.example.yml) | Container scanning configuration | Container security |
-| [`scanner-zap-podinfo.yml`](scanner-zap-podinfo.yml) | ZAP DAST scanning example | Web app security |
-| [`actions-container-scan-matrix.yml`](actions-container-scan-matrix.yml) | Matrix-based container scanning | Multiple images |
+| [`scanner-zap-podinfo.yml`](workflows/scanner-zap-podinfo.yml) | ZAP DAST scanning example | Web app security |
+| [`actions-container-scan-matrix.yml`](workflows/actions-container-scan-matrix.yml) | Matrix-based container scanning | Multiple images |
 
 ---
 


### PR DESCRIPTION
## Summary
- Fix incorrect workflow references in `README.md` and `docs/failure-control.md` — all examples pointed to non-existent `security-scan.yml` instead of the actual `reusable-security-hardening.yml`
- Fix broken relative links in `examples/README.md` — three example file links were missing the `workflows/` subdirectory prefix

## Details

**Workflow references (`README.md`, `docs/failure-control.md`)**:  
All usage examples referenced `.github/workflows/security-scan.yml`, which does not exist. The correct reusable workflow filename is `reusable-security-hardening.yml`. Also corrected the Quick Start section to suggest `security.yml` as the filename (matching the existing heading/convention) rather than `security-scan.yml`.

**Broken links (`examples/README.md`)**:  
Three files in the examples index table had incorrect relative paths:
- `individual-scanner-workflows.yml` → `workflows/individual-scanner-workflows.yml`
- `scanner-zap-podinfo.yml` → `workflows/scanner-zap-podinfo.yml`
- `actions-container-scan-matrix.yml` → `workflows/actions-container-scan-matrix.yml`

## Files changed
- `README.md` — 7 workflow reference fixes
- `docs/failure-control.md` — 8 workflow reference fixes
- `examples/README.md` — 3 broken link fixes

## Test plan
- [ ] Verify `reusable-security-hardening.yml` exists at `.github/workflows/reusable-security-hardening.yml`
- [ ] Verify example links resolve correctly from `examples/README.md`
- [ ] Confirm no other docs reference the old `security-scan.yml` path