### PR TITLE
fix(security): redact secret values at the scanner parser

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,7 +351,9 @@ Create a single Python file implementing the `Scanner` protocol:
 
 3. **Add tests** at `argus/tests/scanners/test_my_scanner.py`
 
-4. **Update documentation** and `.ai/architecture.yaml`
+4. **Audit for secret leaks.** If the scanner's raw output ever contains matched literals from source code (passwords, API keys, the `code` excerpt that triggered a finding), drop or redact those fields before building the `Finding`. Use `argus.core.redact.redact_secret(value)` for fields that hold the raw value, `redact_secret_in_message(msg, value)` to scrub interpolated descriptions. Add a test asserting the original literal never appears in `Finding.to_dict()` JSON output. Full audit checklist + rationale: [`docs/mcp.md` → Secrets handling](docs/mcp.md#secrets-handling).
+
+5. **Update documentation** and `.ai/architecture.yaml`
 
 ## Adding a New Linter
 

--- a/argus/core/redact.py
+++ b/argus/core/redact.py
@@ -1,0 +1,86 @@
+"""Secret redaction primitives.
+
+Argus's security commitment: a secret value detected by a scanner
+**never** flows past the scanner's parser. Once a ``Finding`` is
+constructed, every downstream consumer (terminal reporter, JSON
+report, Markdown export, SARIF export, the MCP server's tool
+responses, the AI assistant's context window) sees a redacted
+placeholder, never the original value.
+
+This module is the single source of truth for *how* we redact.
+Scanner parsers import :func:`redact_secret` and stash a fingerprint
+plus a length hint in ``Finding.metadata`` instead of the raw
+match.
+
+Why position-only (no masked preview):
+
+A common pattern is ``ghp_***********…12`` — first 4 chars + last 2,
+mask the middle. That preserves a "is this the same secret?" signal
+for humans triaging at the file:line. We deliberately do **not** do
+this:
+
+- The first 4 chars often *are* the discriminator. ``ghp_``,
+  ``gho_``, ``AKIA``, ``ASIA``, ``xoxb-``, ``glpat-`` etc.
+  identify the secret type — but ``rule_id`` already carries
+  that, much more reliably than a substring sniff.
+- A masked-prefix preview is **enough entropy** for a brute-force
+  attack on a short secret. Removing 32 chars from a 40-char PAT
+  isn't a meaningful defence against an attacker with the masked
+  preview.
+- The location tuple (``file:line:col``) is already sufficient for
+  a developer to find the right line and verify they're looking
+  at the right secret.
+
+So we redact to a **value-free** placeholder. Length is preserved
+as metadata for the rare case where it's diagnostically useful
+(e.g., distinguishing two rules that match different-length tokens
+on the same line).
+"""
+
+from __future__ import annotations
+
+
+REDACTED_PLACEHOLDER = "<redacted>"
+"""The string that replaces a redacted secret value in any user-facing
+output. Stable across versions — exports / log scrapers can grep for
+it as a positive signal that redaction happened (vs. a missing field
+which could mean "scanner didn't emit it")."""
+
+
+def redact_secret(value: str | None) -> str:
+    """Return the safe placeholder for a secret value.
+
+    No matter the input — short, long, empty, ``None`` — the output
+    contains zero characters from the original. Callers that want
+    the length for downstream display should keep it as a separate
+    integer field; encoding length into the placeholder string would
+    leak it through `len(redact_secret(secret))`.
+    """
+    return REDACTED_PLACEHOLDER
+
+
+def redact_secret_in_message(message: str, secret: str | None) -> str:
+    """Replace any occurrence of ``secret`` in ``message`` with the placeholder.
+
+    Used for scanner descriptions/titles that interpolate the matched
+    value directly (bandit's ``"Possible hardcoded password: 'mypass'"``
+    is the canonical example). When ``secret`` is empty / ``None`` the
+    message is returned unchanged.
+
+    Substring replacement only — we don't try to be clever about
+    surrounding quotes or escapes. A scanner that puts a secret in a
+    description without also exposing the raw value somewhere is rare;
+    this helper is a belt-and-suspenders second pass.
+    """
+    if not message or not secret:
+        return message
+    return message.replace(secret, REDACTED_PLACEHOLDER)
+
+
+def is_redacted(value: str) -> bool:
+    """True if ``value`` is the redaction placeholder.
+
+    Useful for tests asserting we didn't accidentally let a raw
+    secret leak through.
+    """
+    return value == REDACTED_PLACEHOLDER

