### PR TITLE
feat(cli): surface missing tools after init and scan

### DIFF
--- a/.ai/architecture.yaml
+++ b/.ai/architecture.yaml
@@ -37,7 +37,7 @@ components:
       "scanners/": "Scanner modules implementing Scanner protocol (SCANNER_REGISTRY includes linters via auto-merge)"
       "linters/": "Linter modules implementing Scanner protocol (LINTER_REGISTRY auto-merges into SCANNER_REGISTRY)"
       "reporters/": "Output reporters (terminal, markdown, sarif, json)"
-      "preflight/": "CI preflight: provider detection, living issue reporting (GitHub/GitLab), network deps"
+      "preflight/": "CI preflight: provider detection, living issue reporting (GitHub/GitLab), network deps, scanner tool-readiness checks (tool_check.py)"
 
   - name: argus-linters
     location: "argus/linters/"

--- a/argus/cli.py
+++ b/argus/cli.py
@@ -899,12 +899,40 @@ def _cmd_source_scan(args: argparse.Namespace) -> int:
         _write_output_vars(summary, output_vars_path)
         log.debug("Output vars written to %s", output_vars_path)
 
+    # Nudge when scanners ran but produced no results — this is the
+    # "silent empty scan" failure mode users hit on machines without
+    # Docker or the native tools installed. Point them at --check-tools
+    # so they get actionable install suggestions instead of nothing.
+    _print_missing_scanner_nudge(
+        requested=scanner_names or [
+            name for name in engine._scanners
+            if config.get_scanner_config(name).enabled
+        ],
+        summary=summary,
+    )
+
     # Finalize audit trail
     exit_code = EXIT_SUCCESS if summary.passed else EXIT_FINDINGS
     finalize_manifest(manifest, summary=summary, exit_code=exit_code, output_dir=output_dir)
     log.info("Audit manifest written to %s/argus-audit.json", output_dir)
 
     return exit_code
+
+
+def _print_missing_scanner_nudge(requested: list[str], summary) -> None:
+    """Tell the user how to diagnose scanners that produced no results."""
+    completed = {r.scanner for r in summary.results}
+    missing = [name for name in requested if name not in completed]
+    if not missing:
+        return
+    print(
+        f"\n💡 {len(missing)} scanner(s) produced no results: {', '.join(missing)}",
+        file=sys.stderr,
+    )
+    print(
+        "   Run 'argus validate --check-tools' for install suggestions.",
+        file=sys.stderr,
+    )
 
 
 def _cmd_container_scan(args: argparse.Namespace) -> int:
@@ -1689,76 +1717,53 @@ def _check_tool_readiness(
 ) -> tuple[list[str], list]:
     """Check whether enabled scanners can actually run.
 
-    Returns (unavailable_names, tool_statuses) where tool_statuses is a list
-    of ToolStatus objects for use in issue reporting.
+    Returns (unavailable_names, tool_statuses). Pure detection lives in
+    `argus.preflight.tool_check`; this wrapper handles the detailed
+    per-scanner output specific to `argus validate --check-tools`.
     """
-    import shutil
     from argus.scanners import SCANNER_REGISTRY
-    from argus.containers import get_image
-    from argus.preflight.network_deps import get_network_deps
-    from argus.preflight.report_body import ToolStatus
+    from argus.preflight.tool_check import (
+        check_scanner_readiness,
+        container_runtime_available,
+        unavailable_names,
+    )
 
-    container_available = any(shutil.which(r) for r in ("docker", "podman", "nerdctl"))
-    unavailable = []
-    statuses = []
-
-    def _resolve_image(image: str) -> str:
-        """Apply registry override to an image reference."""
-        if not registry or not image:
-            return image
-        parts = image.split("/", 1)
-        if len(parts) == 2 and ("." in parts[0] or ":" in parts[0]):
-            return f"{registry}/{parts[1]}"
-        return f"{registry}/{image}"
+    statuses = check_scanner_readiness(enabled_names, backend=backend, registry=registry)
 
     if registry:
         print(f"\n   Registry: {registry}")
     print("\n   Tool readiness:")
