### PR TITLE
feat(mcp): add unified security_review tool and cache freshness signals

### DIFF
--- a/argus/mcp.py
+++ b/argus/mcp.py
@@ -6,28 +6,52 @@ explaining findings, and summarizing results. Also exposes resources for
 reading the current config, latest scan results, and the config schema.
 """
 
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
 from mcp.server.fastmcp import FastMCP
+
+# A scan older than this is considered stale and should be re-run for
+# accurate posture answers. 24 hours is the default because most code
+# review questions ("is this repo secure?") only need same-day data;
+# older snapshots can miss recent changes or new disclosures.
+DEFAULT_FRESH_THRESHOLD_SECONDS = 86400
 
 mcp = FastMCP(
     "argus",
     instructions="""
 Argus Security Scanner — comprehensive security scanning for your codebase.
 
-WHEN TO USE EACH TOOL:
-- argus_detect: First step — understand what's in the project
+QUICK PATH (RECOMMENDED FOR NATURAL-LANGUAGE QUERIES):
+- argus_security_review: ONE-CALL entry point for "what's my security posture?",
+  "is this repo secure?", "what should I fix?" — orchestrates detect + scan
+  (or fresh-cache reuse) + returns a stable JSON envelope. Use this first
+  when the user asks an open-ended security question.
+
+WHEN TO USE INDIVIDUAL TOOLS:
+- argus_detect: Understand what's in the project (languages, IaC, CI/CD)
 - argus_scan: Run security scans (specify scanners or let auto-detect choose)
 - argus_list_scanners: See what scanners are available and their categories
 - argus_classify: Analyze IaC changes between git branches for compliance
 - argus_validate: Check if argus.yml config is valid
 - argus_init: Generate a tailored config for the project
 - argus_explain_finding: Get remediation guidance for a specific finding
-- argus_scan_summary: Quick check on latest scan status
+- argus_scan_summary: Quick check on latest scan results (returns cache age —
+  if cache_age_seconds > 86400, prefer argus_scan for fresh results)
+
+CACHE FRESHNESS:
+- argus_scan_summary and argus://results/latest both report cache_age_seconds.
+- Treat results > 24h old as stale; re-run argus_scan or argus_security_review
+  rather than answering from a stale snapshot.
 
 COMMON WORKFLOWS:
-1. New project setup: argus_detect -> argus_init -> save config -> argus_scan
-2. Security review: argus_scan -> review findings -> argus_explain_finding for each
-3. Quick check: argus_scan_summary to see latest results
+1. Open-ended posture question: argus_security_review (handles everything)
+2. New project setup: argus_detect -> argus_init -> save config -> argus_scan
+3. Targeted re-scan: argus_scan with specific scanners
 4. Branch comparison: argus_classify to check IaC changes
+5. Fix triage: argus_scan_summary -> argus_explain_finding per finding
 
 SCANNER CATEGORIES:
 - sast: Static analysis (bandit, opengrep)
