### PR TITLE
fix(mcp): startup banner on stderr so argus mcp isn't silent

### DIFF
--- a/argus/cli.py
+++ b/argus/cli.py
@@ -1796,7 +1796,14 @@ def _format_size(size_bytes: int) -> str:
 
 
 def cmd_mcp(args: argparse.Namespace) -> int:
-    """Start the MCP server for AI assistant integration."""
+    """Start the MCP server for AI assistant integration.
+
+    The server speaks JSON-RPC over stdin/stdout (the standard MCP
+    stdio transport), so anything written to stdout would corrupt
+    the protocol. Startup feedback goes to stderr instead — visible
+    to humans running ``argus mcp`` directly, captured in MCP
+    clients' subprocess logs, never seen by the protocol parser.
+    """
     try:
         from argus.mcp import create_server
     except ImportError:
@@ -1807,8 +1814,34 @@ def cmd_mcp(args: argparse.Namespace) -> int:
         )
         return EXIT_ERROR
 
+    # Always log the startup line — MCP clients pipe stderr to their
+    # logs, so it's useful as a "server started" marker there too.
+    print(
+        "argus MCP server starting on stdio transport — awaiting client messages...",
+        file=sys.stderr,
+        flush=True,
+    )
+    if sys.stderr.isatty():
+        # Interactive invocation: explain what to do next so the user
+        # doesn't think the command has hung.
+        print(
+            "\n  This is correct behavior. The server reads JSON-RPC messages from"
+            "\n  stdin and writes responses to stdout — that's how MCP clients"
+            "\n  (Claude Desktop, Cursor, Claude Code, etc.) talk to it."
+            "\n"
+            "\n  Configure your client to launch:  argus mcp"
+            "\n  Press Ctrl+C to exit.",
+            file=sys.stderr,
+            flush=True,
+        )
+
     server = create_server()
-    server.run(transport="stdio")
+    try:
+        server.run(transport="stdio")
+    except KeyboardInterrupt:
+        # Clean exit on Ctrl+C — only meaningful when run interactively;
+        # MCP clients close the subprocess via stdin EOF instead.
+        print("\nargus MCP server stopped.", file=sys.stderr, flush=True)
     return EXIT_SUCCESS
 
 

--- a/argus/tests/test_cli.py
+++ b/argus/tests/test_cli.py
@@ -1306,3 +1306,98 @@ class TestMissingScannerNudge:
 
         _print_missing_scanner_nudge(requested=[], summary=self._summary([]))
         assert capsys.readouterr().err == ""
