### PR TITLE
feat(skills): add local Argus scanner selection skill

### DIFF
--- a/.agents/skills/argus-scanner-selection/SKILL.md
+++ b/.agents/skills/argus-scanner-selection/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: argus-scanner-selection
+description: Analyze a repository or local change set and choose the right Argus scanners, grouped workflows, and inputs to use. Use when a coding agent needs pre-push security checks during development or wants to align local scans with Argus CI coverage.
+license: AGPL-3.0
+compatibility: Designed for skills-compatible coding agents with file search, file read, shell, git, and GitHub workflow editing access.
+metadata:
+  author: huntridge-labs
+  repository: huntridge-labs/argus
+---
+
+# Argus Scanner Selection
+
+Use this skill when you need to bring Argus into a local development loop, map a repository or change set to the smallest effective set of Argus scanners, explain the choice, and optionally wire the same coverage into CI.
+
+Read [the reference guide](references/REFERENCE.md) when you need the full scanner matrix, trigger caveats, or workflow templates.
+
+## Goals
+
+1. Detect the repository's languages, dependency ecosystems, containers, infrastructure, web surfaces, compliance signals, and changed files.
+2. Recommend the right Argus scanners or grouped workflow tokens for the current development task.
+3. Run or prepare the smallest effective pre-push scan plan for local development.
+4. Generate or update GitHub Actions workflows that keep CI aligned with the local scan strategy.
+5. Avoid over-scanning, unsupported scanners, and noisy combinations.
+
+## Inputs to gather
+
+Collect or infer these before making recommendations:
+
+- repository path or URL
+- scan scope: staged diff, branch diff, working tree, or full repository
+- workflow trigger(s): `pull_request`, `push`, `schedule`, `workflow_dispatch`
+- whether GitHub Code Security / GitHub Advanced Security is enabled
+- whether the repo builds or publishes container images
+- whether the repo has a stable running web target or OpenAPI spec for DAST
+- whether FedRAMP SCN tracking is required
+- whether the user wants report-only or gating behavior
+
+Infer from the repository first. Ask the user only when a missing detail changes scanner choice.
+
+## Working procedure
+
+1. Inspect the current repository state first. If there is a staged diff, branch diff, or working-tree change set, treat that as the primary signal for a local development scan.
+2. Inspect the repository for source languages, lockfiles, manifests, Dockerfiles, compose files, container build or publish workflows, Terraform, Kubernetes, CloudFormation, Helm, installer or binary assets, and web entrypoints.
+3. Build a short evidence list from the files you found. Quote concrete paths and changed files when available.
+4. Choose scanners using the selection rules below.
+5. For local development, prefer the smallest effective scanner set that matches the current changes so feedback arrives before push.
+6. Prefer the reusable workflow `/.github/workflows/reusable-security-hardening.yml` when the user wants repository-wide or CI onboarding. Prefer individual scanner workflows or actions only when the user needs split jobs or special inputs.
+7. Prefer an explicit comma-separated `scanners:` list over `all`. The `all` token is convenient, but it does not include every opt-in capability and hides intent in reviews.
+8. Produce:
+   - the recommended scanners
+   - why each scanner is included
+   - what should be run locally now versus what should remain CI-only
+   - which scanners were intentionally excluded
+   - any required inputs, secrets, and permissions
+   - the exact workflow or action snippet to use
+9. If the user asked you to implement, edit the workflow files and preserve the repository's existing conventions.
+10. After editing files, validate the YAML and run the repository's relevant validators.
+
+## Local development guidance
+
+- Start diff-first. If the change set only touches application code, run the source-focused scanners that match the changed languages and dependency manifests.
+- Escalate to full-repository recommendations when the changes touch shared configuration, dependency manifests, Dockerfiles, IaC, release workflows, or security-sensitive areas.
+- Keep DAST and compliance scans opt-in unless the local environment clearly provides the required target or policy context.
+- If the repository is not yet using Argus in CI, still return a local pre-push scan plan and then propose the minimal CI workflow that mirrors it.
+
+## Selection rules
+
+### Baseline for most source repositories
+
+Start with:
+
+- `gitleaks` for secret detection
+- `opengrep` for multi-language pattern-based SAST
+- `osv` for dependency vulnerability scanning when manifests or lockfiles are present
+
+### Add language-specific or platform-specific scanners
+
+- Add `bandit` when Python is present.
+- Add `codeql` when the repository contains CodeQL-supported languages and GitHub Code Security is enabled.
+- Add `dependency-review` for pull request workflows that need dependency diff or license checks.
+- Add `container` when the repository builds container images or contains Dockerfiles and you want the coordinated Trivy + Grype + Syft flow.
+- Add `infrastructure` when Terraform, Kubernetes, or CloudFormation is present and you want the coordinated Trivy IaC + Checkov flow.
+- Add `sbom` when the user explicitly wants SBOM artifacts or the repository publishes build artifacts or container images and supply-chain inventory matters.
+- Add `zap` only when there is a stable URL, a runnable container image, or a compose stack to target.
+- Add `clamav` only when the repository handles uploaded files, archives, installers, binaries, or other third-party artifacts worth malware scanning.
+- Add `scn-detector` only for FedRAMP significant-change workflows on infrastructure diffs.
+
+### Local pre-push prioritization
+
+- For code-only changes, start with `gitleaks`, `opengrep`, and any language-specific scanner such as `bandit`.
+- Add `osv` when the change set touches manifests or lockfiles, or when the repository has dependency risk that should be checked before push.
+- Add `container` only when Dockerfiles, compose files, image build scripts, or container publishing paths are touched, or when the user wants full local image coverage.
+- Add `infrastructure` only when Terraform, Kubernetes, or CloudFormation files are touched, or when the repository is primarily an IaC repo.
+- Keep `zap`, `clamav`, and `scn-detector` out of the default local loop unless the changes or repository signals clearly justify them.
+
+### Prefer grouped workflow tokens for onboarding
+
+Use grouped tokens when they match the user's goal:
+
+- `container` = discover, build, and scan containers with Trivy, Grype, and Syft
+- `infrastructure` = run Trivy IaC and Checkov together
+- `dependencies` = run `osv` and `dependency-review`
+- `sast` = run `codeql`, `opengrep`, `bandit`, and `gitleaks`
+
+Use individual scanners instead of grouped tokens when:
+
+- the user wants only one scanner from the group
+- the workflow trigger makes part of the group invalid (`dependency-review` is PR-only)
+- the repository needs separate jobs, severities, or permissions per scanner
+
+### Avoid these mistakes
+
+- Do not assume `all` includes `zap`, `dependency-review`, or `sbom`.
+- Do not add `codeql` if GitHub Code Security is unavailable; call out the gap and use `opengrep` plus language-specific scanners instead.
+- Do not pair `container` with `trivy-container` or `grype` unless the user explicitly wants separate standalone jobs.
+- Do not pair `infrastructure` with `trivy-iac` or `checkov` unless the user explicitly wants separate standalone jobs.
+- Do not recommend `dependency-review` on non-PR triggers unless the user accepts that it will skip gracefully.
+- Do not add `zap` without a target acquisition plan (`url`, `docker-run`, or `compose`).
+
+## Output format
+
+Return a concise plan with these sections:
+
+1. `Repository and change signals`
+2. `Recommended Argus scanners`
+3. `Local development loop`
+4. `Inputs, secrets, and permissions`
+5. `Excluded scanners and why`
+6. `Workflow shape`
+7. `Next implementation step`
+
+## Implementation guidance
+
+### For reusable workflow onboarding
+
+Prefer a job shaped like:
+
+```yaml
+uses: huntridge-labs/argus/.github/workflows/reusable-security-hardening.yml@<argus-version>
+with:
+  scanners: gitleaks,opengrep,osv
+  enable_code_security: false
+  allow_failure: true
+  severity_threshold: high
+secrets: inherit
+```
+
+Then add or remove scanners based on the repository signals you found.
+
+### For local development workflows
+
+- Prioritize the scanners that match the changed files and repository risk profile.
+- Return a pre-push recommendation that distinguishes:
+  - scanners to run now in the local loop
+  - scanners to keep primarily in CI because they are slower, need hosted permissions, or need runtime targets
+- When the repository already has Argus wired into CI, keep the local recommendation aligned with the CI scanner list unless you have a clear reason to trim it for speed.
+
+### For DAST
+
+If `zap` is selected, keep it in a dedicated job unless the user explicitly wants it in the shared workflow. Choose one mode:
+
+- `url` for an already-running target
+- `docker-run` for a single container image
+- `compose` for a local compose stack
+- `api` scan type when an OpenAPI or Swagger spec exists
+
+### For SCN detection
+
+If `scn-detector` is selected, wire it as a separate job with a dedicated `.github/scn-config.yml`. Treat it as a compliance workflow, not a default scanner.
+
+## Verification
+
+Before you finish:
+
+1. Confirm the selected scanners match the repository signals you found.
+2. Validate that any referenced workflow inputs actually exist in Argus.
+3. Validate edited YAML files.
+4. Run the target repository's relevant validation commands.
+5. Summarize assumptions that still need human confirmation.
+
+## Escalation points
+
+Stop and ask for confirmation only when:
+
+- CodeQL depends on GitHub Code Security status and you cannot infer it
+- ZAP needs a target and none is discoverable
+- SCN detection is relevant but no compliance policy or config exists
+- the repository has no clear manifests, code, infra, containers, or web surface to justify Argus