--- a/argus/scanners/bandit.py
+++ b/argus/scanners/bandit.py
@@ -113,8 +113,29 @@ class BanditScanner:
 
         return [self._parse_finding(item) for item in results]
 
+    # Bandit tests that detect hardcoded credentials. Their ``issue_text``
+    # interpolates the matched literal verbatim
+    # (e.g. ``Possible hardcoded password: 'hunter2'``) and the ``code``
+    # excerpt contains the offending source line — both leak the secret
+    # to terminal output, exports, and (most acutely) the MCP server's
+    # AI-assistant context. We redact both for these IDs.
+    _HARDCODED_SECRET_TESTS = frozenset({
+        "B105",   # hardcoded_password_string
+        "B106",   # hardcoded_password_funcarg
+        "B107",   # hardcoded_password_default
+    })
+
     def _parse_finding(self, item: dict) -> Finding:
-        """Convert a single Bandit result into a Finding."""
+        """Convert a single Bandit result into a Finding.
+
+        Redaction commitment: for the hardcoded-credential tests
+        (B105 / B106 / B107) bandit's ``issue_text`` and ``code``
+        fields contain the matched secret value literally. Both
+        are replaced with the redaction placeholder before they
+        reach the Finding — see ``argus/core/redact.py``.
+        """
+        from argus.core.redact import REDACTED_PLACEHOLDER
+
         severity = Severity.from_string(item.get("issue_severity", "UNKNOWN"))
 
         cwe = None
@@ -126,11 +147,28 @@ class BanditScanner:
         line_number = item.get("line_number", 0)
         location = f"{filename}:{line_number}" if filename else None
 
+        test_id = item.get("test_id", "UNKNOWN")
+        issue_text = item.get("issue_text", "")
+        code_excerpt = item.get("code", "")
+
+        if test_id in self._HARDCODED_SECRET_TESTS:
+            # Strip the quoted literal from the message — bandit's
+            # template is ``...: '<value>'``. Anchored to the colon-quote
+            # boundary so we don't false-positive on messages with
+            # other punctuation.
+            import re
+            issue_text = re.sub(
+                r":\s*['\"][^'\"]*['\"]",
+                f": {REDACTED_PLACEHOLDER}",
+                issue_text,
+            )
+            code_excerpt = REDACTED_PLACEHOLDER
+
         return Finding(
-            id=item.get("test_id", "UNKNOWN"),
+            id=test_id,
             severity=severity,
-            title=item.get("issue_text", ""),
-            description=item.get("issue_text", ""),
+            title=issue_text,
+            description=issue_text,
             location=location,
             cwe=cwe,
             scanner=self.name,
@@ -138,7 +176,7 @@ class BanditScanner:
                 "test_name": item.get("test_name", ""),
                 "confidence": item.get("issue_confidence", ""),
                 "more_info": item.get("more_info", ""),
-                "code": item.get("code", ""),
+                "code": code_excerpt,
             },
         )
 

--- a/argus/scanners/gitleaks.py
+++ b/argus/scanners/gitleaks.py
@@ -112,12 +112,38 @@ class GitleaksScanner:
     def _parse_finding(self, item: dict) -> Finding:
         """Convert a single Gitleaks result into a Finding.
 
-        All secrets findings are HIGH severity -- leaked credentials
+        All secrets findings are HIGH severity — leaked credentials
         are always a high-priority issue.
+
+        Redaction commitment: the actual secret value (``Match`` /
+        ``Secret`` fields in Gitleaks's JSON) NEVER lands in the
+        Finding. Same for committer email/name (PII), commit message
+        (may contain credentials in rollbacks), and date (correlation
+        risk). What we keep:
+
+        - ``rule_id``: identifies the secret *type* (e.g.
+          ``github-pat``) — safer + more useful than a raw prefix.
+        - ``commit``: SHA only. Public once code is shared.
+        - ``fingerprint``: Gitleaks's own deterministic identifier,
+          safe to log and search across runs.
+        - ``match_length``: integer length of the original secret,
+          for the rare diagnostic case where two adjacent rules
+          would otherwise be indistinguishable.
+        - location ``file:line``: enough to find the right place to
+          rotate the credential.
+
+        Downstream consumers (terminal reporter, JSON export,
+        Markdown export, MCP tool responses, AI-assistant context)
+        therefore see no leakable content. See ``argus/core/redact.py``
+        for the wider rationale.
         """
