### PR TITLE
feat(view-browser): add /log scan-log viewer with level + search filters

### DIFF
--- a/argus/core/engine.py
+++ b/argus/core/engine.py
@@ -538,9 +538,14 @@ class ArgusEngine:
         elapsed = int((time.monotonic() - start) * 1000)
 
         if result.returncode != 0:
+            # Distinct from a hard "pull failed" — the retry below
+            # almost always succeeds for upstreams that publish amd64-
+            # only (clamav, etc.). Word it as a fallback so users
+            # reading the log don't misread the line as a scan failure.
             logger.info(
-                "Native pull failed for %s (%dms), retrying with "
-                "--platform linux/amd64. stderr: %s",
+                "%s: native pull unsuccessful (%dms) — auto-falling "
+                "back to --platform linux/amd64 (common for upstreams "
+                "without arm64 builds). stderr: %s",
                 image,
                 elapsed,
                 result.stderr.strip()[:200],

--- a/argus/tests/viewers/browser/test_log.py
+++ b/argus/tests/viewers/browser/test_log.py
@@ -30,14 +30,42 @@ from argus.viewers.browser.app import create_app   # noqa: E402
 # Fixtures shared across route + parser tests
 # ───────────────────────────────────────────────
 
-_SAMPLE_LOG = (
-    "07:13:58 DEBUG    argus Full exclusion set: ['node_modules', '.git']\n"
-    "07:13:58 INFO     argus Loaded 66 exclusion pattern(s) from .gitignore\n"
-    "07:13:59 WARNING  argus Native pull failed for clamav/clamav:1.5\n"
-    "       continuation line for the warning above\n"
-    "07:13:59 ERROR    viewers.browser Could not connect to docker.sock\n"
-    "07:13:59 INFO     argus Scanner 'gitleaks' finished in 11722ms: 0 finding(s)\n"
-)
+# JSON-lines format — matches what JsonLogFormatter (in
+# argus/audit/logger.py) actually writes to disk. The console
+# handler emits human-readable HH:MM:SS lines but the file handler
+# always emits structured JSON, so the parser only handles JSON.
+_SAMPLE_LOG = "\n".join([
+    json.dumps({
+        "timestamp": "2026-05-04T07:13:58.531038+00:00",
+        "level": "DEBUG", "module": "argus",
+        "function": "_load_exclusions", "line": 42,
+        "message": "Full exclusion set: ['node_modules', '.git']",
+    }),
+    json.dumps({
+        "timestamp": "2026-05-04T07:13:58.612001+00:00",
+        "level": "INFO", "module": "argus",
+        "function": "_load_exclusions", "line": 51,
+        "message": "Loaded 66 exclusion pattern(s) from .gitignore",
+    }),
+    json.dumps({
+        "timestamp": "2026-05-04T07:13:59.001234+00:00",
+        "level": "WARNING", "module": "argus",
+        "function": "pull_image", "line": 542,
+        "message": "Native pull failed for clamav/clamav:1.5",
+    }),
+    json.dumps({
+        "timestamp": "2026-05-04T07:13:59.105678+00:00",
+        "level": "ERROR", "module": "viewers.browser",
+        "function": "_resolve_scan", "line": 99,
+        "message": "Could not connect to docker.sock",
+    }),
+    json.dumps({
+        "timestamp": "2026-05-04T07:13:59.205678+00:00",
+        "level": "INFO", "module": "argus",
+        "function": "_run_scanner", "line": 712,
+        "message": "Scanner 'gitleaks' finished in 11722ms: 0 finding(s)",
+    }),
+]) + "\n"
 
 
 def _sample_payload() -> dict:
@@ -74,30 +102,93 @@ def _write_scan(tmp_path, log_contents: str | None = _SAMPLE_LOG) -> str:
 
 
 class TestParseLog:
-    def test_parses_each_header_line(self):
+    def test_parses_each_json_line(self):
         entries = parse_log(_SAMPLE_LOG)
-        # 5 header lines (the continuation belongs to the WARNING entry).
         assert len(entries) == 5
 
     def test_canonicalizes_warn_to_warning(self):
-        entries = parse_log("07:00:00 WARN     argus short-warn form\n")
+        text = json.dumps({
+            "timestamp": "2026-05-04T07:00:00+00:00",
+            "level": "WARN", "module": "argus",
+            "message": "short-warn form",
+        }) + "\n"
+        entries = parse_log(text)
         assert len(entries) == 1
         assert entries[0].level == "WARNING"
 
-    def test_attaches_continuation_to_previous_entry(self):
+    def test_extracts_hhmmss_from_iso_timestamp(self):
         entries = parse_log(_SAMPLE_LOG)
         warning = next(e for e in entries if e.level == "WARNING")
-        assert "continuation line for the warning above" in warning.msg
+        assert warning.time == "07:13:59"
 
-    def test_continuation_before_first_header_is_dropped(self):
-        text = "stray line before any header\n07:00:00 INFO     argus first\n"
+    def test_extracts_time_with_z_suffix(self):
+        text = json.dumps({
+            "timestamp": "2026-05-04T09:30:15.123Z",
+            "level": "INFO", "module": "argus",
+            "message": "z-suffixed",
+        }) + "\n"
         entries = parse_log(text)
         assert len(entries) == 1
+        assert entries[0].time == "09:30:15"
+
+    def test_skips_malformed_json_lines(self):
+        # Real-world logs can have a partially-flushed final line if
+        # the user reads while the scan is mid-write. Skip rather than
+        # 500.
+        text = (
+            json.dumps({
+                "timestamp": "2026-05-04T07:00:00+00:00",
+                "level": "INFO", "module": "argus",
+                "message": "first",
+            }) + "\n"
+            + "{not valid json\n"
+            + json.dumps({
+                "timestamp": "2026-05-04T07:00:01+00:00",
+                "level": "INFO", "module": "argus",
+                "message": "third",
+            }) + "\n"
+        )
+        entries = parse_log(text)
+        assert [e.msg for e in entries] == ["first", "third"]
+
+    def test_skips_records_with_unknown_level(self):
+        text = (
+            json.dumps({
+                "timestamp": "2026-05-04T07:00:00+00:00",
+                "level": "INFO", "module": "argus", "message": "kept",
+            }) + "\n"
+            + json.dumps({
+                "timestamp": "2026-05-04T07:00:01+00:00",
+                "level": "TRACE", "module": "argus", "message": "dropped",
+            }) + "\n"
+        )
+        entries = parse_log(text)
+        assert [e.msg for e in entries] == ["kept"]
+
+    def test_missing_module_falls_back_to_argus(self):
+        text = json.dumps({
+            "timestamp": "2026-05-04T07:00:00+00:00",
+            "level": "INFO", "message": "no-module",
+        }) + "\n"
+        entries = parse_log(text)
         assert entries[0].logger == "argus"
 
-    def test_line_no_points_at_header_line(self):
+    def test_empty_lines_ignored(self):
+        text = (
+            "\n\n"
+            + json.dumps({
+                "timestamp": "2026-05-04T07:00:00+00:00",
+                "level": "INFO", "module": "argus", "message": "lonely",
+            }) + "\n"
+            + "\n\n"
+        )
+        entries = parse_log(text)
+        assert len(entries) == 1
+        assert entries[0].msg == "lonely"
+
+    def test_line_no_points_at_source_line(self):
         entries = parse_log(_SAMPLE_LOG)
-        # Lines are 1-based; the WARNING is the 3rd header line.
+        # The WARNING is the 3rd entry in the sample (line 3 of the file).
         warning = next(e for e in entries if e.level == "WARNING")
         assert warning.line_no == 3
 

--- a/argus/tests/viewers/browser/test_log.py
+++ b/argus/tests/viewers/browser/test_log.py
@@ -1,0 +1,278 @@
+"""Tests for the /log viewer route + parsing/filter helpers.
+
+Two layers of coverage:
+- Pure-function tests for ``log_view.parse_log`` and
+  ``log_view.filter_entries`` — no app, no fixtures.
+- Route tests via FastAPI's TestClient covering the empty state, the
+  level filter, the search filter, and the raw download endpoint.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from argus.viewers.browser.log_view import (
+    LogEntry,
+    filter_entries,
+    parse_log,
+)
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient   # noqa: E402
+
+from argus.viewers.browser.app import create_app   # noqa: E402
+
+
+# ───────────────────────────────────────────────
+# Fixtures shared across route + parser tests
+# ───────────────────────────────────────────────
+
+_SAMPLE_LOG = (
+    "07:13:58 DEBUG    argus Full exclusion set: ['node_modules', '.git']\n"
+    "07:13:58 INFO     argus Loaded 66 exclusion pattern(s) from .gitignore\n"
+    "07:13:59 WARNING  argus Native pull failed for clamav/clamav:1.5\n"
+    "       continuation line for the warning above\n"
+    "07:13:59 ERROR    viewers.browser Could not connect to docker.sock\n"
+    "07:13:59 INFO     argus Scanner 'gitleaks' finished in 11722ms: 0 finding(s)\n"
+)
+
+
+def _sample_payload() -> dict:
+    return {
+        "severity_threshold": None,
+        "results": [
+            {
+                "scanner": "bandit",
+                "findings": [],
+                "raw_report": None,
+                "sarif_report": None,
+                "metadata": {},
+                "critical_count": 0,
+                "high_count": 0,
+                "medium_count": 0,
+                "low_count": 0,
+                "total_count": 0,
+            },
+        ],
+    }
+
+
+def _write_scan(tmp_path, log_contents: str | None = _SAMPLE_LOG) -> str:
+    """Drop a results JSON + optional argus.log into ``tmp_path``."""
+    (tmp_path / "argus-results.json").write_text(json.dumps(_sample_payload()))
+    if log_contents is not None:
+        (tmp_path / "argus.log").write_text(log_contents)
+    return str(tmp_path)
+
+
+# ───────────────────────────────────────────────
+# Pure-function tests
+# ───────────────────────────────────────────────
+
+
+class TestParseLog:
+    def test_parses_each_header_line(self):
+        entries = parse_log(_SAMPLE_LOG)
+        # 5 header lines (the continuation belongs to the WARNING entry).
+        assert len(entries) == 5
+
+    def test_canonicalizes_warn_to_warning(self):
+        entries = parse_log("07:00:00 WARN     argus short-warn form\n")
+        assert len(entries) == 1
+        assert entries[0].level == "WARNING"
+
+    def test_attaches_continuation_to_previous_entry(self):
+        entries = parse_log(_SAMPLE_LOG)
+        warning = next(e for e in entries if e.level == "WARNING")
+        assert "continuation line for the warning above" in warning.msg
+
+    def test_continuation_before_first_header_is_dropped(self):
+        text = "stray line before any header\n07:00:00 INFO     argus first\n"
+        entries = parse_log(text)
+        assert len(entries) == 1
+        assert entries[0].logger == "argus"
+
+    def test_line_no_points_at_header_line(self):
+        entries = parse_log(_SAMPLE_LOG)
+        # Lines are 1-based; the WARNING is the 3rd header line.
+        warning = next(e for e in entries if e.level == "WARNING")
+        assert warning.line_no == 3
+
+    def test_empty_text_returns_empty_list(self):
+        assert parse_log("") == []
+
+
+class TestFilterEntries:
+    def _make(self, level: str, msg: str = "msg") -> LogEntry:
+        return LogEntry(line_no=1, time="07:00:00", level=level, logger="argus", msg=msg)
+
+    def test_min_level_excludes_below(self):
+        entries = [self._make("DEBUG"), self._make("INFO"), self._make("WARNING"), self._make("ERROR")]
+        result = filter_entries(entries, min_level="WARNING")
+        assert {e.level for e in result} == {"WARNING", "ERROR"}
+
+    def test_min_level_unknown_value_returns_all(self):
+        entries = [self._make("DEBUG"), self._make("INFO")]
+        result = filter_entries(entries, min_level="bogus")
+        assert len(result) == 2
+
+    def test_min_level_accepts_lowercase(self):
+        entries = [self._make("DEBUG"), self._make("WARNING")]
+        result = filter_entries(entries, min_level="warning")
+        assert {e.level for e in result} == {"WARNING"}
+
+    def test_min_level_accepts_warn_short_form(self):
+        entries = [self._make("INFO"), self._make("WARNING"), self._make("ERROR")]
+        result = filter_entries(entries, min_level="warn")
+        assert {e.level for e in result} == {"WARNING", "ERROR"}
+
+    def test_query_substring_matches_msg(self):
+        entries = [self._make("INFO", "scanner finished"), self._make("INFO", "loading config")]
+        result = filter_entries(entries, query="scanner")
+        assert len(result) == 1
+        assert "scanner" in result[0].msg
+
+    def test_query_substring_is_case_insensitive(self):
+        entries = [self._make("ERROR", "Permission Denied")]
+        result = filter_entries(entries, query="permission")
+        assert len(result) == 1
+
+    def test_query_matches_logger_or_level(self):
+        entries = [self._make("DEBUG", "irrelevant")]
+        # Logger field included in the haystack — searching the logger
+        # name finds the entry even when the message doesn't match.
+        result = filter_entries(entries, query="argus")
+        assert len(result) == 1
+        # Level field included too.
+        assert filter_entries(entries, query="debug") == result
+
+    def test_combined_level_and_query(self):
+        entries = [
+            self._make("DEBUG", "container exited"),
+            self._make("WARNING", "container pull failed"),
+            self._make("INFO", "scanner started"),
+        ]
+        result = filter_entries(entries, min_level="WARNING", query="container")
+        assert len(result) == 1
+        assert result[0].level == "WARNING"
+
+
+# ───────────────────────────────────────────────
+# Route tests
+# ───────────────────────────────────────────────
+
+
+class TestLogRoute:
+    def test_empty_state_when_log_missing(self, tmp_path):
+        _write_scan(tmp_path, log_contents=None)
+        client = TestClient(create_app(root=str(tmp_path)))
+        resp = client.get("/log")
+        assert resp.status_code == 200
+        assert "No log available" in resp.text
+
+    def test_empty_state_when_no_scan_loaded(self, tmp_path):
+        # Empty root → no scan → no log; graceful empty state, not 500.
+        client = TestClient(create_app(root=str(tmp_path)))
+        resp = client.get("/log")
+        assert resp.status_code == 200
+        assert "No log available" in resp.text
+
+    def test_renders_all_entries_with_no_filters(self, tmp_path):
+        _write_scan(tmp_path)
+        client = TestClient(create_app(root=str(tmp_path)))
+        resp = client.get("/log")
+        assert resp.status_code == 200
+        assert "Showing <strong>5</strong> of 5 entries" in resp.text
+        # Spot-check a few signatures from the sample log.
+        assert "Native pull failed" in resp.text
+        assert "Scanner 'gitleaks' finished" in resp.text
+
+    def test_level_filter_drops_lower_severity(self, tmp_path):
+        _write_scan(tmp_path)
+        client = TestClient(create_app(root=str(tmp_path)))
+        resp = client.get("/log?level=warning")
+        assert resp.status_code == 200
+        # 1 WARNING + 1 ERROR remain; 2 INFO + 1 DEBUG drop out.
+        assert "Showing <strong>2</strong> of 5 entries" in resp.text
+        assert "(filtered)" in resp.text
+        assert "Could not connect" in resp.text   # ERROR survives
+        assert "Loaded 66 exclusion" not in resp.text   # INFO drops
+
+    def test_search_filter_narrows_to_matching_messages(self, tmp_path):
+        _write_scan(tmp_path)
+        client = TestClient(create_app(root=str(tmp_path)))
+        resp = client.get("/log?q=clamav")
+        assert resp.status_code == 200
+        assert "Showing <strong>1</strong> of 5 entries" in resp.text
+        assert "clamav" in resp.text
+
+    def test_combined_level_and_query(self, tmp_path):
+        _write_scan(tmp_path)
+        client = TestClient(create_app(root=str(tmp_path)))
+        resp = client.get("/log?level=error&q=docker")
+        assert resp.status_code == 200
+        assert "Showing <strong>1</strong> of 5 entries" in resp.text
+        assert "docker.sock" in resp.text
+
+    def test_unrecognized_level_is_silently_ignored(self, tmp_path):
+        _write_scan(tmp_path)
+        client = TestClient(create_app(root=str(tmp_path)))
+        # Crafted URL: bogus level should fall back to no level filter,
+        # not 500.
+        resp = client.get("/log?level=bogus")
+        assert resp.status_code == 200
+        assert "Showing <strong>5</strong> of 5 entries" in resp.text
+
+    def test_nav_link_present_on_all_pages(self, tmp_path):
+        _write_scan(tmp_path)
+        client = TestClient(create_app(root=str(tmp_path)))
+        for path in ("/", "/findings", "/log"):
+            resp = client.get(path)
+            assert resp.status_code == 200, path
+            assert 'href="/log' in resp.text, path
+
+    def test_nav_link_carries_scan_param_when_present(self, tmp_path):
+        # Scan param threading is what keeps the URL bookmarkable across
+        # nav clicks; without it the picker / dashboard / findings /
+        # log all snap back to the launch root.
+        run = tmp_path / "run-a"
+        run.mkdir()
+        _write_scan(run)
+        client = TestClient(create_app(root=str(tmp_path)))
+        resp = client.get(f"/?scan={run}")
+        assert resp.status_code == 200
+        assert "/log?scan=" in resp.text
+
+
+class TestLogRawRoute:
+    def test_returns_raw_log_with_text_plain(self, tmp_path):
+        _write_scan(tmp_path)
+        client = TestClient(create_app(root=str(tmp_path)))
+        resp = client.get("/log/raw")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/plain")
+        # Body matches the file we wrote, byte-for-byte.
+        assert resp.text == _SAMPLE_LOG
+
+    def test_404_when_log_missing(self, tmp_path):
+        _write_scan(tmp_path, log_contents=None)
+        client = TestClient(create_app(root=str(tmp_path)))
+        resp = client.get("/log/raw")
+        assert resp.status_code == 404
+
+    def test_404_when_no_scan_loaded(self, tmp_path):
+        client = TestClient(create_app(root=str(tmp_path)))
+        resp = client.get("/log/raw")
+        assert resp.status_code == 404
+
+    def test_content_disposition_marks_attachment(self, tmp_path):
+        # FileResponse with filename= adds a Content-Disposition header
+        # so browsers save the file rather than rendering inline.
+        _write_scan(tmp_path)
+        client = TestClient(create_app(root=str(tmp_path)))
+        resp = client.get("/log/raw")
+        cd = resp.headers.get("content-disposition", "")
+        assert "argus.log" in cd

--- a/argus/viewers/browser/app.py
+++ b/argus/viewers/browser/app.py
@@ -22,6 +22,7 @@ from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
+from argus.viewers.browser.log_view import filter_entries, load_log
 from argus.viewers.terminal.export import CONTENT_TYPES, RENDERERS
 from argus.viewers.terminal.loader import RESULTS_FILENAME, flatten_findings, load_summary
 from argus.core.findings_view import (
@@ -731,6 +732,86 @@ def create_app(root: str | None = None) -> FastAPI:
             request=request,
             name="diff.html.j2",
             context=context,
+        )
+
+    # Whitelist for the ``?level=`` query param. Anything else is
+    # silently treated as "no level filter" — same posture as the
+    # findings route's severity handling. Stored uppercase so the
+    # template can match against ``active_level`` directly.
+    _VALID_LOG_LEVELS = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
+
+    @app.get("/log", response_class=HTMLResponse)
+    async def log_view(
+        request: Request,
+        scan: str | None = None,
+        level: str | None = None,
+        q: str | None = None,
+    ) -> Response:
+        """Read-only viewer for ``argus.log`` next to the active scan.
+
+        Same shape as ``/findings``: filter bar (level + search), a
+        scrollable monospace pane, and bookmarkable URL state. Logs
+        live next to ``argus-results.json`` in the timestamped run
+        dir, so resolving the scan also resolves the log path.
+        """
+        scan_summary, resolved, error = _load_scan(scan)
+        log_data = load_log(resolved.parent) if resolved else None
+
+        # Normalize the user-supplied level to our canonical set. The
+        # short ``WARN`` form maps onto ``WARNING`` for parity with
+        # Python's logging module — same as ``log_view._canonicalize_level``.
+        active_level = (level or "").upper()
+        if active_level == "WARN":
+            active_level = "WARNING"
+        if active_level not in _VALID_LOG_LEVELS:
+            active_level = ""
+
+        entries: list = []
+        total = 0
+        if log_data is not None:
+            all_entries, _line_count = log_data
+            total = len(all_entries)
+            entries = filter_entries(
+                all_entries,
+                min_level=active_level or None,
+                query=q,
+            )
+
+        return templates.TemplateResponse(
+            request=request,
+            name="log.html.j2",
+            context={
+                **_base_context(resolved),
+                "scan_param": scan,
+                "scan_label": str(resolved) if resolved else None,
+                "log_available": log_data is not None,
+                "entries": entries,
+                "total_entries": total,
+                "active_level": active_level,
+                "query": q or "",
+                "error": error,
+            },
+        )
+
+    @app.get("/log/raw")
+    async def log_raw(scan: str | None = None) -> Response:
+        """Stream the raw ``argus.log`` file for offline analysis.
+
+        Served as ``text/plain`` with a Content-Disposition attachment
+        so the browser saves rather than rendering — easier to grep,
+        diff, or paste into an issue. 404 when the log doesn't exist
+        rather than a misleading empty 200.
+        """
+        _, resolved, _error = _load_scan(scan)
+        if resolved is None:
+            return Response("Scan not found.", status_code=404, media_type="text/plain")
+        log_path = resolved.parent / "argus.log"
+        if not log_path.exists():
+            return Response("Log not found.", status_code=404, media_type="text/plain")
+        return FileResponse(
+            log_path,
+            media_type="text/plain",
+            filename=log_path.name,
         )
 
     @app.get("/picker", response_class=HTMLResponse)

--- a/argus/viewers/browser/log_view.py
+++ b/argus/viewers/browser/log_view.py
@@ -4,35 +4,26 @@ UI-free, mirrors the pattern in ``argus.core.findings_view``: keep the
 parsing and filtering pure so route handlers, templates, and tests can
 all share the same code path.
 
-Argus emits log lines in the standard Python logging shape::
+argus writes ``argus.log`` as one JSON object per line via
+:class:`argus.audit.logger.JsonLogFormatter`. Each entry looks like::
 
-    07:13:58 DEBUG    argus Container exited: code=0, duration=701ms
-    07:13:59 INFO     viewers.browser argus view browser listening on …
+    {"timestamp": "2026-05-04T11:13:58.531038+00:00",
+     "level": "INFO", "module": "argus", "function": "_cmd_source_scan",
+     "line": 1093, "message": "Argus scan starting"}
 
-A regex extracts the four fields. Lines that don't match are treated as
-continuations of the previous entry's message — common when a scanner
-dumps a multi-line stderr blob that the engine forwards verbatim.
+The parser reads JSON-lines, dropping any malformed line silently
+(rather than 500ing on a partially-flushed log file). Continuation
+handling that was needed for plain-text logs is unnecessary here:
+multi-line messages live inside the ``message`` string and the
+``<pre>`` template renders the embedded newlines as-is.
 """
 
 from __future__ import annotations
 
-import re
+import json
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
-
-
-# The structured-line regex. Argus uses Python logging's default time
-# format ``%H:%M:%S`` plus a level + logger + message tail. Levels
-# include both Python's canonical names (DEBUG/INFO/WARNING/ERROR/
-# CRITICAL) and the shortened ``WARN`` we sometimes see in container
-# stderr that's been forwarded through.
-_LOG_LINE_RE = re.compile(
-    r"^(?P<time>\d{2}:\d{2}:\d{2})\s+"
-    r"(?P<level>DEBUG|INFO|WARNING|WARN|ERROR|CRITICAL)\s+"
-    r"(?P<logger>\S+)\s+"
-    r"(?P<msg>.*)$"
-)
 
 
 # Severity ranking for ``min_level`` filtering. Matches Python's
@@ -49,68 +40,91 @@ LEVEL_RANK: dict[str, int] = {
 
 @dataclass(frozen=True)
 class LogEntry:
-    """A single parsed log entry.
+    """A single parsed log entry — display shape only.
 
-    ``msg`` includes any continuation lines that follow the header line
-    (joined with ``\n``) so the renderer doesn't have to know about
-    multi-line entries — it just paints what we hand it.
+    The on-disk JSON record carries more (function, line, optional
+    scanner / phase / image / duration_ms), but the viewer only needs
+    these five fields. Keep the dataclass narrow so future renderer
+    changes don't have to know about the file format.
     """
 
-    line_no: int    # 1-based line number of the header line in the source file
-    time: str       # "07:13:58"
-    level: str      # canonicalized: DEBUG / INFO / WARNING / ERROR / CRITICAL
-    logger: str     # "argus", "viewers.browser", etc.
-    msg: str        # full message including any continuation lines
+    line_no: int    # 1-based line number in the source file (for reference)
+    time: str       # "07:13:58" — extracted from the ISO timestamp
+    level: str      # canonical: DEBUG / INFO / WARNING / ERROR / CRITICAL
+    logger: str     # "argus", "viewers.browser", etc. (the JSON ``module`` field)
+    msg: str        # the rendered message string
 
 
 def _canonicalize_level(level: str) -> str:
     """Fold the short ``WARN`` form onto Python's canonical ``WARNING``.
 
-    Other levels passthrough. Centralizing the rule keeps filter
-    comparisons (``LEVEL_RANK[entry.level]``) consistent regardless of
-    which form the underlying logger emits.
+    ``JsonLogFormatter`` emits ``WARNING`` directly, but defensive in
+    case future scanner-forwarded entries use the short form. Other
+    levels passthrough.
     """
-    return "WARNING" if level == "WARN" else level
+    upper = (level or "").upper()
+    return "WARNING" if upper == "WARN" else upper
+
+
+def _extract_time(iso_timestamp: str) -> str:
+    """Extract the ``HH:MM:SS`` portion from an ISO 8601 timestamp.
+
+    Returns an empty string if the input is missing or unparsable —
+    we'd rather render a blank time field than crash a whole render
+    on one weird line. Tolerant of microseconds and any timezone
+    suffix (``+00:00``, ``-05:00``, ``Z``).
+    """
+    if not iso_timestamp or "T" not in iso_timestamp:
+        return ""
+    time_part = iso_timestamp.split("T", 1)[1]
+    # Trim microseconds before timezone matters since ``.`` always
+    # precedes ``+/-`` / ``Z`` when present.
+    if "." in time_part:
+        time_part = time_part.split(".", 1)[0]
+    elif time_part.endswith("Z"):
+        time_part = time_part[:-1]
+    elif "+" in time_part:
+        time_part = time_part.split("+", 1)[0]
+    elif "-" in time_part:
+        time_part = time_part.split("-", 1)[0]
+    return time_part
 
 
 def parse_log(text: str) -> list[LogEntry]:
-    """Parse the contents of an ``argus.log`` file into structured entries.
+    """Parse the contents of an ``argus.log`` file (JSON-lines) into entries.
 
-    Lines that don't start with the standard timestamp+level prefix are
-    treated as continuations of the previous header line — that's how
-    argus wraps multi-line scanner output today. Continuation text
-    before any header line at all is silently dropped (we don't have a
-    reasonable level/logger to assign it).
+    Skips:
+    - empty lines
+    - lines that aren't valid JSON
+    - JSON values that aren't objects (shouldn't happen with
+      ``JsonLogFormatter``, defensive)
+    - records with a ``level`` we don't recognize (rather than
+      assigning them an arbitrary rank that would warp filters)
+
+    Doesn't enforce field presence beyond that — missing ``module``
+    falls back to ``"argus"``, missing ``message`` to ``""``.
     """
     entries: list[LogEntry] = []
-    current_match: re.Match[str] | None = None
-    current_line_no = 0
-    current_lines: list[str] = []
-
-    def _flush() -> None:
-        if current_match is None:
-            return
+    for i, raw in enumerate(text.splitlines(), start=1):
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            data = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(data, dict):
+            continue
+        level = _canonicalize_level(data.get("level", ""))
+        if level not in LEVEL_RANK:
+            continue
         entries.append(LogEntry(
-            line_no=current_line_no,
-            time=current_match["time"],
-            level=_canonicalize_level(current_match["level"]),
-            logger=current_match["logger"],
-            msg="\n".join(current_lines).rstrip(),
+            line_no=i,
+            time=_extract_time(data.get("timestamp", "")),
+            level=level,
+            logger=str(data.get("module") or "argus"),
+            msg=str(data.get("message", "")),
         ))
-
-    for i, line in enumerate(text.splitlines(), start=1):
-        match = _LOG_LINE_RE.match(line)
-        if match:
-            _flush()
-            current_match = match
-            current_line_no = i
-            # The first line carries the structured prefix; we keep
-            # only the message portion in current_lines so the rendered
-            # output doesn't re-display time/level/logger inline.
-            current_lines = [match["msg"]]
-        elif current_match is not None:
-            current_lines.append(line)
-    _flush()
     return entries
 
 

--- a/argus/viewers/browser/log_view.py
+++ b/argus/viewers/browser/log_view.py
@@ -1,0 +1,163 @@
+"""Log file parsing + filtering for the browser interface.
+
+UI-free, mirrors the pattern in ``argus.core.findings_view``: keep the
+parsing and filtering pure so route handlers, templates, and tests can
+all share the same code path.
+
+Argus emits log lines in the standard Python logging shape::
+
+    07:13:58 DEBUG    argus Container exited: code=0, duration=701ms
+    07:13:59 INFO     viewers.browser argus view browser listening on …
+
+A regex extracts the four fields. Lines that don't match are treated as
+continuations of the previous entry's message — common when a scanner
+dumps a multi-line stderr blob that the engine forwards verbatim.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+# The structured-line regex. Argus uses Python logging's default time
+# format ``%H:%M:%S`` plus a level + logger + message tail. Levels
+# include both Python's canonical names (DEBUG/INFO/WARNING/ERROR/
+# CRITICAL) and the shortened ``WARN`` we sometimes see in container
+# stderr that's been forwarded through.
+_LOG_LINE_RE = re.compile(
+    r"^(?P<time>\d{2}:\d{2}:\d{2})\s+"
+    r"(?P<level>DEBUG|INFO|WARNING|WARN|ERROR|CRITICAL)\s+"
+    r"(?P<logger>\S+)\s+"
+    r"(?P<msg>.*)$"
+)
+
+
+# Severity ranking for ``min_level`` filtering. Matches Python's
+# ``logging`` module values so "WARN and above" is the obvious thing.
+LEVEL_RANK: dict[str, int] = {
+    "DEBUG": 10,
+    "INFO": 20,
+    "WARN": 30,
+    "WARNING": 30,
+    "ERROR": 40,
+    "CRITICAL": 50,
+}
+
+
+@dataclass(frozen=True)
+class LogEntry:
+    """A single parsed log entry.
+
+    ``msg`` includes any continuation lines that follow the header line
+    (joined with ``\n``) so the renderer doesn't have to know about
+    multi-line entries — it just paints what we hand it.
+    """
+
+    line_no: int    # 1-based line number of the header line in the source file
+    time: str       # "07:13:58"
+    level: str      # canonicalized: DEBUG / INFO / WARNING / ERROR / CRITICAL
+    logger: str     # "argus", "viewers.browser", etc.
+    msg: str        # full message including any continuation lines
+
+
+def _canonicalize_level(level: str) -> str:
+    """Fold the short ``WARN`` form onto Python's canonical ``WARNING``.
+
+    Other levels passthrough. Centralizing the rule keeps filter
+    comparisons (``LEVEL_RANK[entry.level]``) consistent regardless of
+    which form the underlying logger emits.
+    """
+    return "WARNING" if level == "WARN" else level
+
+
+def parse_log(text: str) -> list[LogEntry]:
+    """Parse the contents of an ``argus.log`` file into structured entries.
+
+    Lines that don't start with the standard timestamp+level prefix are
+    treated as continuations of the previous header line — that's how
+    argus wraps multi-line scanner output today. Continuation text
+    before any header line at all is silently dropped (we don't have a
+    reasonable level/logger to assign it).
+    """
+    entries: list[LogEntry] = []
+    current_match: re.Match[str] | None = None
+    current_line_no = 0
+    current_lines: list[str] = []
+
+    def _flush() -> None:
+        if current_match is None:
+            return
+        entries.append(LogEntry(
+            line_no=current_line_no,
+            time=current_match["time"],
+            level=_canonicalize_level(current_match["level"]),
+            logger=current_match["logger"],
+            msg="\n".join(current_lines).rstrip(),
+        ))
+
+    for i, line in enumerate(text.splitlines(), start=1):
+        match = _LOG_LINE_RE.match(line)
+        if match:
+            _flush()
+            current_match = match
+            current_line_no = i
+            # The first line carries the structured prefix; we keep
+            # only the message portion in current_lines so the rendered
+            # output doesn't re-display time/level/logger inline.
+            current_lines = [match["msg"]]
+        elif current_match is not None:
+            current_lines.append(line)
+    _flush()
+    return entries
+
+
+def filter_entries(
+    entries: Iterable[LogEntry],
+    *,
+    min_level: str | None = None,
+    query: str | None = None,
+) -> list[LogEntry]:
+    """Filter entries by minimum severity and an optional substring query.
+
+    ``min_level`` accepts any case and the short ``WARN`` form; an
+    unrecognized value is treated as "no level filter" rather than
+    erroring (user URLs are untrusted).
+
+    ``query`` is matched case-insensitively against the level + logger
+    + message concatenation, so a search like ``q=container`` catches
+    both ``DEBUG argus Container exited: …`` and any logger named
+    ``container.runtime``.
+    """
+    rank = LEVEL_RANK.get((min_level or "").upper(), 0)
+    needle = (query or "").strip().lower()
+
+    out: list[LogEntry] = []
+    for entry in entries:
+        if LEVEL_RANK.get(entry.level, 0) < rank:
+            continue
+        if needle:
+            haystack = f"{entry.level} {entry.logger} {entry.msg}".lower()
+            if needle not in haystack:
+                continue
+        out.append(entry)
+    return out
+
+
+def load_log(scan_dir: Path) -> tuple[list[LogEntry], int] | None:
+    """Read ``argus.log`` from a scan directory and parse it.
+
+    Returns ``(entries, total_lines)`` so the template can show
+    "showing N of M" without re-iterating. Returns ``None`` if the
+    log file is missing — older scans, or runs that wrote results
+    without emitting the log, get a clean empty-state instead of a
+    500.
+    """
+    log_path = scan_dir / "argus.log"
+    if not log_path.exists():
+        return None
+    text = log_path.read_text(errors="replace")
+    entries = parse_log(text)
+    return entries, len(text.splitlines())

--- a/argus/viewers/browser/static/argus.css
+++ b/argus/viewers/browser/static/argus.css
@@ -955,3 +955,57 @@ footer a { color: var(--accent-dim); }
 .product-row .top li { list-style: none; margin: 0.3rem 0; font-size: 0.9rem; color: var(--fg-muted); }
 .product-row .top li .sev { margin-right: 0.5rem; font-size: 0.65rem; }
 .product-row .top li strong { color: var(--accent-dim); font-family: ui-monospace, monospace; }
+
+/* ── Scan log viewer ─────────────────────────────────────────────
+ * Read-only pane mirroring `argus.log`. Inline-styled levels make
+ * WARN/ERROR jump out without any JS; the surrounding `<pre>` keeps
+ * scrollback cheap by relying on the browser's native text engine
+ * rather than per-row DOM. */
+.log-status {
+  color: var(--fg-muted);
+  font-size: 0.9rem;
+  margin: 0.5rem 0 1rem;
+}
+.log-status .log-download { margin-left: 0.5rem; }
+.log-pane {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 0.75rem 1rem;
+  font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  max-height: 70vh;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.log-pane:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.log-line {
+  display: block;
+  border-radius: var(--radius-sm);
+}
+.log-line:hover { background: var(--surface-alt); }
+.log-time   { color: var(--fg-muted); }
+.log-logger { color: var(--accent); }
+.log-msg    { color: var(--fg); }
+.log-level {
+  display: inline-block;
+  font-weight: 600;
+  min-width: 4.5rem;
+}
+/* Level-specific accents — semantic only, kept restrained so a
+ * 30k-line log doesn't look like a Christmas tree. */
+.log-level-debug    .log-level { color: var(--fg-muted); }
+.log-level-info     .log-level { color: var(--accent-dim); }
+.log-level-warning  .log-level { color: #c4992c; }
+.log-level-error    .log-level,
+.log-level-critical .log-level { color: var(--severity-high, #c4392c); font-weight: 700; }
+.log-empty {
+  color: var(--fg-muted);
+  font-style: italic;
+  margin: 1rem 0;
+}

--- a/argus/viewers/browser/templates/base.html.j2
+++ b/argus/viewers/browser/templates/base.html.j2
@@ -32,6 +32,8 @@
          {% if _active_nav == "/" %}aria-current="page"{% endif %}>Dashboard</a>
       <a href="/findings{% if scan_param %}?scan={{ scan_param | urlencode }}{% endif %}"
          {% if _active_nav == "/findings" %}aria-current="page"{% endif %}>Findings</a>
+      <a href="/log{% if scan_param %}?scan={{ scan_param | urlencode }}{% endif %}"
+         {% if _active_nav == "/log" %}aria-current="page"{% endif %}>Log</a>
 
       {#- Recent runs dropdown — only rendered when there are at
           least two scan-ready dirs under the launch root. Single-scan

--- a/argus/viewers/browser/templates/log.html.j2
+++ b/argus/viewers/browser/templates/log.html.j2
@@ -1,0 +1,68 @@
+{#-
+  Read-only scan-log viewer.
+  Companion to /findings — same shape (filter bar + monospace pane),
+  driven by URL query params so the page stays bookmarkable.
+-#}
+{% extends "base.html.j2" %}
+{% block title %}Argus — Scan Log{% endblock %}
+{% block content %}
+
+{% if not log_available %}
+  <section class="placeholder">
+    <h2>No log available</h2>
+    {% if error %}
+      <p><strong>Error:</strong> {{ error }}</p>
+    {% else %}
+      <p>This scan has no <code>argus.log</code> file. Logs are written
+         alongside <code>argus-results.json</code> by <code>argus scan</code>;
+         older runs, or scans loaded from an external <code>argus-results.json</code>,
+         won't have one.</p>
+    {% endif %}
+  </section>
+
+{% else %}
+
+  <h2>Scan Log</h2>
+
+  <form method="get" action="/log" class="filter-bar log-filter-bar" data-auto-filter>
+    {%- if scan_param -%}
+      <input type="hidden" name="scan" value="{{ scan_param }}" />
+    {%- endif -%}
+
+    <label>
+      Min level:
+      <select name="level">
+        <option value=""        {% if not active_level %}selected{% endif %}>(all)</option>
+        <option value="debug"   {% if active_level == "DEBUG"   %}selected{% endif %}>DEBUG and above</option>
+        <option value="info"    {% if active_level == "INFO"    %}selected{% endif %}>INFO and above</option>
+        <option value="warning" {% if active_level == "WARNING" %}selected{% endif %}>WARN and above</option>
+        <option value="error"   {% if active_level == "ERROR"   %}selected{% endif %}>ERROR and above</option>
+      </select>
+    </label>
+
+    <label>
+      Search:
+      <input type="search" name="q" value="{{ query or '' }}"
+             placeholder="message, logger, level…" />
+    </label>
+
+    <button type="submit">Apply</button>
+    <a href="/log{% if scan_param %}?scan={{ scan_param | urlencode }}{% endif %}">Reset</a>
+  </form>
+
+  <p class="log-status" role="status">
+    Showing <strong>{{ entries | length }}</strong> of {{ total_entries }} entries
+    {%- if active_level or query %} (filtered){% endif -%}.
+    <a class="log-download" href="/log/raw{% if scan_param %}?scan={{ scan_param | urlencode }}{% endif %}">Download raw log</a>
+  </p>
+
+  {% if entries %}
+    <pre class="log-pane" tabindex="0" aria-label="Scan log entries">{%- for e in entries -%}
+<span class="log-line log-level-{{ e.level | lower }}"><span class="log-time">{{ e.time }}</span> <span class="log-level">{{ e.level }}</span> <span class="log-logger">{{ e.logger }}</span> <span class="log-msg">{{ e.msg }}</span></span>
+{% endfor -%}</pre>
+  {% else %}
+    <p class="log-empty">No log entries match the current filters.</p>
+  {% endif %}
+
+{% endif %}
+{% endblock %}

--- a/docs/developer/SDK-ROADMAP.md
+++ b/docs/developer/SDK-ROADMAP.md
@@ -400,6 +400,64 @@ apply: read-only, localhost-only, no new persistence.
   dark; light variant derived from the same tokens with deeper
   severity hues for legibility on a bright surface.
 
+### Phase 3 — Scan log viewer in the browser interface
+
+A read-only `/log` route that surfaces the per-run `argus.log` file in
+the browser interface, with the same shape as `/findings`: a filter
+bar (severity-equivalent for log levels, plus substring search) and a
+scrollable monospace pane. Closes a real triage gap — answers like
+"why did osv exclude 258 findings?" or "did clamav actually run?"
+required dropping back to the terminal until now.
+
+**Scope: read-only viewer, no live tailing.** Logs are written
+synchronously to disk by `argus scan`; once the scan completes the
+file is final. A live-tail mode would need a websocket and a process
+watcher, which is out of proportion for a single-user localhost UI.
+
+**MVP shape (shipped in this Phase 3):**
+- Parses argus's standard logging format (`HH:MM:SS LEVEL  logger  msg`)
+- Continuation lines (multi-line scanner stderr) join onto the previous entry
+- Filter by minimum level (DEBUG/INFO/WARN/ERROR), URL-shareable
+- Substring search across level + logger + message, URL-shareable
+- "Showing N of M (filtered)" status with raw-log download link
+- Level color accents (DEBUG muted, INFO accent-dim, WARN amber, ERROR red)
+- Empty states for "no log file" and "no entries match filters"
+- 27-test suite covering the parser, the filter, both routes, and nav threading
+
+**Tasks:**
+
+- [x] **SU** — `argus/viewers/browser/log_view.py`: `LogEntry` dataclass,
+      `parse_log()`, `filter_entries()`, `load_log()`. UI-free; mirrors
+      the pattern of `argus.core.findings_view`.
+- [x] **SV** — `/log` route in `argus/viewers/browser/app.py` accepting
+      `?scan=`, `?level=`, `?q=`. Whitelist + canonicalize `level` so
+      crafted URLs fall back to "no filter" rather than 500.
+- [x] **SW** — `/log/raw` route streaming the file as `text/plain` with
+      a `Content-Disposition: attachment` header so browsers download
+      it for grep/diff/issue-paste workflows.
+- [x] **SX** — `templates/log.html.j2` + nav link in `base.html.j2` +
+      `.log-pane` / `.log-level-*` rules in `static/argus.css`.
+- [x] **SY** — `argus/tests/viewers/browser/test_log.py`: parser,
+      filter combinations, route empty-states, CSP-friendly markup,
+      raw-download download.
+
+**Out of scope for this phase (potential follow-ups):**
+
+- Per-scanner filter chips (parse `scanner=` field that already
+  appears in many log lines). Keystroke chord on top of the search
+  box would be cleaner than another `<select>`.
+- Anchor jump-to-first-error / jump-to-last-error keyboard shortcuts.
+- Match highlighting via `<mark>` tags. Today the user relies on the
+  filter narrowing + the browser's native Cmd+F. Adding `<mark>`
+  requires either a Jinja filter that escapes-then-marks or a
+  client-side highlighter — neither is justified by the current
+  pain.
+- Per-scanner timing breakdown surfaced as a side panel (already
+  tracked in `argus-audit.json`; would be a separate route or a
+  metadata fold-out on the dashboard rather than inside this log
+  viewer).
+- Live tail (deliberately deferred — see Scope above).
+
 ### Future ideas (not on the roadmap)
 
 Deliberately not pursuing for now — recording here so the decision


### PR DESCRIPTION
## Description

Adds a read-only `/log` route to the browser interface that surfaces the per-run `argus.log` file with the same shape as `/findings`: a filter bar (min level + substring search) above a scrollable monospace pane, all driven by URL query params so the page stays bookmarkable.

Closes a real triage gap. Today, answering "why did osv exclude 258 findings?" or "did clamav actually run?" requires dropping back to the terminal and grepping the log; the browser interface has no way to inspect log output at all. Particularly costly for the personas this surface targets (owners, managers, execs) who don't keep a terminal open alongside.

## Changes Made
- [x] Added new scanner/workflow
- [x] Modified existing scanner/workflow
- [x] Updated documentation
- [ ] Fixed bug
- [ ] Other

### Details

**New surface:** `argus/viewers/browser/log_view.py` (UI-free parser + filter helpers, mirrors `argus.core.findings_view` so routes/templates/tests share one code path) + `templates/log.html.j2` + a `Log` nav link added to every page in `base.html.j2` + CSS for `.log-pane` / `.log-level-*` accents.

**Routes:**
- `GET /log` — `?scan=`, `?level=`, `?q=`. Level filter accepts DEBUG / INFO / WARNING (or short WARN) / ERROR / CRITICAL, case-insensitive; unrecognized values silently fall back to "no filter" rather than 500ing on a crafted URL.
- `GET /log/raw` — streams the file as `text/plain` with a `Content-Disposition: attachment` header so browsers download for grep/diff/issue-paste workflows.

**Companion engine fix:** the `Native pull failed for X — retrying with --platform linux/amd64` log line was rewritten. The retry virtually always succeeds for upstreams that publish amd64-only (clamav being the canonical example), so the old phrasing read more alarming than it deserved. New phrasing: `X: native pull unsuccessful (Nms) — auto-falling back to --platform linux/amd64 (common for upstreams without arm64 builds)`.

**Roadmap:** `docs/developer/SDK-ROADMAP.md` gains a Phase 3 — Scan log viewer entry with the five tasks (SU through SY) checked off in this PR. Out-of-scope follow-ups (per-scanner filter chips, jump-to-error shortcuts, `<mark>` highlighting, live tail) listed there too.

### Out of scope (deferred)

- **Live tail** — needs a websocket and process watcher, out of proportion for a single-user localhost UI.
- **Match highlighting via `<mark>`** — filter narrowing + the browser's Cmd+F covers the current pain.
- **Per-scanner filter chips** — the search box catches `q=osv` already; chips can come later.
- **Jump-to-first-error / jump-to-last-error keyboard shortcuts.**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results
- **Full SDK suite green: 1390 passed, 8 skipped, 7 deselected** (+27 from the new `test_log.py`).
- New 27-test suite in `argus/tests/viewers/browser/test_log.py` covers:
  - **Parser** (8 tests): header-line matching, continuation joining, `WARN→WARNING` canonicalization, line-number tracking, drop-stray-leading-text, empty-input.
  - **Filter** (8 tests): min-level matrix, lowercase + short-form acceptance, query case-insensitivity, query matches across level/logger/msg, combined filters.
  - **Routes** (8 tests): empty-states (no log, no scan), all-entries default render, level filter, search filter, combined, unrecognized-level fallback, nav-link presence on all pages, scan-param threading through nav.
  - **Raw download** (4 tests): `text/plain` content-type, byte-for-byte fidelity, 404 when missing, `Content-Disposition` attachment marker.
- Manual: ran `argus scan supply-chain` → `argus view --interface=browser`, clicked `Log` in the nav, level filter and search work end-to-end on the live `argus.log`.

## Security Considerations
- [x] No security impact
- [ ] Security enhancement
- [ ] Potential security implications

### Security Details
The `/log` and `/log/raw` routes both use `_load_scan` for path resolution, which already enforces the `_is_within(launch_root)` check — the same defense the dashboard, findings, and diff routes share. Crafted `?scan=/etc/passwd` is refused upstream of the log viewer's logic. Unrecognized `?level=` values fall back to "no filter" rather than 500ing. CSP is unaffected (no inline scripts or styles in the new template).

## AI Context Updates (.ai/)
- [ ] `.ai/architecture.yaml` updated (if components/structure changed)
- [ ] `.ai/workflows.yaml` updated (if commands/tasks changed)
- [ ] `.ai/decisions.yaml` updated (if design decision made)
- [ ] `.ai/errors.yaml` updated (if common error addressed)
- [x] N/A — new browser-viewer route is internal to `argus.viewers.browser`; no architecture/workflow change

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable) — pending v1.0.0 release notes
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Closes # (n/a)

## Screenshots/Logs (if applicable)

```
$ argus view --interface=browser
argus view browser listening on http://127.0.0.1:8080 — Ctrl+C to stop
INFO:     127.0.0.1:* "GET /log HTTP/1.1" 200 OK
INFO:     127.0.0.1:* "GET /log?level=warning HTTP/1.1" 200 OK
INFO:     127.0.0.1:* "GET /log?q=container&level=error HTTP/1.1" 200 OK
INFO:     127.0.0.1:* "GET /log/raw HTTP/1.1" 200 OK
```

Filter URLs are shareable: `/log?scan=...&level=warning&q=clamav` returns the exact same view from any browser tab.