--- a/.agents/skills/argus-scanner-selection/SKILL.md
+++ b/.agents/skills/argus-scanner-selection/SKILL.md
@@ -2,7 +2,7 @@
 name: argus-scanner-selection
 description: Analyze a repository or local change set and choose the right Argus scanners, grouped workflows, and inputs to use. Use when a coding agent needs pre-push security checks during development or wants to align local scans with Argus CI coverage.
 license: AGPL-3.0
-compatibility: Designed for skills-compatible coding agents with file search, file read, shell, git, and GitHub workflow editing access.
+compatibility: Designed for skills-compatible coding agents with file search, file read, shell, git, and GitHub workflow editing access. Local execution guidance assumes `act` and Docker; GHES guidance assumes composite actions or an internal mirror.
 metadata:
   author: huntridge-labs
   repository: huntridge-labs/argus
@@ -28,6 +28,8 @@ Collect or infer these before making recommendations:
 
 - repository path or URL
 - scan scope: staged diff, branch diff, working tree, or full repository
+- hosting environment: github.com, GHES with github.com access, or air-gapped/internal mirror
+- local execution path availability: `act`, container runtime, and network access for pulling actions/images
 - workflow trigger(s): `pull_request`, `push`, `schedule`, `workflow_dispatch`
 - whether GitHub Code Security / GitHub Advanced Security is enabled
 - whether the repo builds or publishes container images