@@ -41,6 +65,78 @@ SCANNER CATEGORIES:
 - linter: Code quality (lint-yaml, lint-json, lint-python, etc.)
 """,
 )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers — cache freshness + results loading
+# ---------------------------------------------------------------------------
+
+
+# Search order for cached scan results. The 'latest' symlink is canonical;
+# the unprefixed paths are legacy fallbacks from older argus runs.
+_RESULTS_CANDIDATES: tuple[str, ...] = (
+    "argus-results/latest/argus-results.json",
+    "argus-results/latest/argus-audit.json",
+    "argus-results/argus-results.json",
+    "argus-results/argus-audit.json",
+)
+
+
+def _freshness_for(path: Path, threshold_seconds: int = DEFAULT_FRESH_THRESHOLD_SECONDS) -> dict[str, Any]:
+    """Compute cache-freshness metadata for a results file.
+
+    Returns a dict with:
+      - cache_age_seconds: int — seconds since file mtime (>=0)
+      - cached_at: str — ISO-8601 UTC timestamp of file mtime
+      - is_stale: bool — True if older than threshold_seconds
+
+    Stale results are still returned to the caller; this metadata lets the
+    LLM decide whether to re-run the scan rather than answering from old data.
+    """
+    mtime = path.stat().st_mtime
+    cached_at = datetime.fromtimestamp(mtime, tz=timezone.utc)
+    age_seconds = max(0, int((datetime.now(timezone.utc) - cached_at).total_seconds()))
+    return {
+        "cache_age_seconds": age_seconds,
+        "cached_at": cached_at.isoformat(),
+        "is_stale": age_seconds > threshold_seconds,
+    }
+
+
+def _find_latest_results_file() -> Path | None:
+    """Locate the most recent scan-results JSON file, or None if absent.
+
+    Tries the canonical candidates first, then falls back to globbing the
+    'latest' run directory for any *.json. Mirrors the discovery used by
+    argus_scan_summary and the argus://results/latest resource so they
+    stay in agreement.
+    """
+    for name in _RESULTS_CANDIDATES:
+        candidate = Path(name)
+        if candidate.exists():
+            return candidate
+
+    latest_link = Path("argus-results/latest")
+    if latest_link.is_symlink() or latest_link.is_dir():
+        json_files = sorted(latest_link.glob("*.json"))
+        if json_files:
+            return json_files[0]
+
+    return None
+
+
+def _stale_warning(age_seconds: int) -> str:
+    """Render a human-readable freshness warning for stale results."""
+    if age_seconds < 3600:
+        age_str = f"{age_seconds // 60}m"
+    elif age_seconds < 86400:
+        age_str = f"{age_seconds // 3600}h"
+    else:
+        age_str = f"{age_seconds // 86400}d"
+    return (
+        f"Results are {age_str} old. For current security state, "
+        "re-run argus_scan or argus_security_review."
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -486,92 +582,219 @@ async def argus_explain_finding(
     return json.dumps(explanation, indent=2)
 
 
+def _summarize_results(results_data: dict) -> dict[str, Any]:
+    """Build the standard summary envelope from a parsed results blob.
+
+    Shared by argus_scan_summary and argus_security_review so they emit
+    the same shape (counts, scanner breakdown, top findings).
+    """
+    summary: dict[str, Any] = {
+        "passed": results_data.get("passed"),
+        "severity_threshold": results_data.get("severity_threshold"),
+        "counts": {
+            "critical": results_data.get("critical_count", 0),
+            "high": results_data.get("high_count", 0),
+            "medium": results_data.get("medium_count", 0),
+            "low": results_data.get("low_count", 0),
+            "total": results_data.get("total_count", 0),
+        },
+    }
+
+    scanner_breakdown = []
+    for result in results_data.get("results", []):
+        scanner_breakdown.append({
+            "scanner": result.get("scanner", "unknown"),
+            "total": result.get("total_count", 0),
+            "critical": result.get("critical_count", 0),
+            "high": result.get("high_count", 0),
+        })
+    summary["scanners"] = scanner_breakdown
+
+    top_findings = []
+    for result in results_data.get("results", []):
+        for finding in result.get("findings", []):
+            sev = finding.get("severity", "unknown")
+            if sev in ("critical", "high"):
+                top_findings.append({
+                    "id": finding.get("id", ""),
+                    "severity": sev,
+                    "title": finding.get("title", ""),
+                    "location": finding.get("location", ""),
+                    "scanner": finding.get("scanner", result.get("scanner", "")),
+                })
+    top_findings.sort(key=lambda f: 0 if f["severity"] == "critical" else 1)
+    summary["top_findings"] = top_findings[:5]
+    return summary
+
+
 @mcp.tool()
 async def argus_scan_summary() -> str:
     """Get a quick summary of the most recent scan results.
 