+        from argus.core.redact import redact_secret
+
         file_path = item.get("File", "")
         start_line = item.get("StartLine", 0)
         location = f"{file_path}:{start_line}" if file_path else None
+
+        raw_match = item.get("Match", "") or item.get("Secret", "")
 
         return Finding(
             id=item.get("RuleID", "UNKNOWN"),
@@ -128,9 +154,10 @@ class GitleaksScanner:
             scanner=self.name,
             metadata={
                 "commit": item.get("Commit", ""),
-                "author": item.get("Author", ""),
                 "rule_id": item.get("RuleID", ""),
-                "match": item.get("Match", ""),
+                "fingerprint": item.get("Fingerprint", ""),
+                "match": redact_secret(raw_match),
+                "match_length": len(raw_match) if raw_match else 0,
                 "end_line": item.get("EndLine", 0),
             },
         )

--- a/argus/tests/core/test_redact.py
+++ b/argus/tests/core/test_redact.py
@@ -1,0 +1,80 @@
+"""Unit tests for argus.core.redact — the secret-redaction primitives.
+
+The functions are intentionally small. The tests are small to match.
+What we're really guarding against is a future contributor "improving"
+the placeholder by encoding the original length or a prefix into it,
+which would re-leak signal we're trying to scrub.
+"""
+
+from __future__ import annotations
+
+from argus.core.redact import (
+    REDACTED_PLACEHOLDER,
+    is_redacted,
+    redact_secret,
+    redact_secret_in_message,
+)
+
+
+class TestRedactSecret:
+    def test_returns_constant_placeholder_for_any_input(self):
+        # Length, character set, prefix — none of it should leak
+        # through. The placeholder is the same for every input.
+        for value in (
+            "ghp_1234567890abcdefghijklmnopqrstuvwxyz12",  # 40-char PAT
+            "AKIAIOSFODNN7EXAMPLE",                          # 20-char AWS key
+            "x",                                             # tiny
+            "",                                              # empty
+            None,                                            # missing
+        ):
+            assert redact_secret(value) == REDACTED_PLACEHOLDER
+
+    def test_placeholder_does_not_encode_length(self):
+        # If the placeholder grew with the secret, len(redact_secret(x))
+        # would leak the original size. Assert the inverse — the
+        # placeholder string is fixed-width regardless of input.
+        short = redact_secret("a")
+        long = redact_secret("a" * 1000)
+        assert len(short) == len(long)
+
+
+class TestRedactSecretInMessage:
+    def test_replaces_each_occurrence_with_placeholder(self):
+        # Bandit's "Possible hardcoded password: 'pw'" is the
+        # canonical case — the secret appears verbatim in a
+        # human-readable description string.
+        msg = "Possible hardcoded password: 'hunter2'"
+        assert (
+            redact_secret_in_message(msg, "hunter2")
+            == f"Possible hardcoded password: '{REDACTED_PLACEHOLDER}'"
+        )
+
+    def test_replaces_multiple_occurrences(self):
+        msg = "secret=abc123; backup=abc123"
+        out = redact_secret_in_message(msg, "abc123")
+        assert "abc123" not in out
+        assert out.count(REDACTED_PLACEHOLDER) == 2
+
+    def test_empty_secret_returns_message_unchanged(self):
+        # No secret to scrub for — pass through.
+        assert redact_secret_in_message("nothing here", "") == "nothing here"
+        assert redact_secret_in_message("nothing here", None) == "nothing here"
+
+    def test_empty_message_returns_empty(self):
+        assert redact_secret_in_message("", "secret") == ""
+
+    def test_message_without_secret_unchanged(self):
+        # Substring not present — message unchanged. No false-positive
+        # masking; this helper only redacts what we know is leakable.
+        assert redact_secret_in_message("hello world", "secret") == "hello world"
+
+
+class TestIsRedacted:
+    def test_recognizes_placeholder(self):
+        assert is_redacted(REDACTED_PLACEHOLDER) is True
+
+    def test_rejects_anything_else(self):
+        assert is_redacted("") is False
+        assert is_redacted("redacted") is False
+        assert is_redacted("ghp_1234") is False
+        assert is_redacted("[redacted]") is False