@@ -44,15 +46,20 @@ Infer from the repository first. Ask the user only when a missing detail changes
 3. Build a short evidence list from the files you found. Quote concrete paths and changed files when available.
 4. Choose scanners using the selection rules below.
 5. For local development, prefer the smallest effective scanner set that matches the current changes so feedback arrives before push.
-6. Prefer the reusable workflow `/.github/workflows/reusable-security-hardening.yml` when the user wants repository-wide or CI onboarding. Prefer individual scanner workflows or actions only when the user needs split jobs or special inputs.
+6. Route by platform:
+   - for github.com CI onboarding, prefer `/.github/workflows/reusable-security-hardening.yml`
+   - for GHES or air-gapped environments, prefer direct composite action snippets and `examples/github-enterprise/*`
+   - for local pre-push runs, prefer direct composite action workflows that can be executed with `act`
 7. Prefer an explicit comma-separated `scanners:` list over `all`. The `all` token is convenient, but it does not include every opt-in capability and hides intent in reviews.
 8. Produce:
    - the recommended scanners
    - why each scanner is included
    - what should be run locally now versus what should remain CI-only
+   - which execution path applies locally, on github.com CI, and on GHES if relevant
    - which scanners were intentionally excluded
    - any required inputs, secrets, and permissions
    - the exact workflow or action snippet to use
+   - the exact local execution command when local runs are requested
 9. If the user asked you to implement, edit the workflow files and preserve the repository's existing conventions.
 10. After editing files, validate the YAML and run the repository's relevant validators.
 
@@ -62,6 +69,16 @@ Infer from the repository first. Ask the user only when a missing detail changes
 - Escalate to full-repository recommendations when the changes touch shared configuration, dependency manifests, Dockerfiles, IaC, release workflows, or security-sensitive areas.
 - Keep DAST and compliance scans opt-in unless the local environment clearly provides the required target or policy context.
 - If the repository is not yet using Argus in CI, still return a local pre-push scan plan and then propose the minimal CI workflow that mirrors it.
+- Default local execution to a temporary or checked-in workflow that calls Argus composite actions directly, then run it with `act`.
+- For local runs, set `post_pr_comment: false` and `enable_code_security: false`; PR comments and SARIF uploads are CI concerns and often skip under `act`.
+- If `act` or a compatible local runner is unavailable, still return the exact workflow and hook snippets, but say local execution is pending environment setup.
+
+## Platform routing
+
+- Use reusable workflows for github.com CI when the repo wants simple onboarding and can call cross-repo `workflow_call`.
+- Use composite actions directly for GHES or air-gapped setups because that is Argus' primary portability path.
+- Use the same direct composite action pattern for local runs so the local plan stays close to GHES and works under `act`.
+- When the platform is unclear, ask whether the target repo runs on github.com or GHES before choosing between reusable workflows and direct actions.
 
 ## Selection rules
 
@@ -133,6 +150,8 @@ Return a concise plan with these sections:
 
 ### For reusable workflow onboarding
 