-    Returns severity counts, scanner breakdown, and top findings
-    without the full payload. Use this for a quick "how bad is it?"
-    check before diving into details with argus://results/latest.
+    Returns severity counts, scanner breakdown, top findings, and **cache
+    freshness metadata** (cache_age_seconds, cached_at). If cache_age_seconds
+    exceeds 86400 (24h), the response includes a freshness_warning and you
+    should prefer running argus_scan (or argus_security_review) for current
+    posture rather than answering from this snapshot.
+
+    Use this for a quick "how bad is it?" check before diving into details
+    with argus://results/latest.
     """
-    import json
-    from pathlib import Path
-
     try:
-        candidates = [
-            Path("argus-results/latest/argus-results.json"),
-            Path("argus-results/latest/argus-audit.json"),
-            Path("argus-results/argus-results.json"),
-            Path("argus-results/argus-audit.json"),
-        ]
-
-        results_data = None
-        source_path = None
-        for candidate in candidates:
-            if candidate.exists():
-                raw = candidate.read_text(encoding="utf-8")
-                results_data = json.loads(raw)
-                source_path = str(candidate)
-                break
-
-        if results_data is None:
-            latest_link = Path("argus-results/latest")
-            if latest_link.is_symlink() or latest_link.is_dir():
-                json_files = sorted(latest_link.glob("*.json"))
-                if json_files:
-                    raw = json_files[0].read_text(encoding="utf-8")
-                    results_data = json.loads(raw)
-                    source_path = str(json_files[0])
-
-        if results_data is None:
+        results_path = _find_latest_results_file()
+        if results_path is None:
             return json.dumps({
                 "error": "No scan results found. Run argus_scan first.",
             })
 
-        # Extract summary counts
-        summary = {
-            "source": source_path,
-            "passed": results_data.get("passed"),
-            "severity_threshold": results_data.get("severity_threshold"),
-            "counts": {
-                "critical": results_data.get("critical_count", 0),
-                "high": results_data.get("high_count", 0),
-                "medium": results_data.get("medium_count", 0),
-                "low": results_data.get("low_count", 0),
-                "total": results_data.get("total_count", 0),
-            },
-        }
+        results_data = json.loads(results_path.read_text(encoding="utf-8"))
 
-        # Scanner breakdown
-        scanner_breakdown = []
-        for result in results_data.get("results", []):
-            scanner_breakdown.append({
-                "scanner": result.get("scanner", "unknown"),
-                "total": result.get("total_count", 0),
-                "critical": result.get("critical_count", 0),
-                "high": result.get("high_count", 0),
-            })
-        summary["scanners"] = scanner_breakdown
+        summary = _summarize_results(results_data)
+        summary["source"] = str(results_path)
 
-        # Top critical/high findings (up to 5)
-        top_findings = []
-        for result in results_data.get("results", []):
-            for finding in result.get("findings", []):
-                sev = finding.get("severity", "unknown")
-                if sev in ("critical", "high"):
-                    top_findings.append({
-                        "id": finding.get("id", ""),
-                        "severity": sev,
-                        "title": finding.get("title", ""),
-                        "location": finding.get("location", ""),
-                        "scanner": finding.get("scanner", result.get("scanner", "")),
-                    })
-        top_findings.sort(key=lambda f: 0 if f["severity"] == "critical" else 1)
-        summary["top_findings"] = top_findings[:5]
+        freshness = _freshness_for(results_path)
+        summary["cache_age_seconds"] = freshness["cache_age_seconds"]
+        summary["cached_at"] = freshness["cached_at"]
+        if freshness["is_stale"]:
+            summary["freshness_warning"] = _stale_warning(
+                freshness["cache_age_seconds"],
+            )
 
         return json.dumps(summary, indent=2)
     except Exception as exc:
         return json.dumps({"error": str(exc)})
+
+
+@mcp.tool()
+async def argus_security_review(
+    path: str = ".",
+    use_cached_if_fresh: bool = True,
+    fresh_threshold_seconds: int = DEFAULT_FRESH_THRESHOLD_SECONDS,
+) -> str:
+    """One-call security posture review — the canonical entry point.
+
+    USE THIS WHEN the user asks open-ended security questions like:
+      - "What's my security posture?"
+      - "Is this repo secure?"
+      - "What should I fix?"
+      - "Run a security review"
+      - "Are there any vulnerabilities?"
+
+    Orchestrates the full workflow in a single call:
+      1. Detect project signals (languages, IaC, CI/CD)
+      2. Reuse cached scan results if fresher than ``fresh_threshold_seconds``
+         (default 24h) and ``use_cached_if_fresh`` is True; otherwise run a
+         new scan via the engine.
+      3. Return a stable JSON envelope so repeated invocations of the same
+         question produce the same shape — no tool-routing variance.
+
+    Args:
+        path: Project root to analyze. Defaults to current directory.
+        use_cached_if_fresh: When True (default), reuse the latest cached
+            scan if it's fresher than the threshold. Set False to force a
+            new scan.
+        fresh_threshold_seconds: Cache freshness cutoff in seconds.
+            Defaults to 86400 (24h).
+
+    Returns:
+        JSON envelope with stable shape:
+          {
+            "version": "1",
+            "cache_used": bool,           // True if served from cache
+            "cache_age_seconds": int,     // 0 for a fresh scan
+            "cached_at": str,             // ISO-8601 UTC timestamp
+            "is_stale": bool,             // age > threshold
+            "freshness_warning": str?,    // present only if is_stale
+            "signals": dict,              // from argus_detect
+            "summary": dict,              // counts + scanners + top_findings
+            "next_steps": list[str]       // recommended follow-ups
+          }
+    """
+    try:
+        from argus.init import detect_project
+
+        signals = detect_project(Path(path))
+
+        results_path: Path | None = None
+        results_data: dict | None = None
+        cache_used = False
+        freshness: dict[str, Any] | None = None
+
+        if use_cached_if_fresh:
+            cached_path = _find_latest_results_file()
+            if cached_path is not None:
+                cached_freshness = _freshness_for(cached_path, fresh_threshold_seconds)
+                if not cached_freshness["is_stale"]:
+                    results_path = cached_path
+                    results_data = json.loads(cached_path.read_text(encoding="utf-8"))
+                    cache_used = True
+                    freshness = cached_freshness
+
+        if results_data is None:
+            from argus.core import ArgusConfig
+            from argus.core.engine import ArgusEngine
+            from argus.scanners import get_available_scanners
+
+            config = ArgusConfig.load()
+            engine = ArgusEngine(config)
+            for scanner_cls in get_available_scanners():
+                engine.register_scanner(scanner_cls())
+
+            scan_summary = engine.run(scanner_names=None, path=path)
+            results_data = scan_summary.to_dict()
+            now = datetime.now(timezone.utc)
+            freshness = {
+                "cache_age_seconds": 0,
+                "cached_at": now.isoformat(),
+                "is_stale": False,
+            }
+
+        envelope: dict[str, Any] = {
+            "version": "1",
+            "cache_used": cache_used,
+            "cache_age_seconds": freshness["cache_age_seconds"],
+            "cached_at": freshness["cached_at"],
+            "is_stale": freshness["is_stale"],
+            "signals": signals,
+            "summary": _summarize_results(results_data),
+        }
+        if freshness["is_stale"]:
+            envelope["freshness_warning"] = _stale_warning(
+                freshness["cache_age_seconds"],
+            )
+        if results_path is not None:
+            envelope["source"] = str(results_path)
+
+        next_steps: list[str] = []
+        counts = envelope["summary"]["counts"]
+        if counts.get("critical", 0) > 0:
+            next_steps.append(
+                "Triage critical findings first — call argus_explain_finding "
+                "for each top_finding with severity=critical."
+            )
+        if counts.get("high", 0) > 0:
+            next_steps.append(
+                "Address high-severity findings — call argus_explain_finding "
+                "for each top_finding with severity=high."
+            )
+        if envelope["is_stale"]:
+            next_steps.append(
+                "Cache is stale — re-run with use_cached_if_fresh=False for "
+                "current results."
+            )
+        if not next_steps:
+            next_steps.append(
+                "No critical or high findings. Review medium/low findings "
+                "in argus://results/latest as time permits."
+            )
+        envelope["next_steps"] = next_steps
+
+        return json.dumps(envelope, indent=2)
+    except Exception as exc:
+        return json.dumps({
+            "error": str(exc),
+            "error_type": type(exc).__name__,
+        }, indent=2)
 
 
 # ---------------------------------------------------------------------------
@@ -644,36 +867,43 @@ async def read_config() -> str:
 async def read_latest_results() -> str:
     """Read the most recent scan results.
 
