### PR TITLE
ci: pin all external GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/ai-summary/action.yml
+++ b/.github/actions/ai-summary/action.yml
@@ -39,7 +39,7 @@ runs:
 
     - name: Set up Node.js
       if: inputs.provider == 'copilot'
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
       with:
         node-version: '20'
 
@@ -50,7 +50,7 @@ runs:
 
     - name: Download scanner summaries
       if: inputs.skip_download == 'false'
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         pattern: scanner-summary-*
         path: /tmp/scanner-summaries

--- a/.github/actions/comment-pr/action.yml
+++ b/.github/actions/comment-pr/action.yml
@@ -36,7 +36,7 @@ runs:
   using: 'composite'
   steps:
     - name: Post PR comment
-      uses: actions/github-script@v8
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       continue-on-error: true
       env:
         SUMMARY_FILE: ${{ inputs.summary_file }}

--- a/.github/actions/get-job-id/action.yml
+++ b/.github/actions/get-job-id/action.yml
@@ -22,7 +22,7 @@ runs:
   steps:
     - name: Get job ID with robust matching
       id: get_id
-      uses: actions/github-script@v8
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       with:
         result-encoding: string
         script: |

--- a/.github/actions/linter-dockerfile/action.yml
+++ b/.github/actions/linter-dockerfile/action.yml
@@ -8,7 +8,7 @@ description: |
 
   **Usage Example:**
   ```yaml
-  - uses: actions/checkout@v6
+  - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
   - uses: huntridge-labs/argus/.github/actions/linter-dockerfile@0.6.3
     with:
       fail_on_issues: false
@@ -201,7 +201,7 @@ runs:
 
     - name: Upload linter summary
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: linter-summary-dockerfile
         path: linter-summaries/dockerfile.md
@@ -219,7 +219,7 @@ runs:
 
     - name: Upload raw lint results
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: dockerfile-lint-results
         path: /tmp/dockerfile_issues.txt

--- a/.github/actions/linter-javascript/action.yml
+++ b/.github/actions/linter-javascript/action.yml
@@ -8,7 +8,7 @@ description: |
 
   **Usage Example:**
   ```yaml
-  - uses: actions/checkout@v6
+  - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
   - uses: huntridge-labs/argus/.github/actions/linter-javascript@0.6.3
     with:
       fail_on_issues: false
@@ -43,7 +43,7 @@ runs:
   using: 'composite'
   steps:
     - name: Set up Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
       with:
         node-version: ${{ inputs.node_version }}
 
@@ -190,7 +190,7 @@ runs:
 
     - name: Upload linter summary
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: linter-summary-javascript
         path: linter-summaries/javascript.md
@@ -199,7 +199,7 @@ runs:
 
     - name: Upload raw lint results
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: javascript-lint-results
         path: |

--- a/.github/actions/linter-json/action.yml
+++ b/.github/actions/linter-json/action.yml
@@ -8,7 +8,7 @@ description: |
 
   **Usage Example:**
   ```yaml
-  - uses: actions/checkout@v6
+  - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
   - uses: huntridge-labs/argus/.github/actions/linter-json@0.6.3
     with:
       fail_on_issues: false
@@ -37,7 +37,7 @@ runs:
   using: 'composite'
   steps:
     - name: Set up Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
       with:
         node-version: ${{ inputs.node_version }}
 
@@ -147,7 +147,7 @@ runs:
 
     - name: Upload linter summary
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: linter-summary-json
         path: linter-summaries/json.md
@@ -156,7 +156,7 @@ runs:
 
     - name: Upload raw lint results
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: json-lint-results
         path: /tmp/json_issues.txt

--- a/.github/actions/linter-python/action.yml
+++ b/.github/actions/linter-python/action.yml
@@ -8,7 +8,7 @@ description: |
 
   **Usage Example:**
   ```yaml
-  - uses: actions/checkout@v6
+  - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
   - uses: huntridge-labs/argus/.github/actions/linter-python@0.6.3
     with:
       fail_on_issues: false
@@ -56,7 +56,7 @@ runs:
   using: 'composite'
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: ${{ inputs.python_version }}
 
@@ -241,7 +241,7 @@ runs:
 
     - name: Upload linter summary
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: linter-summary-python
         path: linter-summaries/python.md
@@ -259,7 +259,7 @@ runs:
 
     - name: Upload raw lint results
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: python-lint-results
         path: |

--- a/.github/actions/linter-terraform/action.yml
+++ b/.github/actions/linter-terraform/action.yml
@@ -8,7 +8,7 @@ description: |
 
   **Usage Example:**
   ```yaml
-  - uses: actions/checkout@v6
+  - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
   - uses: huntridge-labs/argus/.github/actions/linter-terraform@0.6.3
     with:
       fail_on_issues: false
@@ -51,7 +51,7 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v4
+      uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4
       with:
         terraform_version: ${{ inputs.terraform_version }}
 
@@ -251,7 +251,7 @@ runs:
 
     - name: Upload linter summary
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: linter-summary-terraform
         path: linter-summaries/terraform.md
@@ -260,7 +260,7 @@ runs:
 
     - name: Upload raw lint results
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: terraform-lint-results
         path: /tmp/terraform_issues.txt

--- a/.github/actions/linter-yaml/action.yml
+++ b/.github/actions/linter-yaml/action.yml
@@ -8,7 +8,7 @@ description: |
 
   **Usage Example:**
   ```yaml
-  - uses: actions/checkout@v6
+  - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
   - uses: huntridge-labs/argus/.github/actions/linter-yaml@0.6.3
     with:
       fail_on_issues: false
@@ -46,7 +46,7 @@ runs:
   using: 'composite'
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: ${{ inputs.python_version }}
 
@@ -172,7 +172,7 @@ runs:
 
     - name: Upload linter summary
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: linter-summary-yaml
         path: linter-summaries/yaml.md
@@ -190,7 +190,7 @@ runs:
 
     - name: Upload raw lint results
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: yaml-lint-results
         path: /tmp/yaml_issues.txt

--- a/.github/actions/linting-summary/action.yml
+++ b/.github/actions/linting-summary/action.yml
@@ -51,7 +51,7 @@ runs:
   using: 'composite'
   steps:
     - name: Download all linter summaries
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         pattern: ${{ inputs.summary_pattern }}
         path: linter-summaries

--- a/.github/actions/parse-container-config/action.yml
+++ b/.github/actions/parse-container-config/action.yml
@@ -15,7 +15,7 @@ description: |
           matrix: (( steps.parse.outputs.matrix ))
           has_containers: (( steps.parse.outputs.has_containers ))
         steps:
-          - uses: actions/checkout@v6
+          - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
           - uses: huntridge-labs/argus/.github/actions/parse-container-config@0.6.3
             id: parse
             with:
@@ -62,7 +62,7 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: '3.13'
 

--- a/.github/actions/parse-zap-config/action.yml
+++ b/.github/actions/parse-zap-config/action.yml
@@ -15,7 +15,7 @@ description: |
           matrix: (( steps.parse.outputs.matrix ))
           has_scans: (( steps.parse.outputs.has_scans ))
         steps:
