### PR TITLE
fix: dogfood scan now actually scans what we ship

### DIFF
--- a/argus.yml
+++ b/argus.yml
@@ -30,7 +30,18 @@ scanners:
   supply-chain:
     enabled: true
 
-  # Not applicable to this repo
+  # Lint our own Dockerfiles via hadolint as part of the default scan.
+  # Catches bad practices (mutable image tags, missing USER directives,
+  # apt without --no-install-recommends, etc.) on every run.
+  lint-dockerfile:
+    enabled: true
+
+  # Not applicable to this repo as part of the default scan:
+  # - trivy-iac / checkov target Terraform / CloudFormation / K8s — none here
+  # - container / zap operate on built images / running endpoints, not
+  #   source paths; run them on demand:
+  #     argus scan container --discover .
+  #     argus scan zap --target http://...
   trivy-iac:
     enabled: false
   checkov:

--- a/argus/cli.py
+++ b/argus/cli.py
@@ -1349,7 +1349,11 @@ def _launch_view_after_scan(interface: str, results_dir: str) -> None:
         try:
             from argus.viewers.browser import launch as browser_launch, ViewerUnavailable
             try:
-                browser_launch(root=results_dir)
+                # Match `argus view --interface=browser` semantics: auto-open
+                # the user's default browser when stdout is a TTY (interactive
+                # invocation), skip in CI / piped contexts where webbrowser.open
+                # would fail or hang.
+                browser_launch(root=results_dir, open_browser=sys.stdout.isatty())
             except ViewerUnavailable as exc:
                 print(f"\n{exc}", file=sys.stderr)
         except ImportError as exc:  # pragma: no cover — defensive

--- a/argus/scanners/supply_chain.py
+++ b/argus/scanners/supply_chain.py
@@ -39,14 +39,17 @@ class SupplyChainScanner:
     def container_args(self, config: dict | None = None) -> list[str]:
         """Return CLI args for running zizmor+actionlint in a container.
 
-        Uses ``sh -c`` to chain two tools in a single container invocation.
-        This is safe because containers always run Linux regardless of the
-        host OS, so POSIX ``sh`` semantics are guaranteed.  The semicolon
-        between commands ensures actionlint runs even if zizmor exits
-        non-zero (findings found).
+        The supply-chain Dockerfile sets ``ENTRYPOINT ["/bin/sh", "-c"]``
+        so we pass a single-element list — the shell command string. The
+        previous shape (``["sh", "-c", "<cmd>"]``) double-dispatched the
+        shell: docker exec became ``/bin/sh -c "sh" "-c" "<cmd>"``, the
+        script was literally ``"sh"`` (start a no-op interactive shell),
+        and the real zizmor + actionlint commands never ran.
+
+        The semicolon between zizmor and actionlint ensures actionlint
+        runs even if zizmor exits non-zero (findings found).
         """
         return [
-            "sh", "-c",
             "zizmor --format sarif /workspace/.github/ > /output/zizmor.json 2>/dev/null; "
             "actionlint -format '{{json .}}' /workspace/.github/workflows/ > /output/actionlint.json 2>/dev/null || true",
         ]

--- a/argus/tests/scanners/test_supply_chain.py
+++ b/argus/tests/scanners/test_supply_chain.py
@@ -227,11 +227,13 @@ class TestSupplyChainContainerArgs:
         scanner = SupplyChainScanner()
         args = scanner.container_args()
 
+        # Single-element list: the supply-chain Dockerfile sets
+        # ENTRYPOINT ["/bin/sh", "-c"] so we pass just the command
+        # string. Returning ["sh", "-c", ...] would double-dispatch
+        # the shell and the real command would never run.
         assert isinstance(args, list)
-        assert args[0] == "sh"
-        assert args[1] == "-c"
-        # The shell command should reference both tools
-        shell_cmd = args[2]
+        assert len(args) == 1
+        shell_cmd = args[0]
         assert "zizmor" in shell_cmd
         assert "actionlint" in shell_cmd
 
@@ -242,5 +244,5 @@ class TestSupplyChainContainerArgs:
         # Current implementation does not vary container_args by config,
         # so verify the default structure is still returned intact.
         assert isinstance(args, list)
-        assert len(args) == 3
-        assert "zizmor" in args[2]
+        assert len(args) == 1
+        assert "zizmor" in args[0]


### PR DESCRIPTION
## Description

