### PR TITLE
fix(view-browser): elevate header so Recent runs dropdown overlays main content

### DIFF
--- a/argus/viewers/browser/static/argus.css
+++ b/argus/viewers/browser/static/argus.css
@@ -168,6 +168,12 @@ header {
   margin-bottom: 1.5rem;
   flex-wrap: wrap; gap: 0.5rem 1rem;
   padding-top: 1.25rem; padding-bottom: 1.25rem;
+  /* Promote the header into its own stacking context above <main> so
+   * absolutely-positioned descendants (the Recent-runs dropdown) can
+   * overlay the highlighted scan-path block and any other downstream
+   * content. Without this, source order makes <main> paint on top. */
+  position: relative;
+  z-index: 100;
 }
 header .brand {
   display: flex; align-items: center; gap: 0.6rem;
@@ -265,7 +271,10 @@ header nav a[aria-current="page"] {
   margin: 0; list-style: none;
   min-width: 20rem;
   max-height: 24rem; overflow-y: auto;
-  z-index: 10;
+  /* High z-index inside the header's stacking context (header itself
+   * is z-index: 100). Combined, this guarantees the open dropdown
+   * paints above any <main> content beneath. */
+  z-index: 1000;
   box-shadow: 0 6px 24px rgba(0, 0, 0, 0.5);
 }
 .recent-scans-list li { margin: 0; }


### PR DESCRIPTION
## Description

The Recent-runs dropdown in the browser interface was being clipped/overlaid by the highlighted scan-path `<code>` block in `<main>` — the second item in the dropdown was visible only as a partial sliver. Reproduces on any scan dir with two or more sibling runs.

## Changes Made
- [ ] Added new scanner/workflow
- [x] Modified existing scanner/workflow
- [ ] Updated documentation
- [x] Fixed bug
- [ ] Other

### Details

Root cause: the dropdown's `z-index: 10` only competed inside its own local stacking context (parent `.recent-scans-menu` was `position: relative`, so it formed one). But `<header>` itself had no positioning or z-index, so source order let `<main>` paint above the header by default — meaning anything in `<main>` could overlay the dropdown regardless of the dropdown's local z-index.

Two-part CSS fix in `argus/viewers/browser/static/argus.css`:

1. Promote `<header>` to `position: relative; z-index: 100` so it owns a stacking context above `<main>`.
2. Bump `.recent-scans-list` from `z-index: 10` → `z-index: 1000` inside that context (defensive overkill for any future header-internal layering needs).

No template changes. Affects only the browser interface (`argus view --interface=browser`).

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results
- All 147 browser-viewer tests pass.
- Manually verified: open the dropdown on a multi-scan view; both rows are now fully readable and overlay the highlighted scan-path block cleanly.

## Security Considerations
- [x] No security impact
- [ ] Security enhancement
- [ ] Potential security implications

## AI Context Updates (.ai/)
- [x] N/A - No .ai/ updates needed (CSS-only fix)

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable) — pending v1.0.0 release notes
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Closes # (n/a)

## Screenshots/Logs (if applicable)

Repro: open the browser interface against a scan dir with two or more siblings, click "Recent runs". Before the fix, the second timestamp row was clipped by the highlighted `<code>` block beneath. After: the dropdown sits cleanly on top.