-          - uses: actions/checkout@v6
+          - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
           - uses: huntridge-labs/argus/.github/actions/parse-zap-config@0.6.3
             id: parse
             with:
@@ -73,7 +73,7 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: '3.13'
 

--- a/.github/actions/scanner-bandit/action.yml
+++ b/.github/actions/scanner-bandit/action.yml
@@ -47,11 +47,11 @@ runs:
   steps:
     # IMPORTANT: Caller must checkout the repository before calling this action
     # Example:
-    #   - uses: actions/checkout@v6
+    #   - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     #   - uses: ./.github/actions/scanner-bandit
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: ${{ inputs.python_version }}
 
@@ -172,7 +172,7 @@ runs:
         echo "✅ No issues at or above severity threshold"
 
     - name: Upload Bandit artifacts
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: bandit-reports
         path: bandit-reports/
@@ -180,7 +180,7 @@ runs:
       if: always()
 
     - name: Upload Bandit SARIF
-      uses: github/codeql-action/upload-sarif@v4
+      uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4
       with:
         sarif_file: bandit-reports/bandit-report.sarif
       if: inputs.enable_code_security == 'true' && always() && github.actor != 'nektos/act' && hashFiles('bandit-reports/bandit-report.sarif') != ''
@@ -325,7 +325,7 @@ runs:
 
     - name: Upload Bandit summary section
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: scanner-summary-bandit
         path: scanner-summaries/bandit.md

--- a/.github/actions/scanner-checkov/action.yml
+++ b/.github/actions/scanner-checkov/action.yml
@@ -16,7 +16,7 @@ description: |
 
   **Usage Example:**
   ```yaml
-  - uses: actions/checkout@v6
+  - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
   - uses: huntridge-labs/argus/.github/actions/scanner-checkov@0.6.3
     env:
       GITHUB_TOKEN: (secrets.GITHUB_TOKEN)
@@ -109,7 +109,7 @@ runs:
 
     - name: Run Checkov Infrastructure Scan
       if: steps.validate.outputs.has_iac == 'true'
-      uses: bridgecrewio/checkov-action@v12.3089.0
+      uses: bridgecrewio/checkov-action@2fd3901c8feb52417f27f0d9800259a106c1ec1e # v12.3089.0
       with:
         directory: ${{ steps.validate.outputs.iac_path }}
         framework: ${{ inputs.framework }}
@@ -180,7 +180,7 @@ runs:
 
     - name: Upload Checkov reports
       if: steps.validate.outputs.has_iac == 'true' && always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: checkov-reports
         path: checkov-reports/
@@ -189,7 +189,7 @@ runs:
 
     - name: Upload SARIF to GitHub Security
       if: inputs.enable_code_security == 'true' && steps.validate.outputs.has_iac == 'true' && hashFiles('checkov-reports/checkov-results.sarif') != ''
-      uses: github/codeql-action/upload-sarif@v4
+      uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4
       with:
         sarif_file: checkov-reports/checkov-results.sarif
         category: checkov
@@ -249,7 +249,7 @@ runs:
 
     - name: Upload scanner summary
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: scanner-summary-checkov
         path: scanner-summaries/checkov.md

--- a/.github/actions/scanner-clamav/action.yml
+++ b/.github/actions/scanner-clamav/action.yml
@@ -52,7 +52,7 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     - name: Install ClamAV
       shell: bash
@@ -66,7 +66,7 @@ runs:
       continue-on-error: false
 
     - name: Set up Python for database updates
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: '3.12'
 
@@ -204,7 +204,7 @@ runs:
         ls -la clamav-reports/ || echo "No files generated"
 
     - name: Upload ClamAV artifacts
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: clamav-reports-${{ inputs.job_id }}
         path: clamav-reports/
@@ -283,7 +283,7 @@ runs:
 
     - name: Upload ClamAV summary section
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: scanner-summary-clamav-${{ inputs.job_id }}
         path: scanner-summaries/clamav.md

--- a/.github/actions/scanner-codeql/action.yml
+++ b/.github/actions/scanner-codeql/action.yml
@@ -11,7 +11,7 @@ description: |
 
   **Usage Example (single language):**
   ```yaml
-  - uses: actions/checkout@v6
+  - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
   - uses: huntridge-labs/argus/.github/actions/scanner-codeql@0.6.3
     with:
       language: 'python'
@@ -24,7 +24,7 @@ description: |
     matrix:
       language: [python, javascript]
   steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     - uses: huntridge-labs/argus/.github/actions/scanner-codeql@0.6.3
       with:
         language: (use matrix.language)
@@ -86,7 +86,7 @@ runs:
   using: 'composite'
   steps:
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@38697555549f1db7851b81482ff19f1fa5c4fedc # v4
       with:
         languages: ${{ inputs.language }}
         config-file: ${{ inputs.config_file || '' }}
@@ -94,13 +94,13 @@ runs:
 
     - name: Set up Python
       if: inputs.language == 'python'
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: ${{ inputs.setup_python_version }}
 
     - name: Set up Node.js
       if: inputs.language == 'javascript'
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
       with:
         node-version: ${{ inputs.setup_node_version }}
 
@@ -127,11 +127,11 @@ runs:
       continue-on-error: true
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v4
+      uses: github/codeql-action/autobuild@38697555549f1db7851b81482ff19f1fa5c4fedc # v4
 
     - name: Perform CodeQL Analysis
       id: analyze
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@38697555549f1db7851b81482ff19f1fa5c4fedc # v4
       with:
         category: "/language:${{ inputs.language }}"
         output: sarif-results
@@ -231,7 +231,7 @@ runs:
         echo "::endgroup::"
 
     - name: Upload CodeQL reports
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: codeql-reports-${{ inputs.language }}
         path: codeql-reports/
@@ -287,7 +287,7 @@ runs:
 
     - name: Upload scanner summary
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: scanner-summary-codeql-${{ inputs.language }}
         path: scanner-summaries/codeql-${{ inputs.language }}.md

--- a/.github/actions/scanner-container-summary/action.yml
+++ b/.github/actions/scanner-container-summary/action.yml
@@ -16,7 +16,7 @@ description: |
         outputs:
           scan_matrix: (( steps.parse.outputs.scan_matrix ))
         steps:
-          - uses: actions/checkout@v6
+          - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
           - uses: huntridge-labs/argus/.github/actions/parse-container-config@0.6.3
             id: parse
             with:
@@ -79,7 +79,7 @@ runs:
   using: 'composite'
   steps:
     - name: Download scan artifacts
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         pattern: ${{ inputs.artifact_pattern }}
         merge-multiple: false
@@ -107,7 +107,7 @@ runs:
         python3 "${{ github.action_path }}/../scanner-container/scripts/generate_container_summary.py" --combined
 
     - name: Upload combined summary artifact
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: container-scan-summary
         path: scanner-summaries/