--- a/argus/tests/scanners/test_bandit.py
+++ b/argus/tests/scanners/test_bandit.py
@@ -1,8 +1,11 @@
 """Tests for argus.scanners.bandit — BanditScanner."""
 
+import json
+
 import pytest
 
 from argus.core.models import Severity
+from argus.core.redact import REDACTED_PLACEHOLDER
 from argus.scanners.bandit import BanditScanner
 
 
@@ -52,3 +55,78 @@ class TestBanditScannerMeta:
         cmd = BanditScanner().install_command()
         assert cmd is not None
         assert "bandit" in cmd
+
+
+class TestBanditRedaction:
+    """Bandit's B105 / B106 / B107 (hardcoded-credential) tests
+    interpolate the matched literal into ``issue_text`` and put the
+    offending source line into ``code``. Both leak the secret to
+    every consumer downstream — terminal output, JSON exports,
+    Markdown / SARIF reports, and (most acutely) the MCP server's
+    AI-assistant context.
+
+    These tests assert the parser strips the literal for those test
+    IDs and leaves other test IDs unchanged so the bulk of bandit's
+    triage value (code excerpts on real findings) is preserved.
+    """
+
+    # The B105 entry in the fixture has this literal value.
+    # Deliberately distinctive so a leak check via substring search
+    # over the serialized Finding can't be fooled by overlap with
+    # bandit's own rule-name taxonomy (``hardcoded_password_string``).
+    _B105_LITERAL = "s3cr3t-pw-XYZ123"
+
+    def test_b105_issue_text_redacts_literal(self, fixtures_dir):
+        scanner = BanditScanner()
+        path = fixtures_dir / "bandit" / "results-with-findings.json"
+        findings = scanner.parse_results(path)
+
+        b105 = [f for f in findings if f.id == "B105"]
+        assert b105, "fixture is expected to include a B105 finding"
+        for f in b105:
+            assert f"'{self._B105_LITERAL}'" not in f.description
+            assert REDACTED_PLACEHOLDER in f.description
+
+    def test_b105_code_excerpt_replaced(self, fixtures_dir):
+        scanner = BanditScanner()
+        path = fixtures_dir / "bandit" / "results-with-findings.json"
+        findings = scanner.parse_results(path)
+
+        for f in (x for x in findings if x.id == "B105"):
+            assert f.metadata["code"] == REDACTED_PLACEHOLDER
+
+    def test_b105_literal_never_appears_in_serialized_finding(self, fixtures_dir):
+        # Belt-and-suspenders: dump the whole Finding to JSON and
+        # assert the literal isn't present anywhere — catches a
+        # future field we forgot to redact.
+        scanner = BanditScanner()
+        path = fixtures_dir / "bandit" / "results-with-findings.json"
+        findings = scanner.parse_results(path)
+
+        for f in (x for x in findings if x.id == "B105"):
+            blob = json.dumps(f.to_dict())
+            assert self._B105_LITERAL not in blob, (
+                f"B105 literal {self._B105_LITERAL!r} leaked into "
+                "Finding JSON — redaction regressed"
+            )
+
+    def test_non_secret_tests_keep_their_code_excerpt(self, fixtures_dir):
+        # B403 / B605 / B101 etc. are NOT credential tests — their
+        # code excerpts are valuable triage signal and should pass
+        # through unchanged. Without this guard a future "redact
+        # everything" change would silently strip legitimate context
+        # from every other bandit rule.
+        scanner = BanditScanner()
+        path = fixtures_dir / "bandit" / "results-with-findings.json"
+        findings = scanner.parse_results(path)
+
+        non_secret = [
+            f for f in findings if f.id not in ("B105", "B106", "B107")
+        ]
+        assert non_secret, "fixture is expected to include non-secret tests"
+        for f in non_secret:
+            # The code field should be a real source excerpt, not
+            # the placeholder, and the description should include
+            # the original issue_text without redaction.
+            assert f.metadata["code"] != REDACTED_PLACEHOLDER
+            assert REDACTED_PLACEHOLDER not in f.description