+
+
+class TestCmdMcp:
+    """``argus mcp`` UX guards.
+
+    The MCP server uses stdio transport: it speaks JSON-RPC on
+    stdin/stdout and any stray write to stdout would corrupt the
+    protocol. So all human feedback must go to stderr — and we
+    DO need feedback, otherwise users running ``argus mcp``
+    interactively see a silent terminal and assume it hung.
+    """
+
+    def _stub_server(self, monkeypatch):
+        """Replace ``create_server`` with a stub whose .run() returns
+        immediately, so the test never actually starts a real MCP loop."""
+        class _StubServer:
+            def __init__(self):
+                self.run_called_with = None
+
+            def run(self, transport):
+                self.run_called_with = transport
+
+        stub = _StubServer()
+        # cmd_mcp does ``from argus.mcp import create_server`` lazily,
+        # so patch the import target by injecting a fake module.
+        import sys
+        import types
+        fake = types.ModuleType("argus.mcp")
+        fake.create_server = lambda: stub
+        monkeypatch.setitem(sys.modules, "argus.mcp", fake)
+        return stub
+
+    def test_startup_banner_goes_to_stderr_not_stdout(self, monkeypatch, capsys):
+        # stdout is the JSON-RPC channel — anything we write there
+        # would corrupt the protocol. The banner must land on stderr.
+        from argus.cli import cmd_mcp
+        import argparse as _argparse
+
+        self._stub_server(monkeypatch)
+        rc = cmd_mcp(_argparse.Namespace())
+        captured = capsys.readouterr()
+        assert rc == EXIT_SUCCESS
+        assert captured.out == "", "stdout must stay empty for the protocol"
+        assert "argus MCP server starting" in captured.err
+
+    def test_run_invoked_with_stdio_transport(self, monkeypatch):
+        from argus.cli import cmd_mcp
+        import argparse as _argparse
+
+        stub = self._stub_server(monkeypatch)
+        cmd_mcp(_argparse.Namespace())
+        assert stub.run_called_with == "stdio"
+
+    def test_interactive_hint_only_when_stderr_is_a_tty(self, monkeypatch, capsys):
+        # When invoked by an MCP client (subprocess with piped stderr)
+        # the hint adds noise to client logs without helping anyone.
+        # Only humans staring at a real terminal benefit from it.
+        from argus.cli import cmd_mcp
+        import argparse as _argparse
+        import sys as _sys
+
+        self._stub_server(monkeypatch)
+
+        # Non-tty stderr (the default during pytest capture) — no hint.
+        monkeypatch.setattr(_sys.stderr, "isatty", lambda: False)
+        cmd_mcp(_argparse.Namespace())
+        err_no_tty = capsys.readouterr().err
+        assert "argus MCP server starting" in err_no_tty
+        assert "Press Ctrl+C" not in err_no_tty
+
+        # tty stderr — hint included.
+        self._stub_server(monkeypatch)
+        monkeypatch.setattr(_sys.stderr, "isatty", lambda: True)
+        cmd_mcp(_argparse.Namespace())
+        err_tty = capsys.readouterr().err
+        assert "argus MCP server starting" in err_tty
+        assert "Press Ctrl+C" in err_tty
+
+    def test_missing_extra_returns_friendly_error(self, monkeypatch, capsys):
+        from argus.cli import cmd_mcp
+        import argparse as _argparse
+        import builtins
+
+        # Force the lazy ``from argus.mcp import create_server`` to fail.
+        real_import = builtins.__import__
+        def fake_import(name, *a, **kw):
+            if name == "argus.mcp":
+                raise ImportError("No module named 'mcp'")
+            return real_import(name, *a, **kw)
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+
+        rc = cmd_mcp(_argparse.Namespace())
+        assert rc == EXIT_ERROR
+        err = capsys.readouterr().err
+        assert "argus-security[mcp]" in err


### PR DESCRIPTION
## Description

`argus mcp` speaks JSON-RPC over stdin/stdout (the standard MCP stdio transport). Until this fix, nothing got written to stderr either — so a human running `argus mcp` directly saw a frozen terminal and assumed it had hung. The server was working correctly; it just had no UX.

## Changes Made

- [x] Bug fix — `cmd_mcp` now prints a startup banner to stderr immediately after the server is built
- [x] Tests added (`TestCmdMcp` in `argus/tests/test_cli.py`)

### Behavior

| Invocation | What you see on stderr |
|---|---|
| Interactive shell (`argus mcp` in a terminal) | One-line banner + multi-line hint explaining stdio transport, how to wire a client, and Ctrl+C exit |
| Piped from an MCP client (Claude Desktop / Cursor / Claude Code subprocess) | Just the one-line banner, lands as a "server started" marker in the client's logs |
| `Ctrl+C` | Clean `"argus MCP server stopped."` line — no traceback |

stdout stays untouched (the protocol channel must be clean).

## Testing

```
2360 passed, 11 skipped, 7 deselected
```

`TestCmdMcp` (4 new tests):
- Startup banner goes to stderr; stdout stays empty (protocol-safe)
- `server.run()` is invoked with `transport="stdio"`
- TTY hint only appears when `sys.stderr.isatty()` (suppressed when piped)
- The pre-existing missing-`[mcp]`-extra friendly error still works

## Security Considerations
- [x] No security impact — log lines only, no input handling, no new code paths into the protocol channel.