--- a/.github/actions/scanner-container/action.yml
+++ b/.github/actions/scanner-container/action.yml
@@ -139,7 +139,7 @@ runs:
     # ========================================
     - name: Generate SBOM (Syft)
       if: contains(inputs.scanners, 'syft')
-      uses: anchore/sbom-action@v0.24.0
+      uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
       with:
         image: ${{ inputs.image_ref }}
         format: cyclonedx-json
@@ -151,7 +151,7 @@ runs:
 
     - name: Generate SBOM SPDX format
       if: contains(inputs.scanners, 'syft')
-      uses: anchore/sbom-action@v0.24.0
+      uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
       with:
         image: ${{ inputs.image_ref }}
         format: spdx-json
@@ -238,7 +238,7 @@ runs:
     - name: Run Trivy vulnerability scanner (JSON)
       id: trivy-json
       if: contains(inputs.scanners, 'trivy') && contains(github.server_url, 'github.com')
-      uses: aquasecurity/trivy-action@0.35.0
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
       continue-on-error: true
       with:
         image-ref: ${{ inputs.image_ref }}
@@ -251,7 +251,7 @@ runs:
     - name: Run Trivy vulnerability scanner (SARIF)
       id: trivy-sarif
       if: contains(inputs.scanners, 'trivy') && contains(github.server_url, 'github.com')
-      uses: aquasecurity/trivy-action@0.35.0
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
       continue-on-error: true
       with:
         image-ref: ${{ inputs.image_ref }}
@@ -264,7 +264,7 @@ runs:
     - name: Run Trivy vulnerability scanner (Table)
       id: trivy-table
       if: contains(inputs.scanners, 'trivy') && contains(github.server_url, 'github.com')
-      uses: aquasecurity/trivy-action@0.35.0
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
       continue-on-error: true
       with:
         image-ref: ${{ inputs.image_ref }}
@@ -276,7 +276,7 @@ runs:
 
     - name: Upload Trivy SARIF to GitHub Security
       if: contains(inputs.scanners, 'trivy') && inputs.enable_code_security == 'true'
-      uses: github/codeql-action/upload-sarif@v4
+      uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4
       continue-on-error: true
       with:
         sarif_file: trivy-${{ inputs.container_name }}-results.sarif
@@ -328,7 +328,7 @@ runs:
     # ========================================
     - name: Run Grype vulnerability scanner (JSON)
       if: contains(inputs.scanners, 'grype')
-      uses: anchore/scan-action@v7
+      uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7
       id: grype-json
       continue-on-error: true
       with:
@@ -349,7 +349,7 @@ runs:
 
     - name: Run Grype vulnerability scanner (SARIF)
       if: contains(inputs.scanners, 'grype')
-      uses: anchore/scan-action@v7
+      uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7
       id: grype-sarif
       continue-on-error: true
       with:
@@ -370,7 +370,7 @@ runs:
 
     - name: Upload Grype SARIF to GitHub Security
       if: contains(inputs.scanners, 'grype') && inputs.enable_code_security == 'true'
-      uses: github/codeql-action/upload-sarif@v4
+      uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4
       continue-on-error: true
       with:
         sarif_file: grype-${{ inputs.container_name }}-results.sarif
@@ -597,7 +597,7 @@ runs:
     # ========================================
     - name: Upload scan results
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: container-scan-results-${{ inputs.container_name }}-${{ inputs.scanners }}-${{ steps.job-id.outputs.job-id }}
         path: |

--- a/.github/actions/scanner-dependency-review/action.yml
+++ b/.github/actions/scanner-dependency-review/action.yml
@@ -14,7 +14,7 @@ description: |
 
   **Usage Example:**
   ```yaml
-  - uses: actions/checkout@v6
+  - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
   - uses: huntridge-labs/argus/.github/actions/scanner-dependency-review@0.6.3
     env:
       GITHUB_TOKEN: (secrets.GITHUB_TOKEN)
@@ -106,7 +106,7 @@ runs:
     - name: Run Dependency Review
       id: dependency-review
       if: steps.check-event.outputs.is_pr == 'true'
-      uses: actions/dependency-review-action@v4
+      uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
       with:
         comment-summary-in-pr: never
         vulnerability-check: ${{ inputs.vulnerability_check }}
@@ -190,7 +190,7 @@ runs:
 
     - name: Upload reports
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: dependency-review-reports-${{ inputs.job_id }}
         path: dependency-review-reports/
@@ -240,7 +240,7 @@ runs:
 
     - name: Upload scanner summary
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: scanner-summary-dependency-review-${{ inputs.job_id }}
         path: scanner-summaries/dependency-review.md

--- a/.github/actions/scanner-gitleaks/action.yml
+++ b/.github/actions/scanner-gitleaks/action.yml
@@ -60,13 +60,13 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         fetch-depth: 0
 
     - name: Run Gitleaks Secrets Detection
       id: gitleaks-scan
-      uses: gitleaks/gitleaks-action@v2
+      uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
       env:
         GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
         GITLEAKS_LICENSE: ${{ env.GITLEAKS_LICENSE }}
@@ -92,7 +92,7 @@ runs:
         ls -la gitleaks-reports/ || echo "No files generated"
 
     - name: Upload Gitleaks artifacts
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: gitleaks-reports
         path: gitleaks-reports/
@@ -100,7 +100,7 @@ runs:
       if: always()
 
     - name: Upload SARIF to GitHub Code Scanning
-      uses: github/codeql-action/upload-sarif@v4
+      uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4
       if: inputs.enable_code_security == 'true' && always() && github.actor != 'nektos/act' && hashFiles('gitleaks-reports/results.sarif') != ''
       with:
         sarif_file: gitleaks-reports/results.sarif
@@ -151,7 +151,7 @@ runs:
 
     - name: Upload GitLeaks summary section
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: scanner-summary-gitleaks
         path: scanner-summaries/gitleaks.md

--- a/.github/actions/scanner-opengrep/action.yml
+++ b/.github/actions/scanner-opengrep/action.yml
@@ -13,7 +13,7 @@ description: |
 
   **Usage Example:**
   ```yaml
-  - uses: actions/checkout@v6
+  - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
   - uses: huntridge-labs/argus/.github/actions/scanner-opengrep@0.6.3
     with:
       fail_on_severity: 'high'
@@ -125,7 +125,7 @@ runs:
         echo "::endgroup::"
 
     - name: Upload OpenGrep reports
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: opengrep-reports
         path: opengrep-reports/
@@ -135,7 +135,7 @@ runs:
 
     - name: Upload SARIF to GitHub Security
       if: inputs.enable_code_security == 'true' && hashFiles('opengrep-reports/opengrep.sarif') != ''
-      uses: github/codeql-action/upload-sarif@v4
+      uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4
       with:
         sarif_file: opengrep-reports/opengrep.sarif
       continue-on-error: true
@@ -182,7 +182,7 @@ runs:
 
     - name: Upload scanner summary
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: scanner-summary-opengrep
         path: scanner-summaries/opengrep.md