-    Looks for argus-results/latest/argus-results.json (the symlink
-    created by each scan run). Falls back to argus-results.json in
-    the default output directory.
+    Looks for argus-results/latest/argus-results.json (the symlink created
+    by each scan run). Falls back to argus-results.json in the default
+    output directory. When the underlying file is a JSON object, the
+    response is augmented with ``_cache_age_seconds`` and ``_cached_at``
+    fields (underscore-prefixed because they're MCP envelope metadata,
+    not part of the scan-results schema). Use these to decide whether to
+    re-run the scan instead of trusting a stale snapshot.
     """
-    import json
-    from pathlib import Path
-
     try:
-        # Check the 'latest' symlink first
-        candidates = [
-            Path("argus-results/latest/argus-results.json"),
-            Path("argus-results/latest/argus-audit.json"),
-            Path("argus-results/argus-results.json"),
-            Path("argus-results/argus-audit.json"),
-        ]
+        results_path = _find_latest_results_file()
+        if results_path is None:
+            return json.dumps({
+                "error": "No scan results found. Run argus_scan first.",
+            })
 
-        for candidate in candidates:
-            if candidate.exists():
-                return candidate.read_text(encoding="utf-8")
+        raw = results_path.read_text(encoding="utf-8")
+        freshness = _freshness_for(results_path)
 
-        # Try to find any JSON result file in the latest run dir
-        latest_link = Path("argus-results/latest")
-        if latest_link.is_symlink() or latest_link.is_dir():
-            json_files = sorted(latest_link.glob("*.json"))
-            if json_files:
-                return json_files[0].read_text(encoding="utf-8")
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            # Non-JSON or malformed file — return raw bytes unchanged
+            # rather than swallowing the original content.
+            return raw
 
-        return json.dumps({
-            "error": "No scan results found. Run argus_scan first.",
-        })
+        if isinstance(data, dict):
+            data["_cache_age_seconds"] = freshness["cache_age_seconds"]
+            data["_cached_at"] = freshness["cached_at"]
+            if freshness["is_stale"]:
+                data["_freshness_warning"] = _stale_warning(
+                    freshness["cache_age_seconds"],
+                )
+            return json.dumps(data, indent=2)
+
+        # Not a JSON object (e.g. a list at the top level) — return raw
+        # text since we have no envelope to inject metadata into.
+        return raw
     except Exception as exc:
         return json.dumps({"error": str(exc)})
 
@@ -715,14 +945,33 @@ async def read_config_schema() -> str:
 
 @mcp.prompt()
 async def security_review() -> str:
-    """Comprehensive security review prompt for a codebase."""
+    """Run a comprehensive security review of the current codebase.
+
+    Trigger phrases (use this prompt when the user says any of):
+      - "what's my security posture?"
+      - "is this repo secure?"
+      - "what should I fix?"
+      - "run a security review"
+      - "are there any vulnerabilities?"
+      - "check this project for security issues"
+    """
     return (
-        "Perform a security review of this project:\n"
-        "1. Run argus_detect to understand the project\n"
-        "2. Run argus_scan to find vulnerabilities\n"
-        "3. For each HIGH or CRITICAL finding, explain the risk and suggest a fix\n"
-        "4. Summarize the overall security posture\n"
-        "5. Recommend additional scanners if appropriate"
+        "Perform a security review of this project. Prefer the one-call\n"
+        "tool argus_security_review for the orchestration; the explicit\n"
+        "steps below are the breakdown it performs.\n"
+        "\n"
+        "1. Call argus_security_review (handles detect + scan-or-cached\n"
+        "   reuse + stable JSON envelope). If cache_age_seconds > 86400,\n"
+        "   re-call with use_cached_if_fresh=False for fresh results.\n"
+        "2. From the response, list each CRITICAL and HIGH finding by\n"
+        "   id, severity, location, and scanner.\n"
+        "3. For each top finding, call argus_explain_finding with the\n"
+        "   finding id and scanner; report the remediation guidance.\n"
+        "4. Summarize the overall posture: total counts by severity,\n"
+        "   whether the scan passed the threshold, and which scanners\n"
+        "   produced the most findings.\n"
+        "5. Recommend any uninstalled scanners that would add coverage\n"
+        "   based on the detected signals (use argus_list_scanners)."
     )
 
 

--- a/argus/tests/test_mcp.py
+++ b/argus/tests/test_mcp.py
@@ -22,6 +22,7 @@ from argus.mcp import (  # noqa: E402
     argus_list_scanners,
     argus_scan,
     argus_scan_summary,
+    argus_security_review,
     argus_validate,
     create_server,
     read_config,
@@ -1167,7 +1168,18 @@ class TestPrompts:
         result = _run(security_review())
         assert isinstance(result, str)
         assert len(result) > 0
-        assert "argus_detect" in result or "argus_scan" in result
+        # Prompt should steer the assistant toward at least one Argus tool —
+        # argus_security_review is the canonical entry point but legacy
+        # phrasing referencing argus_detect / argus_scan is also acceptable.
+        assert any(
+            tool in result
+            for tool in (
+                "argus_security_review",
+                "argus_detect",
+                "argus_scan",
+                "argus_explain_finding",
+            )
+        )
 
     def test_fix_findings_returns_nonempty(self):
         result = _run(fix_findings())
@@ -1222,3 +1234,367 @@ class TestCreateServer:
         server1 = create_server()
         server2 = create_server()
         assert server1 is server2
+
+    def test_instructions_advertise_security_review_entry_point(self):
+        """The unified tool is the recommended path for natural-language
+        queries. Server instructions must advertise it so clients route to
+        it instead of stitching together argus_detect + argus_scan ad hoc.
+        """
+        server = create_server()
+        assert "argus_security_review" in server.instructions
+        assert "QUICK PATH" in server.instructions
+
+    def test_instructions_warn_about_stale_cache(self):
+        """Instructions must teach clients to check cache_age_seconds and
+        re-scan when stale, so they don't answer posture questions from
+        a 9-day-old snapshot.
+        """
+        server = create_server()
+        assert "cache_age_seconds" in server.instructions
+
+
+# ---------------------------------------------------------------------------
+# TestArgusScanSummaryCacheFreshness
+# ---------------------------------------------------------------------------
+
+
+def _write_results(results_dir, payload, *, mtime_offset_seconds: int = 0):
+    """Write a results JSON file and optionally backdate its mtime.
+
+    A non-zero mtime_offset_seconds backs the file up that many seconds in
+    the past — used to simulate stale cached scans without sleeping.
+    """
+    import os
+    import time
+
+    results_dir.mkdir(parents=True, exist_ok=True)
+    results_file = results_dir / "argus-results.json"
+    results_file.write_text(json.dumps(payload))
+    if mtime_offset_seconds:
+        target = time.time() - mtime_offset_seconds
+        os.utime(results_file, (target, target))
+    return results_file
+
+
+class TestArgusScanSummaryCacheFreshness:
+    """argus_scan_summary now reports cache_age_seconds + cached_at so
+    the LLM can decide whether to trust the cached snapshot or re-scan.
+    These tests pin that behavior — without the freshness signal, an
+    assistant may answer posture questions from a 9-day-old cache (the
+    real-world failure mode this guards against).
+    """
+
+    _BASE_PAYLOAD = {
+        "passed": True,
+        "severity_threshold": "high",
+        "critical_count": 0,
+        "high_count": 0,
+        "medium_count": 0,
+        "low_count": 0,
+        "total_count": 0,
+        "results": [],
+    }
+
+    def test_includes_cache_age_seconds_field(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_results(tmp_path / "argus-results" / "latest", self._BASE_PAYLOAD)
+
+        data = json.loads(_run(argus_scan_summary()))
+
+        assert "cache_age_seconds" in data
+        assert isinstance(data["cache_age_seconds"], int)
+        assert data["cache_age_seconds"] >= 0
+        # A just-written file should be within a few seconds of "now".
+        assert data["cache_age_seconds"] < 10
+
+    def test_includes_cached_at_iso_timestamp(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_results(tmp_path / "argus-results" / "latest", self._BASE_PAYLOAD)
+
+        data = json.loads(_run(argus_scan_summary()))
+
+        assert "cached_at" in data
+        # ISO-8601 with timezone — should parse cleanly via fromisoformat.
+        from datetime import datetime
+        parsed = datetime.fromisoformat(data["cached_at"])
+        assert parsed.tzinfo is not None
+
+    def test_fresh_results_omit_freshness_warning(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_results(tmp_path / "argus-results" / "latest", self._BASE_PAYLOAD)
+
+        data = json.loads(_run(argus_scan_summary()))
+
+        assert "freshness_warning" not in data
+
+    def test_stale_results_include_freshness_warning(self, tmp_path, monkeypatch):
+        # Backdate the file by 48h — well past the 24h staleness threshold.
+        monkeypatch.chdir(tmp_path)
+        _write_results(
+            tmp_path / "argus-results" / "latest",
+            self._BASE_PAYLOAD,
+            mtime_offset_seconds=48 * 3600,
+        )
+
+        data = json.loads(_run(argus_scan_summary()))
+
+        assert data["cache_age_seconds"] >= 48 * 3600
+        assert "freshness_warning" in data
+        # The warning should name argus_scan or argus_security_review so
+        # the client knows what to do — not a vague "results may be stale".
+        assert (
+            "argus_scan" in data["freshness_warning"]
+            or "argus_security_review" in data["freshness_warning"]
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestReadLatestResultsCacheFreshness
+# ---------------------------------------------------------------------------
+
+
+class TestReadLatestResultsCacheFreshness:
+    """The argus://results/latest resource now augments JSON-object
+    payloads with _cache_age_seconds and _cached_at envelope fields.
+    Underscore-prefixed because they're MCP-injected metadata, not part
+    of the scan-results schema downstream consumers parse.
+    """
+
+    _BASE_PAYLOAD = {
+        "passed": True,
+        "severity_threshold": "high",
+        "critical_count": 0,
+        "high_count": 0,
+        "medium_count": 0,
+        "low_count": 0,
+        "total_count": 0,
+        "results": [],
+    }
+
+    def test_dict_payload_gets_cache_metadata(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_results(tmp_path / "argus-results" / "latest", self._BASE_PAYLOAD)
+
+        data = json.loads(_run(read_latest_results()))
+
+        assert "_cache_age_seconds" in data
+        assert "_cached_at" in data
+        assert data["passed"] is True  # original fields preserved
+
+    def test_stale_payload_includes_freshness_warning(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_results(
+            tmp_path / "argus-results" / "latest",
+            self._BASE_PAYLOAD,
+            mtime_offset_seconds=72 * 3600,
+        )
+
+        data = json.loads(_run(read_latest_results()))
+
+        assert "_freshness_warning" in data
+        assert data["_cache_age_seconds"] >= 72 * 3600
+
+
+# ---------------------------------------------------------------------------
+# TestArgusSecurityReview
+# ---------------------------------------------------------------------------
+
+
+class TestArgusSecurityReview:
+    """argus_security_review is the canonical one-call entry point. It
+    must return a stable JSON envelope so the same posture question
+    produces the same response shape across sessions — that's the whole
+    point of unifying the workflow into one tool.
+    """
+
+    _CACHED_PAYLOAD = {
+        "passed": False,
+        "severity_threshold": "high",
+        "critical_count": 1,
+        "high_count": 1,
+        "medium_count": 0,
+        "low_count": 0,
+        "total_count": 2,
+        "results": [
+            {
+                "scanner": "bandit",
+                "total_count": 2,
+                "critical_count": 1,
+                "high_count": 1,
+                "findings": [
+                    {
+                        "id": "B301",
+                        "severity": "critical",
+                        "title": "Pickle usage",
+                        "location": "app.py:10",
+                        "scanner": "bandit",
+                    },
+                    {
+                        "id": "B302",
+                        "severity": "high",
+                        "title": "Insecure marshal",
+                        "location": "utils.py:5",
+                        "scanner": "bandit",
+                    },
+                ],
+            },
+        ],
+    }
+
+    def test_returns_stable_envelope_shape(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_results(
+            tmp_path / "argus-results" / "latest",
+            self._CACHED_PAYLOAD,
+        )
+
+        with patch("argus.init.detect_project", return_value={"python": ["app.py"]}):
+            data = json.loads(_run(argus_security_review()))
+
+        # The envelope keys are the contract — every successful call
+        # returns the same top-level shape regardless of cache state.
+        for key in (
+            "version",
+            "cache_used",
+            "cache_age_seconds",
+            "cached_at",
+            "is_stale",
+            "signals",
+            "summary",
+            "next_steps",
+        ):
+            assert key in data, f"missing envelope key: {key}"
+        assert data["version"] == "1"
+
+    def test_uses_cache_when_fresh(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_results(
+            tmp_path / "argus-results" / "latest",
+            self._CACHED_PAYLOAD,
+        )
+
+        with patch("argus.init.detect_project", return_value={"python": []}):
+            data = json.loads(_run(argus_security_review()))
+
+        assert data["cache_used"] is True
+        assert data["is_stale"] is False
+        # Summary should reflect the cached payload, not a fresh scan.
+        assert data["summary"]["counts"]["critical"] == 1
+        assert data["summary"]["counts"]["high"] == 1
+
+    def test_summary_includes_top_findings(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_results(
+            tmp_path / "argus-results" / "latest",
+            self._CACHED_PAYLOAD,
+        )
+
+        with patch("argus.init.detect_project", return_value={}):
+            data = json.loads(_run(argus_security_review()))
+
+        top = data["summary"]["top_findings"]
+        assert len(top) == 2
+        # critical sorts before high
+        assert top[0]["severity"] == "critical"
+        assert top[1]["severity"] == "high"
+
+    def test_signals_passed_through_from_detect(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_results(
+            tmp_path / "argus-results" / "latest",
+            self._CACHED_PAYLOAD,
+        )
+
+        signals = {"python": ["app.py"], "github-actions": [".github/workflows/ci.yml"]}
+        with patch("argus.init.detect_project", return_value=signals):
+            data = json.loads(_run(argus_security_review()))
+
+        assert data["signals"] == signals
+
+    def test_next_steps_recommend_explain_for_critical(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_results(
+            tmp_path / "argus-results" / "latest",
+            self._CACHED_PAYLOAD,
+        )
+
+        with patch("argus.init.detect_project", return_value={}):
+            data = json.loads(_run(argus_security_review()))
+
+        joined = " ".join(data["next_steps"])
+        assert "argus_explain_finding" in joined
+        assert "critical" in joined.lower()
+
+    def test_next_steps_clean_when_no_findings(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        clean_payload = dict(self._CACHED_PAYLOAD)
+        clean_payload["critical_count"] = 0
+        clean_payload["high_count"] = 0
+        clean_payload["total_count"] = 0
+        clean_payload["results"] = []
+        _write_results(tmp_path / "argus-results" / "latest", clean_payload)
+
+        with patch("argus.init.detect_project", return_value={}):
+            data = json.loads(_run(argus_security_review()))
+
+        assert data["next_steps"]
+        joined = " ".join(data["next_steps"]).lower()
+        assert "no critical or high" in joined
+
+    def test_stale_cache_triggers_warning_and_rescan_hint(
+        self, tmp_path, monkeypatch,
+    ):
+        monkeypatch.chdir(tmp_path)
+        # Backdate cache 9 days — the exact failure mode the user reported.
+        _write_results(
+            tmp_path / "argus-results" / "latest",
+            self._CACHED_PAYLOAD,
+            mtime_offset_seconds=9 * 86400,
+        )
+
+        # Stale cache => the tool must run a fresh scan rather than reuse.
+        # Mock the engine path so the test stays hermetic.
+        mock_summary = MagicMock()
+        mock_summary.to_dict.return_value = self._CACHED_PAYLOAD
+        mock_engine_instance = MagicMock()
+        mock_engine_instance.run.return_value = mock_summary
+
+        with patch("argus.init.detect_project", return_value={}), \
+             patch("argus.core.ArgusConfig.load", return_value=MagicMock()), \
+             patch("argus.core.engine.ArgusEngine", return_value=mock_engine_instance), \
+             patch("argus.scanners.get_available_scanners", return_value=[]):
+            data = json.loads(_run(argus_security_review()))
+
+        # When stale, we re-scanned, so cache_used is False.
+        assert data["cache_used"] is False
+        mock_engine_instance.run.assert_called_once()
+
+    def test_force_fresh_scan_skips_cache(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write_results(
+            tmp_path / "argus-results" / "latest",
+            self._CACHED_PAYLOAD,
+        )
+
+        mock_summary = MagicMock()
+        mock_summary.to_dict.return_value = self._CACHED_PAYLOAD
+        mock_engine_instance = MagicMock()
+        mock_engine_instance.run.return_value = mock_summary
+
+        with patch("argus.init.detect_project", return_value={}), \
+             patch("argus.core.ArgusConfig.load", return_value=MagicMock()), \
+             patch("argus.core.engine.ArgusEngine", return_value=mock_engine_instance), \
+             patch("argus.scanners.get_available_scanners", return_value=[]):
+            data = json.loads(_run(argus_security_review(use_cached_if_fresh=False)))
+
+        assert data["cache_used"] is False
+        mock_engine_instance.run.assert_called_once()
+
+    def test_error_returns_structured_error(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+
+        with patch("argus.init.detect_project", side_effect=RuntimeError("boom")):
+            data = json.loads(_run(argus_security_review()))
+
+        assert "error" in data
+        assert data["error_type"] == "RuntimeError"

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -165,14 +165,17 @@ Any client that supports the standard MCP stdio transport accepts the same shape
 
 | Tool | What it does |
 |---|---|
+| `argus_security_review` | **Recommended entry point** for natural-language posture queries ("is this repo secure?", "what should I fix?"). One call: detect → fresh-scan-or-cached-with-age → stable JSON envelope. |
 | `argus_detect` | Inspect a project and report scanner-relevant signals (languages, package files, IaC, etc.) |
 | `argus_init` | Generate a tailored `argus.yml` for the project |
 | `argus_validate` | Check whether an existing `argus.yml` is valid |
 | `argus_list_scanners` | List every scanner the SDK knows about, grouped by category |
 | `argus_scan` | Run a scan (specify scanners or auto-detect) |
-| `argus_scan_summary` | Quick check of the latest scan results without re-scanning |
+| `argus_scan_summary` | Quick check of the latest scan results without re-scanning. Returns `cache_age_seconds` so callers can decide whether to trust the snapshot. |
 | `argus_explain_finding` | Get remediation guidance for a specific finding |
 | `argus_classify` | Classify IaC changes between two git refs for compliance review |
+
+**Cache freshness**: both `argus_scan_summary` and the `argus://results/latest` resource report `cache_age_seconds` and `cached_at`. Results older than 24 hours are flagged with a `freshness_warning` field. Treat stale results as a cue to re-run `argus_scan` rather than answering posture questions from a 9-day-old snapshot.
 
 ### Resources
 


### PR DESCRIPTION
## Description
Stabilizes Argus MCP responses across sessions for the same posture question. Addresses the routing variance observed across three consecutive Claude Code sessions where the same query ("what's my security posture?") produced different tool sequences and a 9-day-old cached scan was answered as current state.

## Changes Made
- [ ] Added new scanner/workflow
- [x] Modified existing scanner/workflow
- [x] Updated documentation
- [x] Fixed bug
- [ ] Other (please specify)

### Details
Three changes in one PR — they reinforce each other and don't make sense in isolation:

**1. New `argus_security_review` tool — canonical entry point**
- Single call orchestrates: `detect` → reuse-cached-if-fresh OR run new scan → returns a stable JSON envelope
- Envelope shape: `version`, `cache_used`, `cache_age_seconds`, `cached_at`, `is_stale`, `signals`, `summary`, `next_steps`
- Replaces ad-hoc stitching of `argus_detect` + `argus_scan` + `argus_scan_summary` with one routable call
- Args: `path`, `use_cached_if_fresh` (default True), `fresh_threshold_seconds` (default 86400 / 24h)

**2. Cache freshness on `argus_scan_summary` and `argus://results/latest`**
- Both now report `cache_age_seconds` (int) and `cached_at` (ISO-8601 UTC) computed from the results-file mtime
- When age > 24h, response includes `freshness_warning` naming `argus_scan` / `argus_security_review` as the rescan path
- Resource fields are underscore-prefixed (`_cache_age_seconds`, `_cached_at`) to mark them as MCP envelope metadata, not part of the scan-results schema
- Prevents the failure mode where a stale cached scan is answered as current state

**3. Tightened routing hints**
- `security_review` prompt docstring lists explicit trigger phrases ("what's my security posture?", "is this repo secure?", "what should I fix?")
- Server instructions add a QUICK PATH section advertising `argus_security_review` as the first stop for natural-language queries
- Server instructions teach clients to check `cache_age_seconds` and rescan when stale

No breaking changes — existing tools and resources keep their previous shape; new fields are additive.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results
- 17 new tests in `argus/tests/test_mcp.py` covering cache freshness fields, the unified tool's envelope shape, cache reuse vs fresh-scan paths, and the stale-cache rescan trigger
- Full suite: **2403 passed, 3 skipped, 7 deselected** locally (no regressions)
- MCP-only: **86 passed** (up from 69)

## Security Considerations
- [ ] No security impact
- [x] Security enhancement
- [ ] Potential security implications (explain below)

### Security Details
Reduces the chance an LLM answers a security-posture question from stale data. A 9-day-old scan can miss new disclosures, recently-introduced secrets, or freshly-added IaC misconfigurations — all of which the freshness warning now flags explicitly. The unified tool also reduces tool-routing variance, making security reviews more consistent across sessions.

## AI Context Updates (.ai/)
- [ ] \`.ai/architecture.yaml\` updated (if components/structure changed)
- [ ] \`.ai/workflows.yaml\` updated (if commands/tasks changed)
- [ ] \`.ai/decisions.yaml\` updated (if design decision made)
- [ ] \`.ai/errors.yaml\` updated (if common error addressed)
- [x] N/A - No .ai/ updates needed

The MCP tool/prompt surface lives in \`argus/mcp.py\` and \`docs/mcp.md\`; both are updated. No architecture-level changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Follow-up to PR #100 (MCP docs + uvx + registry) and PR #101 (per-scanner secret redaction). Together these three PRs make the MCP server safe to ship to AI clients and stable enough to give consistent answers.