-    for name in enabled_names:
-        net_deps = get_network_deps(name)
+    for status in statuses:
+        name = status.name
         cls = SCANNER_REGISTRY.get(name)
-        if not cls:
+        if cls is None:
             print(f"     {name}: ⚠️  unknown scanner (not in registry)")
-            unavailable.append(name)
-            statuses.append(ToolStatus(name, False, "none", network_deps=net_deps))
-            continue
-
-        scanner = cls()
-        local = scanner.is_available()
-        raw_image = get_image(name) or getattr(scanner, "container_image", "")
-        image = _resolve_image(raw_image)
-
-        if local:
+        elif status.available and status.method == "local":
             print(f"     {name}: ✅ installed locally")
-            statuses.append(ToolStatus(name, True, "local", network_deps=net_deps))
-        elif backend == "local":
-            install_cmd = scanner.install_command() or "see docs"
-            print(f"     {name}: ❌ not found (install: {install_cmd})")
-            unavailable.append(name)
-            statuses.append(ToolStatus(name, False, "none", network_deps=net_deps))
-        elif not container_available:
-            install_cmd = scanner.install_command() or "see docs"
-            print(f"     {name}: ❌ not found, Docker not available (install: {install_cmd})")
-            unavailable.append(name)
-            statuses.append(ToolStatus(name, False, "none", network_deps=net_deps))
-        elif image:
-            print(f"     {name}: 🐳 will use container ({image})")
-            statuses.append(ToolStatus(name, True, "container", image=image, network_deps=net_deps))
+        elif status.available and status.method == "container":
+            print(f"     {name}: 🐳 will use container ({status.image})")
         else:
-            install_cmd = scanner.install_command() or "see docs"
-            print(f"     {name}: ❌ not found, no container image (install: {install_cmd})")
-            unavailable.append(name)
-            statuses.append(ToolStatus(name, False, "none", network_deps=net_deps))
+            install_cmd = cls().install_command() or "see docs"
+            if backend == "local":
+                print(f"     {name}: ❌ not found (install: {install_cmd})")
+            elif not container_runtime_available():
+                print(f"     {name}: ❌ not found, Docker not available (install: {install_cmd})")
+            else:
+                print(f"     {name}: ❌ not found, no container image (install: {install_cmd})")
 
-        if net_deps:
-            for dep in net_deps:
-                print(f"             ℹ️  Requires network: {dep}")
+        for dep in status.network_deps:
+            print(f"             ℹ️  Requires network: {dep}")
 
-    if not container_available and backend != "local":
-        print("\n   ⚠️  No container runtime found (docker, podman, or nerdctl) — scanners without local installs will fail")
-        print("      Install Docker, Podman, or nerdctl — or set execution.backend: local in argus.yml")
+    if not container_runtime_available() and backend != "local":
+        print(
+            "\n   ⚠️  No container runtime found (docker, podman, or nerdctl) — "
+            "scanners without local installs will fail"
+        )
+        print(
+            "      Install Docker, Podman, or nerdctl — or set execution.backend: local in argus.yml"
+        )
 