--- a/.github/actions/scanner-osv/action.yml
+++ b/.github/actions/scanner-osv/action.yml
@@ -13,7 +13,7 @@ description: |
 
   **Usage Example:**
   ```yaml
-  - uses: actions/checkout@v6
+  - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
   - uses: huntridge-labs/argus/.github/actions/scanner-osv@0.6.3
     env:
       GITHUB_TOKEN: (secrets.GITHUB_TOKEN)
@@ -151,7 +151,7 @@ runs:
 
     - name: Run OSV-Scanner (JSON)
       id: scan
-      uses: google/osv-scanner-action/osv-scanner-action@v2.3.3
+      uses: google/osv-scanner-action/osv-scanner-action@c5996e0193a3df57d695c1b8a1dec2a4c62e8730 # v2.3.3
       with:
         scan-args: ${{ steps.build-args.outputs.json_args }}
       continue-on-error: true
@@ -174,7 +174,7 @@ runs:
 
     - name: Run OSV-Scanner (SARIF)
       if: inputs.enable_code_security == 'true'
-      uses: google/osv-scanner-action/osv-scanner-action@v2.3.3
+      uses: google/osv-scanner-action/osv-scanner-action@c5996e0193a3df57d695c1b8a1dec2a4c62e8730 # v2.3.3
       with:
         scan-args: ${{ steps.build-args.outputs.sarif_args }}
       continue-on-error: true
@@ -233,7 +233,7 @@ runs:
 
     - name: Upload OSV reports
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: osv-reports-${{ inputs.job_id }}
         path: osv-reports/
@@ -242,7 +242,7 @@ runs:
 
     - name: Upload SARIF to GitHub Security
       if: inputs.enable_code_security == 'true' && hashFiles('osv-reports/osv-results.sarif') != ''
-      uses: github/codeql-action/upload-sarif@v4
+      uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4
       with:
         sarif_file: osv-reports/osv-results.sarif
         category: osv-scanner
@@ -283,7 +283,7 @@ runs:
 
     - name: Upload scanner summary
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: scanner-summary-osv-${{ inputs.job_id }}
         path: scanner-summaries/osv.md

--- a/.github/actions/scanner-syft/action.yml
+++ b/.github/actions/scanner-syft/action.yml
@@ -7,7 +7,7 @@ description: |
 
   **Usage Example:**
   ```yaml
-  - uses: actions/checkout@v6
+  - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
   - uses: huntridge-labs/argus/.github/actions/scanner-syft@0.6.3
     with:
       scan_path: '.'
@@ -123,7 +123,7 @@ runs:
     - name: Generate SBOM (Path)
       id: sbom-path
       if: steps.setup.outputs.type == 'path'
-      uses: anchore/sbom-action@v0.24.0
+      uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
       with:
         path: ${{ steps.setup.outputs.target }}
         format: ${{ inputs.output_format }}
@@ -135,7 +135,7 @@ runs:
     - name: Generate SBOM (Image)
       id: sbom-image
       if: steps.setup.outputs.type == 'image'
-      uses: anchore/sbom-action@v0.24.0
+      uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
       with:
         image: ${{ steps.setup.outputs.target }}
         format: ${{ inputs.output_format }}
@@ -210,7 +210,7 @@ runs:
         echo "Found $COMPONENT_COUNT components/packages"
 
     - name: Upload SBOM artifacts
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: sbom-${{ steps.setup.outputs.prefix }}
         path: ${{ steps.setup.outputs.output_dir }}/
@@ -219,7 +219,7 @@ runs:
 
     - name: Upload to GitHub Dependency Graph
       if: inputs.enable_code_security == 'true' && steps.setup.outputs.type == 'path'
-      uses: anchore/sbom-action/publish-sbom@v0.24.0
+      uses: anchore/sbom-action/publish-sbom@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
       with:
         sbom-artifact-match: sbom-${{ steps.setup.outputs.prefix }}
       continue-on-error: true
@@ -309,7 +309,7 @@ runs:
 
     - name: Upload summary artifact
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: scanner-summary-syft-${{ steps.setup.outputs.prefix }}
         path: scanner-summaries/syft.md

--- a/.github/actions/scanner-trivy-iac/action.yml
+++ b/.github/actions/scanner-trivy-iac/action.yml
@@ -64,7 +64,7 @@ runs:
   steps:
     # IMPORTANT: Caller must checkout the repository before calling this action
     # Example:
-    #   - uses: actions/checkout@v6
+    #   - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     #   - uses: ./.github/actions/scanner-trivy-iac
 
     - name: Validate scan directory
@@ -159,7 +159,7 @@ runs:
 
     - name: Upload Trivy SARIF results to GitHub Security
       if: inputs.enable_code_security == 'true' && steps.validate.outputs.has_iac == 'true' && always() && github.actor != 'nektos/act'
-      uses: github/codeql-action/upload-sarif@v4
+      uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4
       with:
         sarif_file: ${{ steps.validate.outputs.iac_path }}/security-reports/trivy-results.sarif
         category: trivy-iac
@@ -265,7 +265,7 @@ runs:
 
     - name: Upload Trivy artifacts
       if: steps.validate.outputs.has_iac == 'true' && always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: trivy-iac-scan-results
         path: |
@@ -308,7 +308,7 @@ runs:
 
     - name: Upload scanner summary section
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: scanner-summary-trivy-iac
         path: scanner-summaries/trivy-iac.md

--- a/.github/actions/scanner-zap-summary/action.yml
+++ b/.github/actions/scanner-zap-summary/action.yml
@@ -58,7 +58,7 @@ runs:
   using: 'composite'
   steps:
     - name: Download ZAP report artifacts
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         pattern: ${{ inputs.artifact_pattern }}
         path: zap-downloads
@@ -66,7 +66,7 @@ runs:
       continue-on-error: true
 
     - name: Download summary artifacts
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         pattern: ${{ inputs.summary_pattern }}
         path: scanner-summaries
@@ -145,7 +145,7 @@ runs:
 
     - name: Upload combined summary
       if: steps.generate.outputs.summary_path != ''
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: ${{ inputs.output_name }}
         path: ${{ steps.generate.outputs.summary_path }}

--- a/.github/actions/scanner-zap/action.yml
+++ b/.github/actions/scanner-zap/action.yml
@@ -219,7 +219,7 @@ runs:
 
     - name: Login to registry
       if: inputs.app_image_ref != '' && steps.validate.outputs.has_registry_password == 'true'
-      uses: docker/login-action@v4
+      uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
       with:
         username: ${{ inputs.registry_username }}
         password: ${{ inputs.registry_password }}
@@ -335,7 +335,7 @@ runs:
 
     - name: Run ZAP (baseline)
       if: inputs.scan_type == 'baseline'
-      uses: zaproxy/action-baseline@v0.15.0
+      uses: zaproxy/action-baseline@de8ad967d3548d44ef623df22cf95c3b0baf8b25 # v0.15.0
       continue-on-error: ${{ inputs.allow_failure == 'true' }}
       with:
         token: ${{ inputs.post_pr_comment == 'true' && github.token || '' }}