Three related fixes that surfaced from running `argus scan` against the argus repo itself. Default scan was silently incomplete: the supply-chain scanner was a no-op, the post-scan browser viewer never auto-opened, and our own Dockerfiles weren't being linted at all.

## Changes Made
- [ ] Added new scanner/workflow
- [x] Modified existing scanner/workflow
- [ ] Updated documentation
- [x] Fixed bug
- [ ] Other

### Details

**1. supply-chain scanner ran in 795ms doing nothing.** The Dockerfile sets `ENTRYPOINT ["/bin/sh", "-c"]` AND the scanner's `container_args()` also returned `["sh", "-c", "<cmd>"]`. Docker exec resolved to `/bin/sh -c "sh" "-c" "<cmd>"` — the script was literally `"sh"` (start a no-op interactive shell, exit immediately), and the real zizmor + actionlint commands never ran. The scanner's `container_args()` now returns a single-element list (just the command string); the Dockerfile's entrypoint provides the shell.

**Empirical verification** on argus's own `.github/workflows/`:
- Before fix: 0 findings, "produced no output files" warning, 795ms.
- After fix: 44 zizmor findings parsed (38 after exclusion filtering), `Container exited: code=0, stdout=0 bytes, stderr=0 bytes, Output files: ['zizmor.json', 'actionlint.json']`, 838ms.

**2. `argus scan --interface=browser` never auto-opened the browser.** `_launch_view_after_scan` called `browser_launch(root=...)` without an `open_browser=` argument, so it always defaulted to `False`. `argus view --interface=browser` correctly TTY-checks and auto-opens — the post-scan path now matches via `open_browser=sys.stdout.isatty()`. Same TTY default as `argus view`: opens in interactive contexts, skips in CI / piped contexts.

**3. `argus.yml` dogfood config wasn't linting our own Dockerfiles.** We have four Dockerfiles under `docker/` but no Dockerfile-targeting scanner was enabled. `lint-dockerfile` (hadolint) is now part of the default scan, so missing USER directives, mutable image tags, apt-without-flags, etc. surface on every run. The inline comment on the disabled scanners was rewritten to point at the right on-demand commands (`argus scan container --discover .`, `argus scan zap --target ...`).

### What's still not in default scan (intentional)
- `container` — operates on built image refs, not source paths. On-demand: `argus scan container --discover .` or `--image <ref>`.
- `zap` — operates on a running endpoint. On-demand: `argus scan zap --target http://...`.
- `trivy-iac` / `checkov` — target Terraform/CloudFormation/K8s, none of which exist in this repo.

### Out of scope (separate follow-up)
- Engine only parses `result_files[0]` for scanners with multiple outputs. Supply-chain produces both `zizmor.json` and `actionlint.json`; today only zizmor's findings are picked up. That's a multi-file engine fix, not a one-line config tweak — worth its own PR.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results
- Full SDK suite green: **1363 passed, 8 skipped, 7 deselected** (no test net loss).
- `argus/tests/scanners/test_supply_chain.py::TestSupplyChainContainerArgs` updated to expect the new single-element list shape.
- Manual verification: ran `argus scan supply-chain` against argus repo — 38 findings vs 0 before; ran `argus scan --interface=browser` — Safari opens automatically.

## Security Considerations
- [x] No security impact
- [x] Security enhancement
- [ ] Potential security implications

### Security Details
Restoring the supply-chain scanner brings 38 zizmor findings on argus's own GitHub Actions workflows back into scope (template injection, unpinned actions, etc.). Adding `lint-dockerfile` brings hadolint findings on our own Dockerfiles into the default scan. Both improve our security posture; neither introduces new attack surface.

## AI Context Updates (.ai/)
- [ ] N/A — config + scanner-internal fixes; no architecture or workflow change

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable) — pending v1.0.0 release notes
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Closes # (n/a)

## Screenshots/Logs (if applicable)

```
$ argus scan supply-chain --no-spinner --verbose 2>&1 | grep "Container\|Output\|Parsed\|finding"
DEBUG    argus Container exited: code=0, duration=701ms, stdout=0 bytes, stderr=0 bytes
DEBUG    argus Output files: ['zizmor.json', 'actionlint.json']
DEBUG    argus Parsed 44 finding(s) from zizmor.json
INFO     argus Filtered 6 finding(s) from excluded paths for 'supply-chain'
INFO     argus Scanner 'supply-chain' completed in 838ms: 38 finding(s)
```