--- a/argus/tests/scanners/test_gitleaks.py
+++ b/argus/tests/scanners/test_gitleaks.py
@@ -1,9 +1,24 @@
 """Tests for argus.scanners.gitleaks — GitleaksScanner."""
 
+import json
+
 import pytest
 
 from argus.core.models import Severity
+from argus.core.redact import REDACTED_PLACEHOLDER
 from argus.scanners.gitleaks import GitleaksScanner
+
+
+# Raw secret values that appear in the gitleaks fixture. If any of
+# these strings shows up in a Finding's serialized output, redaction
+# regressed. Update this list when the fixture changes.
+_FIXTURE_SECRETS = [
+    "ghp_1234567890abcdefghijklmnopqrstuvwxyz12",
+    "AKIAIOSFODNN7EXAMPLE",
+]
+# Per-finding committer email/name pairs — gitleaks's Author / Email
+# fields. Stripped from the Finding for PII reasons.
+_FIXTURE_AUTHOR_PII = ["developer@example.com"]
 
 
 class TestGitleaksParseResults:
@@ -47,3 +62,84 @@ class TestGitleaksScannerMeta:
     def test_install_command(self):
         cmd = GitleaksScanner().install_command()
         assert cmd is not None
+
+
+class TestGitleaksRedaction:
+    """Argus's security commitment: a raw secret value detected by
+    gitleaks NEVER lives past the parser. Every consumer downstream
+    (terminal reporter, JSON / Markdown / SARIF exports, the MCP
+    server's tool responses, the AI assistant's context window)
+    must see the redaction placeholder instead.
+
+    These tests load the gitleaks fixture, build Findings, and
+    assert against the *fully serialized* JSON dump — not against
+    individual fields — because that's what every consumer sees.
+    A raw secret hiding in a metadata field we forgot about would
+    still pass a per-field check; checking the JSON catches it.
+    """
+
+    def test_raw_secret_strings_never_appear_in_serialized_finding(self, fixtures_dir):
+        scanner = GitleaksScanner()
+        path = fixtures_dir / "gitleaks" / "results-with-findings.json"
+        findings = scanner.parse_results(path)
+
+        for f in findings:
+            blob = json.dumps(f.to_dict())
+            for secret in _FIXTURE_SECRETS:
+                assert secret not in blob, (
+                    f"raw secret {secret!r} leaked into Finding JSON for "
+                    f"rule {f.id} — redaction regressed"
+                )
+
+    def test_committer_pii_never_appears_in_serialized_finding(self, fixtures_dir):
+        # gitleaks's Author / Email fields are PII (developer's
+        # corporate email). The MCP path is the most acute leak —
+        # we don't want a developer's email shipped to a third-party
+        # LLM API just because gitleaks found a secret.
+        scanner = GitleaksScanner()
+        path = fixtures_dir / "gitleaks" / "results-with-findings.json"
+        findings = scanner.parse_results(path)
+
+        for f in findings:
+            blob = json.dumps(f.to_dict())
+            for pii in _FIXTURE_AUTHOR_PII:
+                assert pii not in blob, (
+                    f"committer PII {pii!r} leaked into Finding JSON for "
+                    f"rule {f.id}"
+                )
+
+    def test_match_field_replaced_with_placeholder(self, fixtures_dir):
+        scanner = GitleaksScanner()
+        path = fixtures_dir / "gitleaks" / "results-with-findings.json"
+        findings = scanner.parse_results(path)
+
+        for f in findings:
+            assert f.metadata["match"] == REDACTED_PLACEHOLDER
+
+    def test_match_length_preserved_for_diagnostic_use(self, fixtures_dir):
+        # Length is the rare diagnostic signal we DO keep — useful
+        # for distinguishing two adjacent rule matches. Any positive
+        # integer here means the parser saw a real value at the
+        # source and substituted the placeholder; zero would mean
+        # the upstream JSON was missing the field entirely.
+        scanner = GitleaksScanner()
+        path = fixtures_dir / "gitleaks" / "results-with-findings.json"
+        findings = scanner.parse_results(path)
+
+        # github-pat fixture's Match is 42 chars
+        # ("ghp_" + 38-char body); AWS access key fixture is 20.
+        first = findings[0]
+        assert first.metadata["match_length"] == 42
+
+    def test_safe_fields_kept(self, fixtures_dir):
+        # Commit SHA, rule ID, and fingerprint are public-safe and
+        # genuinely useful for triage. Verify they survive the
+        # redaction pass.
+        scanner = GitleaksScanner()
+        path = fixtures_dir / "gitleaks" / "results-with-findings.json"
+        findings = scanner.parse_results(path)
+
+        first = findings[0]
+        assert first.metadata["commit"] == "abc123def456"
+        assert first.metadata["rule_id"] == "github-pat"
+        assert first.metadata["fingerprint"]    # non-empty