@@ -348,7 +348,7 @@ runs:
 
     - name: Run ZAP (full)
       if: inputs.scan_type == 'full'
-      uses: zaproxy/action-full-scan@v0.13.0
+      uses: zaproxy/action-full-scan@3c58388149901b9a03b7718852c5ba889646c27c # v0.13.0
       continue-on-error: ${{ inputs.allow_failure == 'true' }}
       with:
         token: ${{ inputs.post_pr_comment == 'true' && github.token || '' }}
@@ -361,7 +361,7 @@ runs:
 
     - name: Run ZAP (api)
       if: inputs.scan_type == 'api'
-      uses: zaproxy/action-api-scan@v0.10.0
+      uses: zaproxy/action-api-scan@5158fe4d9d8fcc75ea204db81317cce7f9e5453d # v0.10.0
       continue-on-error: ${{ inputs.allow_failure == 'true' }}
       with:
         token: ${{ inputs.post_pr_comment == 'true' && github.token || '' }}
@@ -485,7 +485,7 @@ runs:
 
     - name: Upload scan summary
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: scanner-summary-zap-${{ steps.validate.outputs.artifact_prefix }}
         path: scanner-summaries/zap.md

--- a/.github/actions/scn-detector/action.yml
+++ b/.github/actions/scn-detector/action.yml
@@ -112,7 +112,7 @@ runs:
   steps:
     # Step 1: Setup Python environment
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: '3.12'
 
@@ -298,7 +298,7 @@ runs:
     # Step 7: Upload artifacts
     - name: Upload SCN artifacts
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: scn-reports-${{ inputs.job_id }}
         path: scn-reports/
@@ -307,7 +307,7 @@ runs:
 
     - name: Upload SCN summary
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: scn-summary-${{ inputs.job_id }}
         path: scn-summaries/

--- a/.github/actions/security-summary/action.yml
+++ b/.github/actions/security-summary/action.yml
@@ -51,7 +51,7 @@ runs:
   using: 'composite'
   steps:
     - name: Download all scanner summaries
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         pattern: ${{ inputs.summary_pattern }}
         path: scanner-summaries

--- a/.github/workflows/aicac.yml
+++ b/.github/workflows/aicac.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Check if .ai directory exists
         id: check-aicac
@@ -33,7 +33,7 @@ jobs:
           fi
 
       - name: Run AICaC Action
