### PR TITLE
fix(ci): restore git push credentials for release workflow

### DIFF
--- a/.ai/errors.yaml
+++ b/.ai/errors.yaml
@@ -193,6 +193,35 @@ error_patterns:
             types: [opened, synchronize, reopened]
 
   # ==============================================================================
+  # RELEASE ERRORS
+  # ==============================================================================
+
+  - pattern: "could not read Username for 'https://github.com'"
+    category: release
+    context: "release-it git push fails during release workflow"
+
+    root_cause: |
+      The checkout step uses persist-credentials: false (supply chain
+      hardening best practice), which removes the token from the git
+      credential store. When release-it runs git push, there are no
+      credentials available for HTTPS authentication.
+
+    solution:
+      steps:
+        - "Add git remote set-url to the Configure Git step"
+        - "Inject the token via env var, not inline ${{ }}"
+      code: |
+        - name: Configure Git
+          run: |
+            git config --global user.name "github-actions[bot]"
+            git config --global user.email "github-actions[bot]@users.noreply.github.com"
+            git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          env:
+            GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+      note: "Do NOT remove persist-credentials: false — fix the remote URL instead"
+      reference: "PR #86"
+
+  # ==============================================================================
   # WORKFLOW ERRORS
   # ==============================================================================
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,9 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Release (Auto)
         if: github.event_name == 'push' || github.event.inputs.releaseType == 'auto'


### PR DESCRIPTION
## Description
The supply chain hardening PRs (#80, #85) added `persist-credentials: false` to the checkout step in the release workflow. This removed the git credential store, causing `release-it`'s `git push` to fail with `fatal: could not read Username for 'https://github.com'`.

## Changes Made
- [ ] Added new scanner/workflow
- [ ] Modified existing scanner/workflow
- [ ] Updated documentation
- [x] Fixed bug
- [ ] Other (please specify)

### Details
- **Affected workflow**: `.github/workflows/release.yml`
- Added `git remote set-url` in the "Configure Git" step to embed the token in the remote URL, restoring push capability while keeping `persist-credentials: false` for security.
- No breaking changes.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results
- All 1141 pytest tests pass
- `zizmor` reports no findings on the modified workflow (4 pre-existing suppressed)

## Security Considerations
- [ ] No security impact
- [x] Security enhancement
- [ ] Potential security implications (explain below)

### Security Details
Keeps `persist-credentials: false` (supply chain best practice) while restoring push credentials only where needed. Token is injected via env var (not inline `${{ }}`), avoiding expression injection. zizmor confirms no new findings.

## AI Context Updates (.ai/)
- [ ] `.ai/architecture.yaml` updated (if components/structure changed)
- [ ] `.ai/workflows.yaml` updated (if commands/tasks changed)
- [ ] `.ai/decisions.yaml` updated (if design decision made)
- [x] `.ai/errors.yaml` updated (if common error addressed)
- [ ] N/A - No .ai/ updates needed

## Checklist
- [x] Code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Fixes release job failure on run #24221241085.

## Screenshots/Logs (if applicable)
Error from failed release run:
\`\`\`
Rolling back remote tag push 0.7.0
WARNING An error was encountered when trying to rollback the tag on the remote:
  fatal: could not read Username for 'https://github.com': No such device or address
✖ Git push
ERROR fatal: could not read Username for 'https://github.com': No such device or address
\`\`\`