-    return unavailable, statuses
+    return unavailable_names(statuses), statuses
 
 
 def _report_issue(

--- a/argus/init.py
+++ b/argus/init.py
@@ -81,9 +81,51 @@ def run_init(
     config_content = generate_config(signals)
     config_path.write_text(config_content, encoding="utf-8")
 
-    _print_summary(signals, config_path)
+    enabled_scanners = _extract_enabled_scanners(config_content)
+    readiness = _check_local_readiness(enabled_scanners)
+
+    _print_summary(signals, config_path, readiness=readiness)
 
     return EXIT_SUCCESS
+
+
+def _extract_enabled_scanners(config_content: str) -> list[str]:
+    """Parse scanners out of the just-generated argus.yml content.
+
+    We parse the string we just wrote instead of re-reading the file so
+    tests stay deterministic across filesystems, and we avoid importing
+    the full config loader here just for a name list.
+    """
+    import yaml
+    try:
+        data = yaml.safe_load(config_content) or {}
+    except yaml.YAMLError:
+        return []
+    scanners = data.get("scanners", {})
+    if not isinstance(scanners, dict):
+        return []
+    enabled = []
+    for name, cfg in scanners.items():
+        if isinstance(cfg, dict) and cfg.get("enabled", True):
+            enabled.append(name)
+    return enabled
+
+
+def _check_local_readiness(scanner_names: list[str]) -> dict[str, int] | None:
+    """Return a {local, container, missing} bucket summary, or None on error.
+
+    Swallows all errors from the readiness check — init must never fail
+    because a scanner registry import blew up. A None return skips the
+    readiness block entirely in `_print_summary`.
+    """
+    if not scanner_names:
+        return None
+    try:
+        from argus.preflight.tool_check import check_scanner_readiness, summarize
+        statuses = check_scanner_readiness(scanner_names, backend="auto")
+        return summarize(statuses)
+    except Exception:
+        return None
 
 
 def detect_project(root: Path) -> dict[str, list[str]]:
@@ -397,11 +439,13 @@ def _guess_iac_path(signals: dict[str, list[str]]) -> str:
 def _print_summary(
     signals: dict[str, list[str]],
     config_path: Path,
+    readiness: dict[str, int] | None = None,
 ) -> None:
     """Print a polished summary of what was created and next steps."""
     G = "\033[32m"
     B = "\033[1;32m"
     D = "\033[90m"
+    Y = "\033[33m"
     R = "\033[0m"
 
     print(f"\n{B}  Initialized!{R}  {D}Created {config_path}{R}")
@@ -425,6 +469,21 @@ def _print_summary(
         for key, evidence in signals.items():
             label = signal_labels.get(key, key)
             print(f"    {D}-{R} {label} {D}({evidence[0]}){R}")
+
+    if readiness is not None:
+        local = readiness["local"]
+        container = readiness["container"]
+        missing = readiness["missing"]
+        print(f"\n{G}  Tool readiness on this machine:{R}")
+        print(
+            f"    {D}-{R} {local} ready locally, {container} via container, "
+            f"{Y if missing else G}{missing} missing{R}"
+        )
+        if missing:
+            print(
+                f"    {D}-{R} {Y}Run {G}argus validate --check-tools{Y} "
+                f"for per-scanner install suggestions.{R}"
+            )
 
     print(f"\n{G}  Next steps:{R}")
     print(f"    {B}1.{R} Review argus.yml and adjust scanner settings")

--- a/argus/preflight/tool_check.py
+++ b/argus/preflight/tool_check.py
@@ -1,0 +1,98 @@
+"""Pure-logic readiness checks for registered scanners.
+
+Extracted from `argus validate --check-tools` so the same logic can drive
+`argus init` (so users see what's runnable on this machine right after
+generating a config) and end-of-scan nudges (so a user who just got an
+empty scan knows *why* and where to look). Keep this module free of I/O
+so callers own their own formatting.
+"""
+
+from __future__ import annotations
+
+import shutil
+
+from argus.preflight.report_body import ToolStatus
+
+
+CONTAINER_RUNTIMES = ("docker", "podman", "nerdctl")
+
+
+def container_runtime_available() -> bool:
+    """True if docker, podman, or nerdctl is on PATH."""
+    return any(shutil.which(r) for r in CONTAINER_RUNTIMES)
+
+
+def resolve_image(image: str, registry: str) -> str:
+    """Apply a registry override to an image reference."""
+    if not registry or not image:
+        return image
+    parts = image.split("/", 1)
+    if len(parts) == 2 and ("." in parts[0] or ":" in parts[0]):
+        return f"{registry}/{parts[1]}"
+    return f"{registry}/{image}"
+
+
+def check_scanner_readiness(
+    scanner_names: list[str],
+    backend: str = "auto",
+    registry: str = "",
+) -> list[ToolStatus]:
+    """Return a ToolStatus per scanner name — no I/O, no printing.
+
+    A scanner is available when (a) its local binary is installed, or
+    (b) the backend allows containers and a container runtime + image are
+    both present. Unknown scanners are reported as unavailable with
+    method="none" rather than raising, so callers can surface a full
+    status table even when the config references typos.
+    """
+    from argus.containers import get_image
+    from argus.preflight.network_deps import get_network_deps
+    from argus.scanners import SCANNER_REGISTRY
+
+    runtime_ok = container_runtime_available()
+    statuses: list[ToolStatus] = []
+
+    for name in scanner_names:
+        net_deps = get_network_deps(name)
+        cls = SCANNER_REGISTRY.get(name)
+        if cls is None:
+            statuses.append(ToolStatus(name, False, "none", network_deps=net_deps))
+            continue
+
+        scanner = cls()
+        local = scanner.is_available()
+        raw_image = get_image(name) or getattr(scanner, "container_image", "")
+        image = resolve_image(raw_image, registry)
+
+        if local:
+            statuses.append(ToolStatus(name, True, "local", network_deps=net_deps))
+        elif backend == "local":
+            statuses.append(ToolStatus(name, False, "none", network_deps=net_deps))
+        elif not runtime_ok:
+            statuses.append(ToolStatus(name, False, "none", network_deps=net_deps))
+        elif image:
+            statuses.append(
+                ToolStatus(name, True, "container", image=image, network_deps=net_deps)
+            )
+        else:
+            statuses.append(ToolStatus(name, False, "none", network_deps=net_deps))
+
+    return statuses
+
+
+def summarize(statuses: list[ToolStatus]) -> dict[str, int]:
+    """Bucket statuses by method for compact one-line summaries."""
+    buckets = {"local": 0, "container": 0, "missing": 0}
+    for s in statuses:
+        if not s.available:
+            buckets["missing"] += 1
+        elif s.method == "local":
+            buckets["local"] += 1
+        elif s.method == "container":
+            buckets["container"] += 1
+    return buckets
+
+
+def unavailable_names(statuses: list[ToolStatus]) -> list[str]:
+    """Names of scanners that cannot run with the current setup."""
+    return [s.name for s in statuses if not s.available]

--- a/argus/tests/preflight/test_tool_check.py
+++ b/argus/tests/preflight/test_tool_check.py
@@ -1,0 +1,150 @@
+"""Unit tests for argus.preflight.tool_check."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from argus.preflight.report_body import ToolStatus
+from argus.preflight.tool_check import (
+    check_scanner_readiness,
+    container_runtime_available,
+    resolve_image,
+    summarize,
+    unavailable_names,
+)
+
+
+class FakeScanner:
+    """Stand-in scanner used to drive readiness checks without real tools."""
+
+    def __init__(self, available: bool = False, image: str = ""):
+        self._available = available
+        self.container_image = image
+
+    def is_available(self) -> bool:
+        return self._available
+
+    def install_command(self) -> str | None:
+        return "pip install fake"
+
+
+class TestContainerRuntimeAvailable:
+    def test_true_when_docker_found(self):
+        with patch("argus.preflight.tool_check.shutil.which") as which:
+            which.side_effect = lambda r: "/usr/bin/docker" if r == "docker" else None
+            assert container_runtime_available() is True
+
+    def test_false_when_nothing_found(self):
+        with patch("argus.preflight.tool_check.shutil.which", return_value=None):
+            assert container_runtime_available() is False
+
+
+class TestResolveImage:
+    def test_no_registry_passthrough(self):
+        assert resolve_image("ghcr.io/foo/bar:1", "") == "ghcr.io/foo/bar:1"
+
+    def test_empty_image_passthrough(self):
+        assert resolve_image("", "my.registry") == ""
+
+    def test_registry_replaces_host(self):
+        assert resolve_image("ghcr.io/foo/bar:1", "my.registry") == "my.registry/foo/bar:1"
+
+    def test_registry_prepends_short_ref(self):
+        assert resolve_image("bandit:1", "my.registry") == "my.registry/bandit:1"
+
+
+class TestCheckScannerReadiness:
+    def test_local_available(self):
+        registry = {"fake": lambda: FakeScanner(available=True, image="img:1")}
+        with patch.dict("argus.scanners.SCANNER_REGISTRY", registry, clear=False):
+            with patch("argus.containers.get_image", return_value="img:1"):
+                with patch(
+                    "argus.preflight.tool_check.container_runtime_available",
+                    return_value=True,
+                ):
+                    statuses = check_scanner_readiness(["fake"])
+        assert len(statuses) == 1
+        assert statuses[0] == ToolStatus("fake", True, "local", network_deps=[])
+
+    def test_container_fallback_when_local_missing(self):
+        registry = {"fake": lambda: FakeScanner(available=False, image="img:1")}
+        with patch.dict("argus.scanners.SCANNER_REGISTRY", registry, clear=False):
+            with patch("argus.containers.get_image", return_value="img:1"):
+                with patch(
+                    "argus.preflight.tool_check.container_runtime_available",
+                    return_value=True,
+                ):
+                    statuses = check_scanner_readiness(["fake"])
+        assert statuses[0].available is True
+        assert statuses[0].method == "container"
+        assert statuses[0].image == "img:1"
+
+    def test_missing_when_no_local_no_runtime(self):
+        registry = {"fake": lambda: FakeScanner(available=False, image="img:1")}
+        with patch.dict("argus.scanners.SCANNER_REGISTRY", registry, clear=False):
+            with patch("argus.containers.get_image", return_value="img:1"):
+                with patch(
+                    "argus.preflight.tool_check.container_runtime_available",
+                    return_value=False,
+                ):
+                    statuses = check_scanner_readiness(["fake"])
+        assert statuses[0].available is False
+        assert statuses[0].method == "none"
+
+    def test_backend_local_ignores_containers(self):
+        registry = {"fake": lambda: FakeScanner(available=False, image="img:1")}
+        with patch.dict("argus.scanners.SCANNER_REGISTRY", registry, clear=False):
+            with patch("argus.containers.get_image", return_value="img:1"):
+                with patch(
+                    "argus.preflight.tool_check.container_runtime_available",
+                    return_value=True,
+                ):
+                    statuses = check_scanner_readiness(["fake"], backend="local")
+        assert statuses[0].available is False
+        assert statuses[0].method == "none"
+
+    def test_unknown_scanner_is_unavailable(self):
+        # Ensure the scanner is genuinely absent from both registries.
+        with patch.dict("argus.scanners.SCANNER_REGISTRY", {}, clear=True):
+            statuses = check_scanner_readiness(["nope"])
+        assert statuses[0].available is False
+        assert statuses[0].method == "none"
+
+    def test_no_image_no_local_is_unavailable(self):
+        registry = {"fake": lambda: FakeScanner(available=False, image="")}
+        with patch.dict("argus.scanners.SCANNER_REGISTRY", registry, clear=False):
+            with patch("argus.containers.get_image", return_value=""):
+                with patch(
+                    "argus.preflight.tool_check.container_runtime_available",
+                    return_value=True,
+                ):
+                    statuses = check_scanner_readiness(["fake"])
+        assert statuses[0].available is False
+
+
+class TestSummarize:
+    def test_buckets_mixed_statuses(self):
+        statuses = [
+            ToolStatus("a", True, "local"),
+            ToolStatus("b", True, "container", image="img"),
+            ToolStatus("c", True, "container", image="img"),
+            ToolStatus("d", False, "none"),
+        ]
+        assert summarize(statuses) == {"local": 1, "container": 2, "missing": 1}
+
+    def test_empty_input(self):
+        assert summarize([]) == {"local": 0, "container": 0, "missing": 0}
+
+
+class TestUnavailableNames:
+    def test_returns_only_unavailable(self):
+        statuses = [
+            ToolStatus("a", True, "local"),
+            ToolStatus("b", False, "none"),
+            ToolStatus("c", False, "none"),
+        ]
+        assert unavailable_names(statuses) == ["b", "c"]
+
+    def test_empty_when_all_available(self):
+        statuses = [ToolStatus("a", True, "local")]
+        assert unavailable_names(statuses) == []

--- a/argus/tests/test_cli.py
+++ b/argus/tests/test_cli.py
@@ -774,3 +774,40 @@ class TestCacheSubcommand:
         result = cmd_cache(args)
         assert result == EXIT_SUCCESS
         assert not tmp_path.exists()
+
+
+class TestMissingScannerNudge:
+    """End-of-scan nudge when requested scanners produced no results."""
+
+    def _summary(self, scanner_names: list[str]):
+        from argus.core.models import ScanResult, ScanSummary
+
+        results = [ScanResult(scanner=name, findings=[]) for name in scanner_names]
+        return ScanSummary(results=results, severity_threshold=None)
+
+    def test_no_output_when_all_scanners_completed(self, capsys):
+        from argus.cli import _print_missing_scanner_nudge
+
+        _print_missing_scanner_nudge(
+            requested=["bandit", "gitleaks"],
+            summary=self._summary(["bandit", "gitleaks"]),
+        )
+        assert capsys.readouterr().err == ""
+
+    def test_lists_missing_and_points_to_check_tools(self, capsys):
+        from argus.cli import _print_missing_scanner_nudge
+
+        _print_missing_scanner_nudge(
+            requested=["bandit", "gitleaks", "opengrep"],
+            summary=self._summary(["bandit"]),
+        )
+        err = capsys.readouterr().err
+        assert "2 scanner(s) produced no results" in err
+        assert "gitleaks" in err and "opengrep" in err
+        assert "argus validate --check-tools" in err
+
+    def test_silent_when_nothing_requested(self, capsys):
+        from argus.cli import _print_missing_scanner_nudge
+
+        _print_missing_scanner_nudge(requested=[], summary=self._summary([]))
+        assert capsys.readouterr().err == ""

--- a/argus/tests/test_init.py
+++ b/argus/tests/test_init.py
@@ -7,6 +7,8 @@ from argus.init import (
     detect_project,
     generate_config,
     run_init,
+    _extract_enabled_scanners,
+    _check_local_readiness,
     _guess_iac_path,
 )
 
@@ -238,3 +240,87 @@ class TestRunInit:
         assert result == 0
         assert (tmp_path / "argus.yml").exists()
         assert not (tmp_path / ".github" / "workflows").exists()
+
+
+class TestExtractEnabledScanners:
+    """Parsing the just-written argus.yml for enabled scanner names."""
+
+    def test_returns_enabled_scanners(self):
+        content = """
+version: "1.0"
+scanners:
+  gitleaks:
+    enabled: true
+  bandit:
+    enabled: true
+  zap:
+    enabled: false
+"""
+        assert set(_extract_enabled_scanners(content)) == {"gitleaks", "bandit"}
+
+    def test_defaults_enabled_when_omitted(self):
+        content = """
+scanners:
+  gitleaks: {}
+"""
+        assert _extract_enabled_scanners(content) == ["gitleaks"]
+
+    def test_invalid_yaml_returns_empty(self):
+        assert _extract_enabled_scanners("not: [valid: yaml") == []
+
+    def test_no_scanners_section_returns_empty(self):
+        assert _extract_enabled_scanners("version: \"1.0\"") == []
+
+
+class TestCheckLocalReadiness:
+    """The init-time readiness helper must never crash the init flow."""
+
+    def test_returns_summary_when_ok(self, monkeypatch):
+        from argus.preflight.report_body import ToolStatus
+
+        def fake_check(names, backend="auto"):
+            return [
+                ToolStatus("a", True, "local"),
+                ToolStatus("b", True, "container", image="img"),
+                ToolStatus("c", False, "none"),
+            ]
+
+        monkeypatch.setattr(
+            "argus.preflight.tool_check.check_scanner_readiness", fake_check
+        )
+        result = _check_local_readiness(["a", "b", "c"])
+        assert result == {"local": 1, "container": 1, "missing": 1}
+
+    def test_empty_names_returns_none(self):
+        assert _check_local_readiness([]) is None
+
+    def test_swallows_exceptions(self, monkeypatch):
+        def boom(*args, **kwargs):
+            raise RuntimeError("registry exploded")
+
+        monkeypatch.setattr(
+            "argus.preflight.tool_check.check_scanner_readiness", boom
+        )
+        assert _check_local_readiness(["a"]) is None
+
+
+class TestRunInitReadinessOutput:
+    """End-to-end: init should show a readiness one-liner in the summary."""
+
+    def test_readiness_line_printed(self, tmp_path, capsys):
+        result = run_init(target_dir=str(tmp_path))
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "Tool readiness on this machine" in captured.out
+
+    def test_check_tools_hint_when_missing(self, tmp_path, capsys, monkeypatch):
+        # Force the missing-count bucket to be non-zero regardless of what's
+        # actually installed on the test machine.
+        monkeypatch.setattr(
+            "argus.init._check_local_readiness",
+            lambda names: {"local": 0, "container": 0, "missing": len(names)},
+        )
+        result = run_init(target_dir=str(tmp_path))
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "argus validate --check-tools" in captured.out


### PR DESCRIPTION
## Description
Addresses the \"I ran argus on Windows with no Docker or native tools and got nothing useful\" UX gap. Two low-friction visibility touches that let the user self-serve a diagnosis instead of staring at an empty result set.

## Changes Made
- [x] Modified existing scanner/workflow (`argus init`, `argus scan`, internal refactor)
- [x] Updated documentation (`.ai/architecture.yaml`)
- [x] Fixed bug (silent-empty-scan when no tools available)
- [x] Added new module (`argus/preflight/tool_check.py`)

### Details
- **New module** `argus/preflight/tool_check.py` — pure-logic readiness detection (`check_scanner_readiness`, `container_runtime_available`, `summarize`, `unavailable_names`). Extracted from `cli._check_tool_readiness` so the same logic drives init and scan without duplication.
- **`argus init`** now prints a one-line readiness summary after generating `argus.yml`:
  `Tool readiness on this machine: N ready locally, M via container, K missing`
  When `missing > 0`, appends: `Run argus validate --check-tools for per-scanner install suggestions.`
  The readiness check is best-effort — init never fails because the registry import blew up or Docker CLI misbehaved.
- **`argus scan`** emits a stderr nudge when any requested scanner produced no results:
  `💡 N scanner(s) produced no results: <names>`
  `Run 'argus validate --check-tools' for install suggestions.`
  Stderr keeps stdout (JSON/SARIF) pipe-clean for CI consumers.
- **`argus validate --check-tools`** output is **unchanged** — the wrapper delegates to the shared helper but preserves the detailed per-scanner rendering. No breaking change for existing users/CI.
- **No breaking changes.**

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed (verified nudge text shape, init readiness line)

### Test Results
```
2001 passed, 11 skipped, 7 deselected in 10.50s
```
28 new tests:
- `argus/tests/preflight/test_tool_check.py` (16) — covers local/container/missing branches, registry override, backend=local, unknown scanners, empty input, summarize bucketing.
- `argus/tests/test_init.py` (+9) — `_extract_enabled_scanners`, `_check_local_readiness` (success/empty/swallows-exceptions), end-to-end readiness line in summary.
- `argus/tests/test_cli.py` (+3) — `_print_missing_scanner_nudge` (silent when all completed, lists missing + suggests check-tools, silent when nothing requested).

## Security Considerations
- [x] No security impact

### Security Details
Readiness check is read-only — inspects PATH, scanner registry, and the local container runtime availability. No network calls, no shell execution of scanner binaries.

## AI Context Updates (.ai/)
- [x] `.ai/architecture.yaml` updated (preflight/ description extended to note `tool_check.py`)
- [x] N/A for `workflows.yaml`, `decisions.yaml`, `errors.yaml` — no command/workflow/decision changes; the nudge is an observable-behavior improvement, not a design shift.

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (.ai/architecture.yaml)
- [x] All tests pass
- [x] **Reviewed CONTRIBUTING.md guidelines**