+Use this on github.com when the user wants CI onboarding and cross-repo reusable workflows are available.
+
 Prefer a job shaped like:
 
 ```yaml
@@ -154,6 +173,57 @@ Then add or remove scanners based on the repository signals you found.
   - scanners to run now in the local loop
   - scanners to keep primarily in CI because they are slower, need hosted permissions, or need runtime targets
 - When the repository already has Argus wired into CI, keep the local recommendation aligned with the CI scanner list unless you have a clear reason to trim it for speed.
+- Prefer direct composite action jobs instead of reusable workflows so the same pattern works with `act` and GHES.
+- Include a runnable `act` command whenever the user asks for a pre-push or local development workflow.
+
+### For GHES or air-gapped workflows
+
+- Prefer direct composite action snippets that follow `examples/github-enterprise/*`.
+- Do not default to cross-repo reusable workflows on GHES.
+- If the environment is air-gapped, call out that action references may need to point to an internal mirror.
+
+### For concrete local execution
+
+When the user wants to actually run Argus before push, provide a minimal workflow plus an `act` command. A baseline pattern is:
+
+```yaml
+name: Local Argus Pre-Push
+
+on:
+  workflow_dispatch:
+
+jobs:
+  local-argus:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: huntridge-labs/argus/.github/actions/scanner-gitleaks@<argus-version>
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          post_pr_comment: false
+          enable_code_security: false
+          fail_on_severity: none
+
+      - uses: huntridge-labs/argus/.github/actions/scanner-opengrep@<argus-version>
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          post_pr_comment: false
+          enable_code_security: false
+          fail_on_severity: none
+```
+
+Run it locally with:
+
+```bash
+act workflow_dispatch --workflows .github/workflows/local-argus-pre-push.yml --secret GITHUB_TOKEN=local-test-token
+```
+
+Then add `scanner-bandit`, `scanner-osv`, `scanner-container`, or `scanner-trivy-iac` / `scanner-checkov` based on the selected local scan plan.
 
 ### For DAST
 

--- a/.agents/skills/argus-scanner-selection/references/REFERENCE.md
+++ b/.agents/skills/argus-scanner-selection/references/REFERENCE.md
@@ -1,0 +1,205 @@
+# Argus Scanner Selection Reference
+
+Use this file when you need the detailed mapping from repository signals or local change sets to Argus scanners, workflow structure, and operational caveats.
+
+## Scanner matrix
+
+| Repository signal | Evidence to look for | Recommended scanner(s) | Why | Caveats |
+| --- | --- | --- | --- | --- |
+| Any source repository | `src/`, `app/`, `lib/`, language source files | `gitleaks`, `opengrep` | Baseline coverage for secrets + multi-language SAST | `gitleaks` benefits from full git history on CI |
+| Python present | `*.py`, `pyproject.toml`, `requirements*.txt`, `poetry.lock` | `bandit` | Python-specific security linting | Keep `opengrep` too for broader rules |
+| CodeQL-supported languages + GHAS enabled | `*.py`, `*.js`, `*.ts`, `*.go`, `*.java`, `*.c`, `*.cpp`, `*.cs`, `*.rb`, `*.swift`, `*.kt` | `codeql` | Semantic analysis with language-aware results | In Argus' reusable workflow, omit `codeql` unless `enable_code_security: true` |
+| Dependency manifests or lockfiles | `package-lock.json`, `pnpm-lock.yaml`, `poetry.lock`, `requirements.txt`, `go.sum`, `Cargo.lock`, etc. | `osv` | Works on any trigger and auto-discovers manifests | Prefer this over `dependency-review` for push/schedule runs |
+| Pull request dependency policy | PR workflow + lockfiles/manifests | `dependency-review` | Dependency diff + optional license checks | PR-only; expected to skip on non-PR events |
+| Dockerfiles or image publish/build pipeline | `Dockerfile*`, `docker-compose.yml`, container build jobs | `container` | Coordinated Trivy + Grype + Syft workflow | Prefer this over combining standalone container scanners |
+| Need SBOM artifact or supply-chain inventory | release workflow, image publishing, compliance asks | `sbom` | Generates CycloneDX/SPDX/Syft inventories | `sbom` is not included in `all` |
+| Terraform / Kubernetes / CloudFormation | `*.tf`, `*.tfvars`, `*.yaml` under k8s dirs, `cloudformation/` | `infrastructure` | Coordinated Trivy IaC + Checkov workflow | Prefer this over adding `trivy-iac` and `checkov` separately |
+| Need only one IaC engine | same as above, but user wants split jobs | `trivy-iac` or `checkov` | Fine-grained control | Avoid pairing with `infrastructure` unless explicitly requested |
+| Web app or API with stable target | app server, deploy preview URL, compose stack, OpenAPI spec | `zap` | DAST / API scanning | Needs target mode: `url`, `docker-run`, or `compose` |
+| Untrusted binaries, archives, uploads | `*.zip`, `*.jar`, installers, media ingest, upload pipeline | `clamav` | Malware detection | Not a default scanner for source-only repos |
+| FedRAMP change classification | `.github/scn-config.yml`, compliance docs, regulated infra diffs | `scn-detector` | Significant Change Notification detection | Separate workflow/action, not part of `reusable-security-hardening.yml` |
+
+## Local development decision table
+
+Use this table when the goal is to catch issues before push.
+
+| Local change pattern | Default local scanners | Usually keep in CI unless explicitly requested |
+| --- | --- | --- |
+| application code only | `gitleaks`, `opengrep`, plus `bandit` for Python | `zap`, `clamav`, `scn-detector` |
+| manifest or lockfile change | `gitleaks`, `opengrep`, `osv` | `dependency-review` on non-PR events |
+| Dockerfile, compose, or image build change | `gitleaks`, `opengrep`, `container` | separate standalone container scanners unless needed |
+| Terraform / Kubernetes / CloudFormation change | `gitleaks`, `opengrep`, `infrastructure` | `scn-detector` unless FedRAMP workflows require it |
+| upload pipeline or binary artifact change | `gitleaks`, `opengrep`, `clamav` when relevant | `zap` unless a local target exists |
+| web app change with stable local or preview target | baseline local set plus `zap` if a target is available | `zap` if there is no reliable target mode |
+
+## Local-first recommendations
+
+- Start with the changed files, then widen to the full repository only when the changes touch shared security posture.
+- Mirror CI where practical, but trim clearly slow or environment-dependent scans from the default pre-push loop.
+- Prefer `osv` over `dependency-review` for local or non-PR checks.
+- Treat `zap`, `clamav`, and `scn-detector` as explicitly justified local checks, not baseline defaults.
+
+## Grouped tokens vs standalone scanners
+
+Use grouped tokens when the user wants broad onboarding with fewer workflow decisions:
+
+| Token | Expands to | Best when |
+| --- | --- | --- |
+| `container` | coordinated container discovery/build + Trivy + Grype + Syft | repo builds images and you want one container job family |
+| `infrastructure` | coordinated Trivy IaC + Checkov | repo has IaC and you want one infrastructure job family |
+| `dependencies` | `osv` + `dependency-review` | pull request workflows need both manifest scanning and diff checks |
+| `sast` | `codeql` + `opengrep` + `bandit` + `gitleaks` | repo is code-heavy and all grouped scanners are valid |
+
+Use standalone scanners when:
+
+- the trigger invalidates part of a group (`dependency-review` on push or schedule)
+- you need separate permissions, thresholds, or job names
+- the user wants only one scanner from the group
+
+## Trigger-aware recipes
+
+### Pull request baseline
+
+Use this for most application repositories:
+
+```yaml
+uses: huntridge-labs/argus/.github/workflows/reusable-security-hardening.yml@<argus-version>
+with:
+  scanners: gitleaks,opengrep,osv,dependency-review
+  enable_code_security: false
+  allow_failure: true
+  severity_threshold: high
+secrets: inherit
+```
+
+Then add `bandit`, `codeql`, `container`, `infrastructure`, `sbom`, or `clamav` when the repository signals justify them.
+
+### Local pre-push baseline
+
+Use this as the default mental model for a coding agent helping before push:
+
+- start with `gitleaks` and `opengrep`
+- add `bandit` for Python changes
+- add `osv` for manifest or lockfile changes
+- add `container` for Docker and image-related changes
+- add `infrastructure` for IaC changes
+- add `zap`, `clamav`, or `scn-detector` only when the change set clearly requires them
+
+When the repository already has Argus in CI, prefer keeping the local recommendation compatible with the CI scanner list while still optimizing for faster iteration.
+
+### Push or scheduled baseline
+
+Prefer `osv` over `dependencies` unless you want a graceful PR-only skip from `dependency-review`:
+
+```yaml
+uses: huntridge-labs/argus/.github/workflows/reusable-security-hardening.yml@<argus-version>
+with:
+  scanners: gitleaks,opengrep,osv
+  enable_code_security: false
+  allow_failure: true
+  severity_threshold: high
+secrets: inherit
+```
+
+### Containerized service
+
+```yaml
+uses: huntridge-labs/argus/.github/workflows/reusable-security-hardening.yml@<argus-version>
+with:
+  scanners: gitleaks,opengrep,osv,container,sbom
+  enable_code_security: false
+  allow_failure: true
+  severity_threshold: high
+secrets: inherit
+```
+
+Drop `sbom` if the user does not need inventory artifacts.
+
+### Python service with GHAS enabled
+
+```yaml
+uses: huntridge-labs/argus/.github/workflows/reusable-security-hardening.yml@<argus-version>
+with:
+  scanners: gitleaks,opengrep,osv,bandit,codeql
+  enable_code_security: true
+  allow_failure: true
+  severity_threshold: high
+secrets: inherit
+```
+
+### Infrastructure repository
+
+```yaml
+uses: huntridge-labs/argus/.github/workflows/reusable-security-hardening.yml@<argus-version>
+with:
+  scanners: gitleaks,opengrep,infrastructure
+  iac_path: infrastructure
+  enable_code_security: false
+  allow_failure: true
+  severity_threshold: high
+secrets: inherit
+```
+
+### Web app with DAST
+
+Keep ZAP separate unless the user explicitly wants it folded into the shared workflow:
+
+```yaml
+jobs:
+  security:
+    uses: huntridge-labs/argus/.github/workflows/reusable-security-hardening.yml@<argus-version>
+    with:
+      scanners: gitleaks,opengrep,osv
+      enable_code_security: false
+      allow_failure: true
+      severity_threshold: high
+    secrets: inherit
+
+  dast:
+    uses: huntridge-labs/argus/.github/workflows/scanner-zap.yml@<argus-version>
+    with:
+      scan_mode: url
+      scan_type: baseline
+      target_url: https://example.test
+      fail_on_severity: high
+    secrets: inherit
+```
+
+### FedRAMP companion flow
+
+Use `scn-detector` as a separate job or workflow:
+
+```yaml
+- uses: huntridge-labs/argus/.github/actions/scn-detector@<argus-version>
+  with:
+    config_file: .github/scn-config.yml
+    create_issues: true
+    post_pr_comment: true
+    enable_ai_fallback: true
+```
+
+## Inputs, secrets, and permissions
+
+| Scanner / workflow | Key inputs | Secrets | Permissions / notes |
+| --- | --- | --- | --- |
+| `reusable-security-hardening.yml` | `scanners`, `enable_code_security`, `allow_failure`, `severity_threshold` | `GITHUB_TOKEN` implied, `GITLEAKS_LICENSE` optional | `contents: read`, `actions: read`, `pull-requests: write`, `security-events: write`; add `id-token: write` when using the full reusable workflow defaults |
+| `codeql` | `codeql_languages`, `config_file`, `enable_code_security` | none beyond `GITHUB_TOKEN` | Requires GitHub Code Security to stay enabled in the reusable workflow |
+| `bandit` | `bandit_config_file` | none | Python-only |
+| `osv` | `osv_scan_path`, `osv_lockfile`, `osv_recursive` | none | Any trigger |
+| `dependency-review` | `vulnerability_check`, `license_check`, `allow_licenses`, `deny_licenses` | none | Pull request event only |
+| `container` | `scan_mode`, `image_ref`, `container_name`, `scanners` | `registry_password` optional | add `packages: read` for private registries and image pulls |
+| `infrastructure` | `iac_path` | optional `AWS_ACCOUNT_ID` in some setups | same baseline permissions as the shared workflow |
+| `sbom` | `scan_path`, `scan_image`, `output_format` | `registry_password` optional | Dependency Graph upload requires the relevant GitHub permissions |
+| `zap` | `scan_mode`, `scan_type`, `target_url` or `api_spec`, `compose_file`, `app_image_ref` | `registry_password` optional | target must exist and be reachable from the runner |
+| `scn-detector` | `config_file`, `create_issues`, `post_pr_comment`, `enable_ai_fallback` | `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` optional, `GITHUB_TOKEN` required | also needs `issues: write` when creating issues |
+
+## Review checklist
+
+Before finalizing a recommendation or implementation:
+
+1. Confirm every selected scanner has a matching repository signal.
+2. Confirm every omitted scanner has an explicit reason.
+3. Check whether `enable_code_security` should be true or false.
+4. Check whether `dependency-review` belongs only on PR events.
+5. Check whether grouped tokens are hiding an invalid or redundant combination.
+6. Validate any workflow YAML you edited.

--- a/.agents/skills/argus-scanner-selection/references/REFERENCE.md
+++ b/.agents/skills/argus-scanner-selection/references/REFERENCE.md
@@ -2,6 +2,17 @@
 
 Use this file when you need the detailed mapping from repository signals or local change sets to Argus scanners, workflow structure, and operational caveats.
 
+## Platform routing
+
+| Environment | Preferred Argus integration path | Why |
+| --- | --- | --- |
+| github.com CI | `reusable-security-hardening.yml` or direct composite actions | quickest onboarding when cross-repo reusable workflows are available |
+| GHES with github.com access | direct composite actions | GHES cannot reliably use cross-repo `workflow_call`, but can use composite actions directly |
+| air-gapped GHES / internal mirror | direct composite actions from the internal mirror | same portability model, but refs must point at the mirrored source |
+| local pre-push workflow | direct composite actions executed with `act` | keeps local runs close to GHES-compatible usage and avoids reusable-workflow indirection |
+
+If the target platform is GHES, use `examples/github-enterprise/*` as the starting point instead of the reusable workflow.
+
 ## Scanner matrix
 
 | Repository signal | Evidence to look for | Recommended scanner(s) | Why | Caveats |
@@ -38,6 +49,8 @@ Use this table when the goal is to catch issues before push.
 - Mirror CI where practical, but trim clearly slow or environment-dependent scans from the default pre-push loop.
 - Prefer `osv` over `dependency-review` for local or non-PR checks.
 - Treat `zap`, `clamav`, and `scn-detector` as explicitly justified local checks, not baseline defaults.
+- Default local execution to direct composite action workflows plus `act`.
+- Disable PR comments and SARIF upload in local runs with `post_pr_comment: false` and `enable_code_security: false`.
 
 ## Grouped tokens vs standalone scanners
 
@@ -87,6 +100,60 @@ Use this as the default mental model for a coding agent helping before push:
 
 When the repository already has Argus in CI, prefer keeping the local recommendation compatible with the CI scanner list while still optimizing for faster iteration.
 
+### Concrete local execution recipe
+
+Use a direct composite action workflow for local runs:
+
+```yaml
+name: Local Argus Pre-Push
+
+on:
+  workflow_dispatch:
+
+jobs:
+  local-argus:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: huntridge-labs/argus/.github/actions/scanner-gitleaks@<argus-version>
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          post_pr_comment: false
+          enable_code_security: false
+          fail_on_severity: none
+
+      - uses: huntridge-labs/argus/.github/actions/scanner-opengrep@<argus-version>
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          post_pr_comment: false
+          enable_code_security: false
+          fail_on_severity: none
+```
+
+Run it with:
+
+```bash
+act workflow_dispatch --workflows .github/workflows/local-argus-pre-push.yml --secret GITHUB_TOKEN=local-test-token
+```
+
+Then extend the workflow with `scanner-bandit`, `scanner-osv`, `scanner-container`, `scanner-trivy-iac`, or `scanner-checkov` based on the detected change set.
+
+### Optional pre-push hook pattern
+
+If the user wants automatic enforcement before push, wire the local workflow into a git hook:
+
+```bash
+#!/bin/sh
+act workflow_dispatch --workflows .github/workflows/local-argus-pre-push.yml --secret GITHUB_TOKEN=local-test-token || exit 1
+```
+
+Keep this opt-in. The skill should recommend hooks only when the user explicitly wants automatic blocking behavior.
+
 ### Push or scheduled baseline
 
 Prefer `osv` over `dependencies` unless you want a graceful PR-only skip from `dependency-review`:
@@ -103,6 +170,8 @@ secrets: inherit
 
 ### Containerized service
 
+Use this recipe on github.com CI. For GHES, switch to the equivalent direct composite action pattern from `examples/github-enterprise/`.
+
 ```yaml
 uses: huntridge-labs/argus/.github/workflows/reusable-security-hardening.yml@<argus-version>
 with:
@@ -117,6 +186,8 @@ Drop `sbom` if the user does not need inventory artifacts.
 
 ### Python service with GHAS enabled
 
+Use this recipe on github.com CI. On GHES, use direct composite actions and verify Code Security / GHAS availability separately.
+
 ```yaml
 uses: huntridge-labs/argus/.github/workflows/reusable-security-hardening.yml@<argus-version>
 with:
@@ -128,6 +199,8 @@ secrets: inherit
 ```
 
 ### Infrastructure repository
+
+Use this recipe on github.com CI. For GHES, use the direct composite action pattern from `examples/github-enterprise/infrastructure-scanning.yml`.
 
 ```yaml
 uses: huntridge-labs/argus/.github/workflows/reusable-security-hardening.yml@<argus-version>

--- a/.ai/architecture.yaml
+++ b/.ai/architecture.yaml
@@ -9,7 +9,7 @@ architecture:
   primary:
     location: ".github/actions/"
     pattern: "Composite actions"
-    version: "0.6.5"
+    version: "0.6.8"
     status: production
     advantage: "GHES compatible, self-contained"
 
@@ -81,6 +81,16 @@ components:
     instances:
       - security-summary
       - linting-summary
+
+  - name: agent-skills
+    location: ".agents/skills/"
+    purpose: "Portable Agent Skills bundles that help skills-compatible agents bring Argus into local development workflows and align those checks with CI coverage."
+    type: agent-skill
+    structure:
+      SKILL.md: "Agent Skills metadata and instructions"
+      references/REFERENCE.md: "Scanner matrix, trigger caveats, and workflow recipes"
+    instances:
+      - argus-scanner-selection
 
   - name: scn-detector
     location: ".github/actions/scn-detector/"

--- a/.ai/architecture.yaml
+++ b/.ai/architecture.yaml
@@ -88,7 +88,7 @@ components:
     type: agent-skill
     structure:
       SKILL.md: "Agent Skills metadata and instructions"
-      references/REFERENCE.md: "Scanner matrix, trigger caveats, and workflow recipes"
+      references/REFERENCE.md: "Scanner matrix, platform routing guidance, local act recipes, trigger caveats, and workflow recipes"
     instances:
       - argus-scanner-selection
 

--- a/.ai/context.yaml
+++ b/.ai/context.yaml
@@ -11,7 +11,7 @@ project:
   purpose: "Automated security scanning orchestration for GitHub Actions"
   primary_language: yaml  # GitHub Actions workflows
   secondary_languages: [python]
-  version: "0.6.5"
+  version: "0.6.8"
   license: "AGPL-3.0"
   repository: "huntridge-labs/argus"
 
@@ -35,6 +35,7 @@ entrypoints:
   reusable_workflow: ".github/workflows/reusable-security-hardening.yml"
   examples: "examples/workflows/"
   documentation: "docs/"
+  agent_skills: ".agents/skills/"
   docsite: "scripts/docsite/"
   docsite_config: "docsite.yml"
   docsite_url: "https://huntridge-labs.github.io/argus/"
@@ -42,6 +43,7 @@ entrypoints:
 common_tasks:
   run_all_scanners: "Call the reusable workflow to run the default scanner suite."
   run_subset: "Enable a subset of scanners via workflow inputs or config."
+  recommend_scanners: "Use the argus-scanner-selection skill to map a target repository or local change set to the right Argus scanners, pre-push checks, workflow inputs, and implementation plan."
   view_reports: "Review SARIF uploads, PR comments, and summary reports."
   update_versions: "Bump scanner or action versions and validate outputs."
   troubleshoot_failures: "Inspect workflow logs and scanner outputs to resolve errors."

--- a/.ai/context.yaml
+++ b/.ai/context.yaml
@@ -43,7 +43,7 @@ entrypoints:
 common_tasks:
   run_all_scanners: "Call the reusable workflow to run the default scanner suite."
   run_subset: "Enable a subset of scanners via workflow inputs or config."
-  recommend_scanners: "Use the argus-scanner-selection skill to map a target repository or local change set to the right Argus scanners, pre-push checks, workflow inputs, and implementation plan."
+  recommend_scanners: "Use the argus-scanner-selection skill to map a target repository or local change set to the right Argus scanners, choose the correct github.com versus GHES integration path, and produce pre-push execution plus CI alignment guidance."
   view_reports: "Review SARIF uploads, PR comments, and summary reports."
   update_versions: "Bump scanner or action versions and validate outputs."
   troubleshoot_failures: "Inspect workflow logs and scanner outputs to resolve errors."

--- a/.ai/workflows.yaml
+++ b/.ai/workflows.yaml
@@ -177,6 +177,21 @@ user_workflows:
             fail_on_severity: none  # Report only, don't fail
             enable_code_security: true
 
+  argus_scanner_selection_skill:
+    description: "Use the bundled Agent Skills bundle to analyze a target repository or local change set and choose the right Argus scanners for pre-push checks and CI alignment"
+    category: planning
+    location: ".agents/skills/argus-scanner-selection/SKILL.md"
+    outputs:
+      - "Recommended scanners and rationale"
+      - "Local development scan plan"
+      - "Exact workflow or action snippet"
+      - "Required inputs, secrets, and permissions"
+    steps:
+      - "Inspect the target repository or current change set for languages, manifests, Dockerfiles, IaC, web targets, and compliance signals"
+      - "Map findings to scanners using .agents/skills/argus-scanner-selection/references/REFERENCE.md"
+      - "Prefer the smallest effective pre-push scanner set locally, then keep CI workflow recommendations aligned"
+      - "Prefer an explicit scanners list over 'all' when generating onboarding workflows"
+
 # ==============================================================================
 # CONTRIBUTOR WORKFLOWS - For developers of this project
 # ==============================================================================

--- a/.ai/workflows.yaml
+++ b/.ai/workflows.yaml
@@ -184,11 +184,14 @@ user_workflows:
     outputs:
       - "Recommended scanners and rationale"
       - "Local development scan plan"
+      - "Platform-specific routing for github.com CI versus GHES"
       - "Exact workflow or action snippet"
+      - "Concrete local act command when local execution is requested"
       - "Required inputs, secrets, and permissions"
     steps:
-      - "Inspect the target repository or current change set for languages, manifests, Dockerfiles, IaC, web targets, and compliance signals"
+      - "Inspect the target repository or current change set for languages, manifests, Dockerfiles, IaC, web targets, compliance signals, and hosting environment"
       - "Map findings to scanners using .agents/skills/argus-scanner-selection/references/REFERENCE.md"
+      - "Route github.com CI toward reusable workflows and GHES/local usage toward direct composite actions"
       - "Prefer the smallest effective pre-push scanner set locally, then keep CI workflow recommendations aligned"
       - "Prefer an explicit scanners list over 'all' when generating onboarding workflows"
 


### PR DESCRIPTION
## Summary
- add `.agents/skills/argus-scanner-selection/SKILL.md` as an open-standard Agent Skills bundle for local Argus scanner selection
- add `.agents/skills/argus-scanner-selection/references/REFERENCE.md` with local pre-push guidance, scanner mappings, grouped-token guidance, trigger-aware workflow recipes, and input/permission notes
- update `.ai/context.yaml`, `.ai/architecture.yaml`, and `.ai/workflows.yaml` so the skill is represented in Argus' AICaC context

## Why
Argus is already strong in CI, but local development workflows can also benefit from a portable way to bring the same scanner intelligence into pre-push loops. This PR adds a local coding agent skill that helps inspect a repository or current change set, choose the smallest effective Argus scanners to run before push, and keep that local coverage aligned with CI.

## What this adds
- local change-aware scanner selection for staged diffs, branch diffs, working tree changes, or full-repository checks
- pre-push guidance for when to run `gitleaks`, `opengrep`, `osv`, `bandit`, `container`, `infrastructure`, and when to keep slower or target-dependent checks like `zap`, `clamav`, or `scn-detector` opt-in
- guidance for keeping local recommendations aligned with Argus CI coverage instead of treating local and CI workflows as separate concerns
- ready-to-use workflow/action snippets with inputs, secrets, and permission expectations
- AICaC updates so the new local-dev skill is represented in project context

## Validation
- parsed and validated the new `SKILL.md` frontmatter and updated `.ai/*.yaml`
- `npm run validate`
- `python3.12 -m pytest -q -o addopts=''`

## Notes
- no scanner runtime behavior changed in this PR; this adds a portable local-development skill and project context
- the goal is to make Argus viable in local dev loops as well as CI