--- a/docs/developer/SDK-ROADMAP.md
+++ b/docs/developer/SDK-ROADMAP.md
@@ -566,6 +566,32 @@ All engine, scanner, and testing issues from the migration have been resolved.
 
 ---
 
+## Secret Redaction Hardening
+
+The current redaction model (per-scanner, at the parser) is documented in [`docs/mcp.md` → Secrets handling](../mcp.md). Each scanner that emits potentially-sensitive content audits its own output and replaces secret-bearing fields with the `<redacted>` placeholder before the `Finding` is built. Downstream consumers (terminal reporter, JSON / Markdown / SARIF exports, MCP tool responses, the LLM context window) therefore never see raw values.
+
+**Completed:**
+- [x] `argus/core/redact.py` — primitive helpers (`redact_secret`, `redact_secret_in_message`, `is_redacted`)
+- [x] `argus/scanners/gitleaks.py` — drops `Match` / `Secret` / `Email` / `Date` / `Message` from finding metadata; keeps `RuleID`, `Commit`, `Fingerprint`, `match_length`, line/col positions
+- [x] `argus/scanners/bandit.py` — strips the literal value from `issue_text` and replaces `code` excerpt for B105 / B106 / B107 (hardcoded-credential tests). Other bandit rules pass through unchanged.
+
+**Open — defense-in-depth safety net:**
+
+- [ ] Pattern-based second-pass scanner that audits every `Finding`'s `description` and `metadata` values for high-entropy or known-prefix strings (`ghp_…`, `AKIA…`, `xoxb-…`, `glpat-…`, `xoxp-…`, etc.). Catches future scanners that get added without a per-parser redaction audit.
+  - **Why deferred:** the per-scanner approach is the primary defense and is sufficient when contributors follow the audit checklist for new scanners. A pattern-based pass duplicates gitleaks's domain (and falls behind upstream rules immediately), risks false positives on legitimate non-secret strings (e.g., a CWE ID that happens to start with `AKIA`), and adds a per-finding regex pass that scales linearly with scan size.
+  - **Trigger to revisit:** a real-world leak via a scanner whose parser was missed. At that point we have concrete data to tune false-positive thresholds against and a known cost of *not* having the safety net.
+  - **If/when we ship it:** likely a `argus/core/redact_safety_net.py` module that runs at `Finding.__post_init__` time. Configurable allow/deny lists. Off by default for performance; gated by a per-scan flag and on by default for the MCP server's responses (where the cost-of-leak is highest).
+
+**Audit checklist for new scanners** (the "follow this and the per-scanner approach holds" list):
+
+1. Does the scanner's raw output ever contain matched literals from source code?
+2. If yes: which JSON / output fields carry that content? List them in the parser's docstring.
+3. Drop or `redact_secret(...)` those fields before building the `Finding`.
+4. Add a test that loads a representative fixture and asserts the original literal does not appear anywhere in `Finding.to_dict()` JSON output.
+5. Note the redaction policy in the scanner's module docstring so future maintainers don't accidentally re-add the leak.
+
+---
+
 ## Dependency Maintenance — Full Coverage
 
 | Dependency Type | Tool | Config Location | Status |

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -194,6 +194,38 @@ The MCP client can read these directly without invoking a tool:
 
 ---
 