-        uses: eFAILution/AICaC/.github/actions/aicac-adoption@0.3.0
+        uses: eFAILution/AICaC/.github/actions/aicac-adoption@a76d235ee2b26b0faa7c66124128acc837eb7c1d # 0.3.0
         with:
           mode: ${{ steps.check-aicac.outputs.mode }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/container-scan-from-config.yml
+++ b/.github/workflows/container-scan-from-config.yml
@@ -85,7 +85,7 @@ jobs:
       has_containers: ${{ steps.parse.outputs.has_containers }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Parse container config
         id: parse

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -105,7 +105,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Discover Dockerfiles in repository
         id: discover
@@ -173,10 +173,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Build container image
         id: build
@@ -226,7 +226,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Authenticate to container registry
         if: inputs.registry_username != ''
@@ -266,11 +266,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Download all scan artifacts
         if: needs.discover-containers.outputs.has_containers == 'true' || inputs.scan_mode == 'remote'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         continue-on-error: true
         with:
           pattern: ${{ inputs.scan_mode == 'remote' && inputs.container_name != '' && format('container-scan-results-{0}*', inputs.container_name) || 'container-scan-results-*' }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -94,7 +94,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run OSV Scanner
         uses: huntridge-labs/argus/.github/actions/scanner-osv@0.6.3
@@ -116,7 +116,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Dependency Review Scanner
         uses: huntridge-labs/argus/.github/actions/scanner-dependency-review@0.6.3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,11 +20,11 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/infrastructure-scan.yml
+++ b/.github/workflows/infrastructure-scan.yml
@@ -62,7 +62,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Trivy IaC Scanner
         uses: huntridge-labs/argus/.github/actions/scanner-trivy-iac@0.6.3
@@ -82,7 +82,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Checkov Scanner
         uses: huntridge-labs/argus/.github/actions/scanner-checkov@0.6.3

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run YAML Linter
         id: lint
@@ -67,7 +67,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run JSON Linter
         id: lint
@@ -82,7 +82,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Python Linter
         id: lint
@@ -97,7 +97,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run JavaScript Linter
         id: lint
@@ -112,7 +112,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Dockerfile Linter
         id: lint
@@ -127,7 +127,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Terraform Linter
         id: lint
@@ -144,7 +144,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Generate Linting Summary
         id: summary

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
@@ -32,7 +32,7 @@ jobs:
           git fetch --tags
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -165,7 +165,7 @@ jobs:
 
       - name: Upload debug artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: release-preview-debug
           path: release_output.txt
@@ -173,7 +173,7 @@ jobs:
 
       - name: Comment PR
         if: success() && github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         continue-on-error: true
         with:
           script: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,19 +38,19 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: '22'
           cache: 'npm'
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.12'
           cache: 'pip'
@@ -92,19 +92,19 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: '22'
           cache: 'npm'
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.12'
           cache: 'pip'

--- a/.github/workflows/reusable-security-hardening.yml
+++ b/.github/workflows/reusable-security-hardening.yml
@@ -774,118 +774,118 @@ jobs:
     steps:
     - name: Download CodeQL artifacts
       if: needs.scan-coordinator.outputs.run_codeql == 'true'
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         pattern: codeql-*
       continue-on-error: true
 
     - name: Download OpenGrep artifacts
       if: needs.scan-coordinator.outputs.run_opengrep == 'true'
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         pattern: opengrep-*
       continue-on-error: true
 
     - name: Download Bandit artifacts
       if: needs.scan-coordinator.outputs.run_bandit == 'true'
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         pattern: bandit-*
       continue-on-error: true
 
     - name: Download GitLeaks artifacts
       if: needs.scan-coordinator.outputs.run_gitleaks == 'true'
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         pattern: gitleaks-*
       continue-on-error: true
 
     - name: Download ClamAV artifacts
       if: needs.scan-coordinator.outputs.run_clamav == 'true'
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         pattern: clamav-*
       continue-on-error: true
 
     - name: Download Container artifacts
       if: needs.scan-coordinator.outputs.run_container == 'true'
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         pattern: container-*
       continue-on-error: true
 
     - name: Download Infrastructure artifacts
       if: needs.scan-coordinator.outputs.run_infrastructure == 'true'
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         pattern: infrastructure-*
       continue-on-error: true
 
     - name: Download Trivy IaC artifacts
       if: needs.scan-coordinator.outputs.run_trivy_iac == 'true'
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         pattern: trivy-iac-*
       continue-on-error: true
 
     - name: Download Checkov artifacts
       if: needs.scan-coordinator.outputs.run_checkov == 'true'
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         pattern: checkov-*
       continue-on-error: true
 
     - name: Download Trivy Container artifacts
       if: needs.scan-coordinator.outputs.run_trivy_container == 'true'
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         pattern: trivy-container-*
       continue-on-error: true
 
     - name: Download Grype artifacts
       if: needs.scan-coordinator.outputs.run_grype == 'true'
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         pattern: grype-*
       continue-on-error: true
 
     - name: Download ZAP artifacts
       if: needs.scan-coordinator.outputs.run_zap == 'true'
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         pattern: zap-reports-*
       continue-on-error: true
 
     - name: Download OSV artifacts
       if: needs.scan-coordinator.outputs.run_osv == 'true'
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         pattern: osv-*
       continue-on-error: true
 
     - name: Download Dependency Review artifacts
       if: needs.scan-coordinator.outputs.run_dependency_review == 'true'
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         pattern: dependency-review-*
       continue-on-error: true
 
     - name: Download Linting artifacts
       if: needs.scan-coordinator.outputs.run_lint == 'true'
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         pattern: '*lint*'
       continue-on-error: true
 
     - name: Download SBOM artifacts
       if: needs.scan-coordinator.outputs.run_sbom == 'true'
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         pattern: sbom-*
       continue-on-error: true
 
     - name: Download all scanner summaries
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         pattern: scanner-summary-*
         merge-multiple: true
@@ -1020,7 +1020,7 @@ jobs:
         fallback-suffix: 'security-hardening-report'
 
     - name: Upload comprehensive security report
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: security-hardening-report-${{ steps.job_id.outputs.job-id }}
         path: security-hardening-report.md
@@ -1028,7 +1028,7 @@ jobs:
 
     - name: Comment PR with security summary
       if: github.event_name == 'pull_request' && (inputs.post_pr_comment == true || inputs.post_pr_comment == null)
-      uses: actions/github-script@v8
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       continue-on-error: true
       with:
         script: |

--- a/.github/workflows/scanner-bandit.yml
+++ b/.github/workflows/scanner-bandit.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Bandit Scanner
         uses: huntridge-labs/argus/.github/actions/scanner-bandit@0.6.3

--- a/.github/workflows/scanner-checkov.yml
+++ b/.github/workflows/scanner-checkov.yml
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Checkov Scanner
         uses: huntridge-labs/argus/.github/actions/scanner-checkov@0.6.3

--- a/.github/workflows/scanner-clamav.yml
+++ b/.github/workflows/scanner-clamav.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run ClamAV Scanner
         uses: huntridge-labs/argus/.github/actions/scanner-clamav@0.6.3

--- a/.github/workflows/scanner-codeql.yml
+++ b/.github/workflows/scanner-codeql.yml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - name: Checkout for language detection
         if: inputs.codeql_languages == ''
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
 
@@ -180,7 +180,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run CodeQL Scanner
         uses: huntridge-labs/argus/.github/actions/scanner-codeql@0.6.3

--- a/.github/workflows/scanner-dependency-review.yml
+++ b/.github/workflows/scanner-dependency-review.yml
@@ -65,7 +65,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Dependency Review Scanner
         uses: huntridge-labs/argus/.github/actions/scanner-dependency-review@0.6.3

--- a/.github/workflows/scanner-grype.yml
+++ b/.github/workflows/scanner-grype.yml
@@ -82,7 +82,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Grype Scanner
         uses: huntridge-labs/argus/.github/actions/scanner-container@0.6.3

--- a/.github/workflows/scanner-opengrep.yml
+++ b/.github/workflows/scanner-opengrep.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run OpenGrep Scanner
         uses: huntridge-labs/argus/.github/actions/scanner-opengrep@0.6.3

--- a/.github/workflows/scanner-osv.yml
+++ b/.github/workflows/scanner-osv.yml
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run OSV Scanner
         uses: huntridge-labs/argus/.github/actions/scanner-osv@0.6.3

--- a/.github/workflows/scanner-syft.yml
+++ b/.github/workflows/scanner-syft.yml
@@ -79,7 +79,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Syft SBOM Generator
         uses: huntridge-labs/argus/.github/actions/scanner-syft@0.6.3

--- a/.github/workflows/scanner-trivy-container.yml
+++ b/.github/workflows/scanner-trivy-container.yml
@@ -82,7 +82,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Trivy Scanner
         uses: huntridge-labs/argus/.github/actions/scanner-container@0.6.3

--- a/.github/workflows/scanner-trivy-iac.yml
+++ b/.github/workflows/scanner-trivy-iac.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Trivy IaC Scanner
         uses: huntridge-labs/argus/.github/actions/scanner-trivy-iac@0.6.3

--- a/.github/workflows/scanner-zap-from-config.yml
+++ b/.github/workflows/scanner-zap-from-config.yml
@@ -88,7 +88,7 @@ jobs:
       post_pr_comment: ${{ steps.parse.outputs.post_pr_comment }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Parse ZAP config
         id: parse
@@ -111,7 +111,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run ZAP scanner
         uses: huntridge-labs/argus/.github/actions/scanner-zap@0.6.3

--- a/.github/workflows/scanner-zap.yml
+++ b/.github/workflows/scanner-zap.yml
@@ -187,7 +187,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run ZAP Scanner
         uses: huntridge-labs/argus/.github/actions/scanner-zap@0.6.3

--- a/.github/workflows/test-actions.yml
+++ b/.github/workflows/test-actions.yml
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Check action E2E test coverage
         id: coverage
@@ -212,7 +212,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Bandit scanner
         id: scan
@@ -245,7 +245,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Opengrep scanner
         id: scan
@@ -278,7 +278,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run CodeQL scanner (Python)
         id: scan
@@ -313,7 +313,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0  # Full history for comprehensive secrets scanning
 
@@ -358,7 +358,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Trivy IaC scanner
         id: scan
@@ -390,7 +390,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Checkov scanner
         id: scan
@@ -427,7 +427,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0  # Required for SCN detector git diff analysis
 
@@ -503,7 +503,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run container scanner (${{ matrix.tool }})
         id: scan
@@ -546,7 +546,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Syft SBOM generator
         id: scan
@@ -587,7 +587,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Dockerfile linter
         uses: ./.github/actions/linter-dockerfile
@@ -613,7 +613,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Python linter
         uses: ./.github/actions/linter-python
@@ -639,7 +639,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run YAML linter
         uses: ./.github/actions/linter-yaml
@@ -665,7 +665,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run JavaScript linter
         uses: ./.github/actions/linter-javascript
@@ -691,7 +691,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run JSON linter
         uses: ./.github/actions/linter-json
@@ -717,7 +717,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Terraform linter
         uses: ./.github/actions/linter-terraform
@@ -753,7 +753,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Wait for podinfo to be ready
         shell: bash
@@ -810,7 +810,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run ClamAV scanner
         id: scan
@@ -850,7 +850,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run OSV scanner
         id: scan
@@ -891,7 +891,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run dependency-review scanner
         id: scan
@@ -930,7 +930,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run linting-summary action
         id: summary
@@ -959,7 +959,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run container-config parser
         id: parse
@@ -983,7 +983,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run zap-config parser
         id: parse
@@ -1010,10 +1010,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/test-ai-summary.yml
+++ b/.github/workflows/test-ai-summary.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Resolve run ID from PR number
         id: resolve
@@ -62,7 +62,7 @@ jobs:
           echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
 
       - name: Download scanner summaries
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: scanner-summary-*
           path: /tmp/scanner-summaries

--- a/.github/workflows/test-examples-functional.yml
+++ b/.github/workflows/test-examples-functional.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Discover example files
         id: discover
@@ -70,10 +70,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -139,10 +139,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/test-lint-workflows.yml
+++ b/.github/workflows/test-lint-workflows.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install actionlint
         shell: bash

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.13'
 
@@ -72,7 +72,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: always()
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v5
         with:
           directory: ./coverage
           flags: unittests
@@ -83,7 +83,7 @@ jobs:
 
       - name: Upload coverage artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: coverage-reports
           path: |

--- a/examples/github-enterprise/all-scanners.yml
+++ b/examples/github-enterprise/all-scanners.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Bandit (Python)
         uses: huntridge-labs/argus/.github/actions/scanner-bandit@0.6.3
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Trivy IaC
         uses: huntridge-labs/argus/.github/actions/scanner-trivy-iac@0.6.3
@@ -91,7 +91,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run ClamAV
         uses: huntridge-labs/argus/.github/actions/scanner-clamav@0.6.3
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Generate SBOM
         uses: huntridge-labs/argus/.github/actions/scanner-syft@0.6.3
@@ -130,10 +130,10 @@ jobs:
     if: always()
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Download all scanner summaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: scanner-summary-*
           path: scanner-summaries/

--- a/examples/github-enterprise/container-scanning.yml
+++ b/examples/github-enterprise/container-scanning.yml
@@ -52,7 +52,7 @@ jobs:
     if: github.event.inputs.image_ref != '' || github.event_name != 'workflow_dispatch'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Determine image to scan
         id: image
@@ -67,7 +67,7 @@ jobs:
 
       # Authenticate to registry if needed (example for GHCR)
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -95,10 +95,10 @@ jobs:
     if: github.event_name != 'workflow_dispatch'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build container image
         id: build
@@ -134,7 +134,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Generate SBOM
         uses: huntridge-labs/argus/.github/actions/scanner-syft@0.6.3

--- a/examples/github-enterprise/containerized-web-app.yml
+++ b/examples/github-enterprise/containerized-web-app.yml
@@ -45,7 +45,7 @@ jobs:
     name: Gitleaks Secret Scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
       - uses: huntridge-labs/argus/.github/actions/scanner-gitleaks@0.6.3
@@ -63,7 +63,7 @@ jobs:
     name: Bandit Python SAST
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: huntridge-labs/argus/.github/actions/scanner-bandit@0.6.3
         with:
           fail_on_severity: 'high'
@@ -75,7 +75,7 @@ jobs:
     name: CodeQL SAST
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: huntridge-labs/argus/.github/actions/scanner-codeql@0.6.3
         with:
           language: 'python'  # Adjust: python, javascript, java, go, etc.
@@ -89,7 +89,7 @@ jobs:
     name: OpenGrep SAST
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: huntridge-labs/argus/.github/actions/scanner-opengrep@0.6.3
         with:
           config: 'auto'
@@ -104,7 +104,7 @@ jobs:
     name: ClamAV Malware Scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: huntridge-labs/argus/.github/actions/scanner-clamav@0.6.3
         with:
           scan_path: '.'
@@ -120,7 +120,7 @@ jobs:
     name: Container Security Scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Build container image
         run: |
@@ -143,7 +143,7 @@ jobs:
     name: ZAP DAST Scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Build and start container
         run: |
@@ -188,7 +188,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download scanner summaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: scanner-summary-*
           path: scanner-summaries

--- a/examples/github-enterprise/dast-scanning.yml
+++ b/examples/github-enterprise/dast-scanning.yml
@@ -45,7 +45,7 @@ jobs:
     if: github.event.inputs.target_url != ''
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run ZAP Scan
         uses: huntridge-labs/argus/.github/actions/scanner-zap@0.6.3
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Wait for app to be ready
         run: |
@@ -104,7 +104,7 @@ jobs:
     if: false # Enable this job by changing to 'true' or removing the condition
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       # Start your API (example using docker-compose)
       - name: Start API

--- a/examples/github-enterprise/infrastructure-scanning.yml
+++ b/examples/github-enterprise/infrastructure-scanning.yml
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Check if IaC path exists
         id: check-path
@@ -110,7 +110,7 @@ jobs:
   #   runs-on: ubuntu-latest
   #   steps:
   #     - name: Checkout repository
-  #       uses: actions/checkout@v6
+  #       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
   #
   #     - name: Run Trivy IaC (full repo)
   #       uses: huntridge-labs/argus/.github/actions/scanner-trivy-iac@0.6.3

--- a/examples/github-enterprise/sast-only.yml
+++ b/examples/github-enterprise/sast-only.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0 # Full history for Gitleaks
 

--- a/examples/workflows/actions-composite-example.yml
+++ b/examples/workflows/actions-composite-example.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Bandit Scanner
         uses: huntridge-labs/argus/.github/actions/scanner-bandit@0.6.3
@@ -65,7 +65,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0  # Full history for comprehensive secrets scanning
 
@@ -89,7 +89,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run CodeQL Scanner (Python)
         uses: huntridge-labs/argus/.github/actions/scanner-codeql@0.6.3
@@ -110,7 +110,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run OpenGrep Scanner
         uses: huntridge-labs/argus/.github/actions/scanner-opengrep@0.6.3
@@ -131,7 +131,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Trivy IaC Scanner
         uses: huntridge-labs/argus/.github/actions/scanner-trivy-iac@0.6.3
@@ -152,7 +152,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run ClamAV Scanner
         uses: huntridge-labs/argus/.github/actions/scanner-clamav@0.6.3
@@ -175,7 +175,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       # Add steps here to start your application
       # Example:
@@ -206,7 +206,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       # Add steps here to build your container image
       # Example:

--- a/examples/workflows/actions-container-scan-matrix.yml
+++ b/examples/workflows/actions-container-scan-matrix.yml
@@ -53,7 +53,7 @@ jobs:
       container_count: ${{ steps.parse.outputs.container_count }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Parse container config
         id: parse

--- a/examples/workflows/actions-linting-example.yml
+++ b/examples/workflows/actions-linting-example.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run YAML Linter
         uses: huntridge-labs/argus/.github/actions/linter-yaml@0.6.3
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run JSON Linter
         uses: huntridge-labs/argus/.github/actions/linter-json@0.6.3
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Python Linter
         uses: huntridge-labs/argus/.github/actions/linter-python@0.6.3
@@ -93,7 +93,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run JavaScript Linter
         uses: huntridge-labs/argus/.github/actions/linter-javascript@0.6.3
@@ -110,7 +110,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Dockerfile Linter
         uses: huntridge-labs/argus/.github/actions/linter-dockerfile@0.6.3
@@ -127,7 +127,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Terraform Linter
         uses: huntridge-labs/argus/.github/actions/linter-terraform@0.6.3

--- a/examples/workflows/actions-scanner-zap-from-config.yml
+++ b/examples/workflows/actions-scanner-zap-from-config.yml
@@ -29,7 +29,7 @@ jobs:
       post_pr_comment: ${{ steps.parse.outputs.post_pr_comment }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Parse ZAP config
         id: parse
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run ZAP scanner
         uses: huntridge-labs/argus/.github/actions/scanner-zap@0.6.3

--- a/examples/workflows/actions-scanner-zap-full-example.yml
+++ b/examples/workflows/actions-scanner-zap-full-example.yml
@@ -88,7 +88,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Create ZAP rules file
         run: |

--- a/examples/workflows/composite-actions-example.yml
+++ b/examples/workflows/composite-actions-example.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Bandit Scanner
         uses: huntridge-labs/argus/.github/actions/scanner-bandit@0.6.3
@@ -68,7 +68,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0  # Full history for comprehensive secrets scanning
 
@@ -92,7 +92,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run CodeQL Scanner (Python)
         uses: huntridge-labs/argus/.github/actions/scanner-codeql@0.6.3
@@ -113,7 +113,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run OpenGrep Scanner
         uses: huntridge-labs/argus/.github/actions/scanner-opengrep@0.6.3
@@ -134,7 +134,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Trivy IaC Scanner
         uses: huntridge-labs/argus/.github/actions/scanner-trivy-iac@0.6.3
@@ -155,7 +155,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Checkov Scanner
         uses: huntridge-labs/argus/.github/actions/scanner-checkov@0.6.3
@@ -177,7 +177,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run ClamAV Scanner
         uses: huntridge-labs/argus/.github/actions/scanner-clamav@0.6.3
@@ -200,7 +200,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       # Add steps here to start your application
       # Example:
@@ -231,7 +231,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       # Add steps here to build your container image
       # Example:
@@ -255,7 +255,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run OSV-Scanner
         uses: huntridge-labs/argus/.github/actions/scanner-osv@0.6.3
@@ -274,7 +274,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Dependency Review
         uses: huntridge-labs/argus/.github/actions/scanner-dependency-review@0.6.3

--- a/examples/workflows/scn-detection-complete.example.yml
+++ b/examples/workflows/scn-detection-complete.example.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -116,7 +116,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -140,7 +140,7 @@ jobs:
     if: contains(github.event.pull_request.files, 'frontend/')
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -161,7 +161,7 @@ jobs:
     if: contains(github.event.pull_request.files, 'terraform/') || contains(github.event.pull_request.files, 'infrastructure/')
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -185,7 +185,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 

--- a/examples/workflows/scn-detection-example.yml
+++ b/examples/workflows/scn-detection-example.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       # Checkout with full history for git diff
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0  # Required for SCN detector to analyze changes
 
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -93,7 +93,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Description
Pin all external GitHub Action references to full commit SHAs to mitigate supply chain attacks from mutable tag hijacking (e.g., GHSA-69fq-xp46-6x23 trivy-action compromise where 75 of 76 tags were force-pushed with malicious code).

## Changes Made
- [ ] Added new scanner/workflow
- [ ] Modified existing scanner/workflow
- [ ] Updated documentation
- [ ] Fixed bug
- [x] Other (please specify)

### Details
- Pinned all 28 unique external action references across 71 files to verified commit SHAs
- Each pinned reference includes a version comment for maintainability (e.g., `@<sha> # v6`)
- Resolved annotated tags to underlying commit SHAs (not tag object SHAs)
- Pinned `actions/dependency-review-action` from moving `@v4` to specific `@v4.9.0` SHA
- Also pinned older version references in enterprise examples (`docker/login-action@v3`, `docker/setup-buildx-action@v3`, `actions/download-artifact@v4`)

**Actions pinned:**
| Action | Version | Status |
|--------|---------|--------|
| `actions/checkout` | v6 | Verified safe |
| `actions/dependency-review-action` | v4.9.0 | Verified safe |
| `actions/download-artifact` | v4, v8 | Verified safe |
| `actions/github-script` | v8 | Verified safe |
| `actions/setup-node` | v6 | Verified safe |
| `actions/setup-python` | v6 | Verified safe |
| `actions/upload-artifact` | v7 | Verified safe |
| `anchore/sbom-action` | v0.24.0 | Verified safe |
| `anchore/scan-action` | v7 | Verified safe |
| `aquasecurity/trivy-action` | 0.35.0 | Only unaffected tag (GHSA-69fq-xp46-6x23) |
| `bridgecrewio/checkov-action` | v12.3089.0 | Verified safe |
| `codecov/codecov-action` | v5 | Verified safe |
| `dependabot/fetch-metadata` | v2 | Verified safe |
| `docker/login-action` | v3, v4 | Verified safe |
| `docker/setup-buildx-action` | v3, v4 | Verified safe |
| `github/codeql-action` | v4 | Verified safe (CVE-2025-24362 patched, no compromise) |
| `gitleaks/gitleaks-action` | v2 | Verified safe |
| `google/osv-scanner-action` | v2.3.3 | Verified safe |
| `hashicorp/setup-terraform` | v4 | Verified safe |
| `zaproxy/action-api-scan` | v0.10.0 | Verified safe |
| `zaproxy/action-baseline` | v0.15.0 | Verified safe |
| `zaproxy/action-full-scan` | v0.13.0 | Verified safe |
| `eFAILution/AICaC` | 0.3.0 | Verified safe |

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results
All 1030 existing tests pass. No functional changes — only action reference format changed from mutable tags to immutable SHAs.

## Security Considerations
- [ ] No security impact
- [x] Security enhancement
- [ ] Potential security implications (explain below)

### Security Details
This change hardens the CI/CD pipeline against supply chain attacks by pinning all external GitHub Action references to immutable commit SHAs. Mutable tags (e.g., `@v6`, `@v2`) can be force-pushed by compromised maintainer accounts, as demonstrated by GHSA-69fq-xp46-6x23 (trivy-action, March 19, 2026) and CVE-2025-30066 (tj-actions/changed-files, March 2025). SHA pinning ensures that even if a tag is hijacked, our workflows continue to use the verified code.

## AI Context Updates (.ai/)
- [ ] `.ai/architecture.yaml` updated (if components/structure changed)
- [ ] `.ai/workflows.yaml` updated (if commands/tasks changed)
- [ ] `.ai/decisions.yaml` updated (if design decision made)
- [ ] `.ai/errors.yaml` updated (if common error addressed)
- [x] N/A - No .ai/ updates needed

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Related to GHSA-69fq-xp46-6x23 (trivy-action supply chain compromise)