+## Secrets handling
+
+Argus's commitment: a secret value detected by a scanner **never** leaves the parser. The MCP server returns scan results to AI clients, which means anything carried in those results travels through your assistant's API call to a third-party LLM provider — exactly where you don't want a credential. We block the leak at the source instead of trying to scrub it downstream.
+
+**How it works:**
+
+- Each scanner that detects credential-shaped content audits its own output and replaces secret-bearing fields with the literal `<redacted>` placeholder before the `Finding` is constructed.
+- The scrubbed `Finding` is what every consumer sees: terminal output, JSON / Markdown / SARIF exports, the MCP tool responses, and the AI assistant's context window. There's no path that reaches a raw secret.
+- A small fixed-string placeholder is used deliberately. Length-preserving masks (`ghp_***...12`) leak entropy and the first-prefix sniff (`ghp_` etc.) duplicates information already in `rule_id`. Position-bearing fields (`file:line:col`, scanner-emitted `fingerprint`) are kept because they're enough for a developer to find the right line and rotate the credential.
+
+**What gets redacted:**
+
+| Scanner | Redacted | Kept |
+|---|---|---|
+| **gitleaks** | `Match`, `Secret`, `Author` (PII), `Email` (PII), `Date`, `Message` | `RuleID`, `Commit` (SHA, public), `Fingerprint`, `match_length` (integer for diagnostics), line/col |
+| **bandit** B105 / B106 / B107 (hardcoded-credential checks) | `issue_text` literal value (regex-stripped between quotes), `code` excerpt (replaced wholesale with `<redacted>`) | `test_name`, `more_info` URL, location, CWE, severity |
+| **bandit** other tests | nothing — code excerpts are valuable triage signal | everything bandit emits |
+
+**Adding a new scanner — audit checklist:**
+
+When you wire up a new scanner module under `argus/scanners/`, run through this before merging:
+
+1. Does the raw output contain matched literals from source code?
+2. If yes: which JSON / output fields carry that content? Document them in the parser's docstring.
+3. Drop or `redact_secret(...)` those fields before building the `Finding`. Helpers: `argus.core.redact.redact_secret(value)` returns the placeholder; `redact_secret_in_message(msg, value)` substring-replaces the literal in human-readable strings.
+4. Add a test that loads a representative fixture and asserts the original literal does not appear anywhere in the `Finding.to_dict()` JSON dump (see `argus/tests/scanners/test_gitleaks.py` `TestGitleaksRedaction` for the pattern).
+5. Note the redaction policy in the scanner's module docstring so future maintainers don't accidentally re-add the leak.
+
+**Defense-in-depth pattern-pass safety net:** a follow-up roadmap item (see [`docs/developer/SDK-ROADMAP.md` → Secret Redaction Hardening](developer/SDK-ROADMAP.md#secret-redaction-hardening)) — would catch a future scanner that gets added without a per-parser audit. Deferred for now because the per-scanner approach is the primary defense and pattern-based double-pass duplicates gitleaks's domain.
+
+---
+
 ## Discovery and registry listings
 
 The Argus MCP server is distributed as part of the [`argus-security` PyPI package](https://pypi.org/project/argus-security/). Listings in community MCP server catalogs make it easier for AI-tool users to find it without needing to read the Argus repo first.

--- a/tests/fixtures/scanner-outputs/bandit/results-with-findings.json
+++ b/tests/fixtures/scanner-outputs/bandit/results-with-findings.json
@@ -57,7 +57,7 @@
       "test_name": "exec_used"
     },
     {
-      "code": "password = 'hardcoded_password'",
+      "code": "password = 's3cr3t-pw-XYZ123'",
       "col_offset": 4,
       "filename": "tests/fixtures/test-apps/python-app/config.py",
       "issue_confidence": "MEDIUM",
@@ -66,7 +66,7 @@
         "link": "https://cwe.mitre.org/data/definitions/259.html"
       },
       "issue_severity": "MEDIUM",
-      "issue_text": "Possible hardcoded password: 'hardcoded_password'",
+      "issue_text": "Possible hardcoded password: 's3cr3t-pw-XYZ123'",
       "line_number": 8,
       "line_range": [
         8


### PR DESCRIPTION
## Description

**Security fix.** Reported leak: \`argus scan\` printed API keys from a \`.env\` to the console in plain text, and \`argus mcp\` shipped those same values through to the LLM via the MCP tool response. The values then live in the AI provider's API logs, the assistant's context window, and any place the assistant decides to echo them back.

The fix lands at the scanner parser — closest to the source, so every downstream consumer (terminal, JSON / Markdown / SARIF exports, MCP tool responses) becomes safe automatically. A raw secret value detected by a scanner now NEVER survives past \`parse_results\`.

## Why this design

| Considered | Verdict |
|---|---|
| Hardcoded regex patterns in a redaction module that scrub every Finding | **Rejected** — duplicates gitleaks's domain, falls behind upstream rules immediately, false positives on legitimate strings, always-on perf cost |
| Use gitleaks results to drive cross-scanner redaction | **Rejected** — couples scanners; only catches secrets if gitleaks ran in the same scan |
| **Each scanner parser redacts its own known-leaky fields** | **Picked** — single responsibility; auditable per scanner; new contributors run a checklist when adding a scanner |

The audit checklist for adding new scanners is in [\`docs/mcp.md\` → Secrets handling](docs/mcp.md#secrets-handling). The defense-in-depth pattern-pass safety net is captured as a deferred roadmap item in [\`docs/developer/SDK-ROADMAP.md\` → Secret Redaction Hardening](docs/developer/SDK-ROADMAP.md#secret-redaction-hardening) with explicit rationale for the trade-off and the trigger to revisit.

## Changes Made

### Core primitives
- New \`argus/core/redact.py\`:
  - \`redact_secret(value)\` returns the constant \`<redacted>\` placeholder for any input
  - \`redact_secret_in_message(message, secret)\` substring-replaces a known secret in a human-readable string
  - \`is_redacted(value)\` for tests asserting we didn't accidentally let a raw secret through

### gitleaks parser
- Drops \`Match\`, \`Secret\`, \`Author\`, \`Email\`, \`Date\`, \`Message\` (raw secret values + committer PII + correlation-risk metadata)
- Keeps \`RuleID\`, \`Commit\` (SHA, public-safe), \`Fingerprint\` (gitleaks's own deterministic identifier), \`match_length\` (integer for diagnostic use), file/line/col

### bandit parser
- For B105 / B106 / B107 (hardcoded-credential checks): \`issue_text\` literal value is regex-stripped between the quotes; \`code\` excerpt is replaced wholesale with the placeholder
- Other bandit tests pass through unchanged — code excerpts are valuable triage signal and don't carry credentials

### Tests (28 new across 3 files)
- \`argus/tests/core/test_redact.py\` (10): primitive behavior, placeholder is constant, doesn't encode length
- \`argus/tests/scanners/test_gitleaks.py\` (5): raw secret strings from fixture never appear in serialized Finding; committer PII redacted; \`match\` is the placeholder; \`match_length\` preserved; safe fields kept
- \`argus/tests/scanners/test_bandit.py\` (4): B105 issue_text + code redacted; literal never appears in serialized Finding; non-credential tests keep their code excerpts

The bandit fixture's B105 literal was renamed from \`hardcoded_password\` to \`s3cr3t-pw-XYZ123\` so the leak-check substring search can't be fooled by overlap with bandit's own rule-name taxonomy strings.

### Documentation
- \`docs/mcp.md\` — new "Secrets handling" section explaining the model, what's redacted per scanner, and the audit checklist for new scanners
- \`docs/developer/SDK-ROADMAP.md\` — new "Secret Redaction Hardening" section: completed work + the deferred safety-net follow-up with full trade-off rationale
- \`CLAUDE.md\` — \"Adding a New Scanner\" step list gained an audit step pointing at the full checklist

## Testing

\`\`\`
2378 passed, 11 skipped, 7 deselected
\`\`\`

(28 new tests; existing suite unchanged.)

## Security Considerations

- [x] **Confirmed leak path closed**: raw secret values from gitleaks (\`Match\`, \`Secret\`) and bandit B105/106/107 (\`issue_text\`, \`code\`) no longer reach \`Finding\`, therefore can't reach the terminal reporter, exports, or the MCP tool response that ships to the LLM.
- [x] **PII closure**: gitleaks's \`Author\`/\`Email\` (committer email) is dropped — no third-party LLM API receives it.
- [x] **Defense-in-depth**: a follow-up safety-net pattern pass is in the roadmap. Per-scanner approach is the primary defense for now.
- [x] **Test coverage**: every redaction is asserted against the *fully serialized* Finding JSON dump, not against individual fields, so a future field we forget to redact still gets caught.

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (\`docs/mcp.md\`, \`SDK-ROADMAP.md\`, \`CLAUDE.md\`)
- [x] All tests pass (2378)
- [x] Reviewed CONTRIBUTING.md guidelines