### PR TITLE
feat(view): config-aware remediation when argus-results.json is missing

### DIFF
--- a/argus.example.yml
+++ b/argus.example.yml
@@ -44,6 +44,11 @@ scanners:
   #   target_url: "http://localhost:3000"
 
 reporting:
+  # ``argus-results.json`` is the canonical scan artifact and is
+  # always written regardless of this list — the viewers, the audit
+  # manifest, and the ``argus report`` subcommand all consume it.
+  # This list selects which *additional* human-readable reports to
+  # emit alongside the JSON. Available: terminal, markdown, sarif.
   formats:
     - terminal
     - sarif

--- a/argus/cli.py
+++ b/argus/cli.py
@@ -230,6 +230,13 @@ def _build_view_parser(subparsers: argparse._SubParsersAction) -> None:
              "stdout is a TTY; CI and other non-interactive contexts already "
              "skip auto-open without this flag.",
     )
+    view_parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Validate that the resolved scan directory contains "
+             "argus-results.json and print actionable remediation if not. "
+             "Doesn't launch the viewer — useful in CI and pre-flight checks.",
+    )
 
 
 def _resolve_view_args(args: argparse.Namespace) -> tuple[str, str | None] | None:
@@ -290,12 +297,40 @@ def cmd_view(args: argparse.Namespace) -> int:
     if resolved is None:
         return EXIT_ERROR
     interface, path = resolved
+
+    # --check short-circuits before launching the viewer: validate that
+    # argus-results.json is reachable from the supplied path and print
+    # remediation guidance if not. Useful in CI and as a pre-flight
+    # check before a maintainer hands off "open this scan in argus
+    # view" to a less-technical stakeholder.
+    if getattr(args, "check", False):
+        return _check_view_artifact(path)
+
     return _launch_view(
         interface,
         path=path,
         port=args.port,
         open_browser=_should_open_browser(args),
     )
+
+
+def _check_view_artifact(path: str | None) -> int:
+    """Resolve ``path`` to an argus-results.json without launching the viewer.
+
+    Reuses the terminal loader's resolver so the success / failure
+    message matches what a real ``argus view`` would surface. On
+    success, prints the resolved path; on failure, prints the
+    diagnoser's remediation output (config-aware hint identifying the
+    likely root cause) to stderr.
+    """
+    from argus.viewers.terminal.loader import locate_results
+    try:
+        resolved = locate_results(path)
+    except FileNotFoundError as exc:
+        print(str(exc), file=sys.stderr)
+        return EXIT_ERROR
+    print(f"OK: {resolved} is readable.")
+    return EXIT_SUCCESS
 
 
 def _should_open_browser(args: argparse.Namespace) -> bool:

--- a/argus/cli.py
+++ b/argus/cli.py
@@ -1297,10 +1297,19 @@ def _cmd_source_scan(args: argparse.Namespace) -> int:
         finalize_manifest(manifest, exit_code=EXIT_ERROR, output_dir=output_dir)
         return EXIT_ERROR
 
-    # Generate reports
+    # Generate reports.
+    #
+    # ``ensure_canonical_json`` guarantees the source-of-truth artifact
+    # (``argus-results.json``) is always written, regardless of what
+    # the user listed in ``reporting.formats``. The viewers, the audit
+    # manifest, and the ``argus report`` subcommand all consume that
+    # file — keeping it implicitly mandatory means a config like
+    # ``formats: [terminal, sarif]`` no longer silently breaks
+    # ``argus view`` (the diagnoser still helps for legacy result dirs
+    # produced before this contract was in place).
     try:
-        from argus.reporters import get_reporter
-        for fmt in config.reporting.formats:
+        from argus.reporters import ensure_canonical_json, get_reporter
+        for fmt in ensure_canonical_json(config.reporting.formats):
             reporter = get_reporter(fmt)
             reporter.report(summary, output_dir)
             log.debug("Generated %s report", fmt)

--- a/argus/reporters/__init__.py
+++ b/argus/reporters/__init__.py
@@ -27,3 +27,30 @@ def get_reporter(name: str):
 def available_reporters() -> list[str]:
     """Return list of registered reporter names."""
     return list(REPORTER_REGISTRY.keys())
+
+
+# The single canonical scan artifact. ``argus-results.json`` is consumed
+# by the audit manifest, both viewers (terminal + browser), the
+# ``argus report`` subcommand, and any downstream tooling built on the
+# SDK. Treating it as always-emitted decouples its existence from
+# user-configured ``reporting.formats``: that list now means "which
+# *additional* human-readable reports to emit alongside the canonical
+# JSON," not "which artifacts exist at all." Eliminates the failure
+# mode where a config like ``formats: [terminal, sarif]`` silently
+# breaks ``argus view``.
+CANONICAL_FORMAT = "json"
+
+
+def ensure_canonical_json(formats: list[str]) -> list[str]:
+    """Return the format list with the canonical JSON output guaranteed.
+
+    Idempotent — if the user already lists ``json`` we don't add a
+    duplicate (which would write the file twice). Order is preserved
+    so the user's terminal/markdown/sarif reports still print in the
+    sequence they configured; the canonical JSON is appended at the
+    end so it's always the last reporter to run (its dict-dump output
+    isn't influenced by side-effects of earlier reporters).
+    """
+    if CANONICAL_FORMAT in formats:
+        return list(formats)
+    return [*formats, CANONICAL_FORMAT]

--- a/argus/tests/reporters/test_registry.py
+++ b/argus/tests/reporters/test_registry.py
@@ -1,0 +1,51 @@
+"""Tests for argus.reporters registry helpers — ``ensure_canonical_json``.
+
+The helper guarantees ``argus-results.json`` is always emitted by the
+source-scan flow, regardless of how the user configures
+``reporting.formats``. That decouples the canonical scan artifact (the
+audit manifest, both viewers, and ``argus report`` all consume it) from
+user choice of additional human-readable reports.
+"""
+
+from __future__ import annotations
+
+from argus.reporters import CANONICAL_FORMAT, ensure_canonical_json
+
+
+class TestEnsureCanonicalJson:
+    def test_appends_json_when_absent(self):
+        assert ensure_canonical_json(["terminal"]) == ["terminal", "json"]
+
+    def test_idempotent_when_json_already_present(self):
+        # User explicitly listed json — don't double-write the file.
+        assert ensure_canonical_json(["json"]) == ["json"]
+
+    def test_preserves_user_order_when_json_already_present(self):
+        # The user's preferred ordering of human reports stays intact.
+        assert ensure_canonical_json(["json", "terminal", "sarif"]) == [
+            "json", "terminal", "sarif",
+        ]
+
+    def test_appends_json_to_multi_format_list(self):
+        # Common production case: user wants terminal + SARIF + audit JSON.
+        assert ensure_canonical_json(["terminal", "sarif"]) == [
+            "terminal", "sarif", "json",
+        ]
+
+    def test_handles_empty_input(self):
+        # Edge case: a config with ``formats: []`` still produces the
+        # canonical artifact. Without this, the viewers would silently
+        # fail downstream.
+        assert ensure_canonical_json([]) == ["json"]
+
+    def test_does_not_mutate_input(self):
+        # Defensive: the helper must not mutate the caller's list, since
+        # the same list lives on the user's ArgusConfig.
+        formats = ["terminal"]
+        ensure_canonical_json(formats)
+        assert formats == ["terminal"]
+
+    def test_canonical_format_constant_is_json(self):
+        # Sanity-check the constant name. If we ever rename the
+        # canonical artifact, every consumer downstream needs to know.
+        assert CANONICAL_FORMAT == "json"

--- a/argus/tests/test_cli.py
+++ b/argus/tests/test_cli.py
@@ -290,6 +290,69 @@ class TestCmdScan:
         captured = capsys.readouterr()
         assert "unknown scanner 'nonexistent'" in captured.err
 
+    def test_scan_source_always_emits_canonical_json(self, monkeypatch, tmp_path):
+        """Regression for Option C: argus-results.json must be written
+        regardless of the user's ``reporting.formats``. Captures the
+        format names the cli.py loop asks ``get_reporter`` for, and
+        asserts 'json' is in the list even though the user configured
+        formats=[terminal] only."""
+        from argus.core.config import ArgusConfig, ReportingConfig, ExecutionConfig
+        from argus.core.models import ScanSummary
+
+        config = ArgusConfig(
+            reporting=ReportingConfig(
+                output_dir=str(tmp_path),
+                formats=["terminal"],   # deliberately omits json
+                severity_threshold=None,
+            ),
+            execution=ExecutionConfig(),
+        )
+        monkeypatch.setattr(
+            "argus.core.config.ArgusConfig.load",
+            lambda _path: config,
+        )
+
+        summary = ScanSummary(results=[], severity_threshold=None)
+        monkeypatch.setattr(
+            "argus.core.engine.ArgusEngine.__init__",
+            lambda self, _cfg: setattr(self, "config", config)
+            or setattr(self, "_scanners", {}),
+        )
+        monkeypatch.setattr(
+            "argus.core.engine.ArgusEngine.run",
+            lambda self, **kwargs: summary,
+        )
+        monkeypatch.setattr(
+            "argus.core.engine.ArgusEngine.register_scanner",
+            lambda self, s: None,
+        )
+        monkeypatch.setattr("argus.scanners.get_available_scanners", lambda: [])
+
+        # Capture every format name the dispatch loop requests so we
+        # can assert canonical JSON was demanded alongside the user's
+        # configured formats.
+        requested: list[str] = []
+
+        def capture_reporter(fmt):
+            requested.append(fmt)
+            return MagicMock()
+
+        monkeypatch.setattr("argus.reporters.get_reporter", capture_reporter)
+        monkeypatch.setattr("argus.audit.get_logger", lambda *a, **kw: MagicMock())
+        monkeypatch.setattr(
+            "argus.audit.create_manifest",
+            lambda **kw: MagicMock(execution_backend=None),
+        )
+        monkeypatch.setattr("argus.audit.finalize_manifest", lambda *a, **kw: None)
+
+        args = _make_scan_args(output_dir=str(tmp_path))
+        cmd_scan(args)
+
+        # Canonical JSON is requested even though config didn't list it.
+        # User's terminal report is still emitted.
+        assert "json" in requested
+        assert "terminal" in requested
+
     def test_scan_source_runs_engine(self, monkeypatch, tmp_path):
         """A valid scan with no findings should call engine.run and return EXIT_SUCCESS."""
         from argus.core.config import ArgusConfig, ReportingConfig, ExecutionConfig

--- a/argus/tests/test_cli.py
+++ b/argus/tests/test_cli.py
@@ -849,6 +849,41 @@ class TestViewSubcommand:
         assert args.interface_or_path is None
         assert args.interface_flag is None
         assert args.path_arg is None
+        assert args.check is False
+
+    def test_view_check_flag_parses(self):
+        parser = build_parser()
+        args = parser.parse_args(["view", "--check"])
+        assert args.check is True
+
+    def test_view_check_succeeds_when_results_present(self, tmp_path, capsys):
+        """--check resolves the path, finds argus-results.json, prints OK,
+        and exits 0 without launching the viewer."""
+        from argus.cli import _check_view_artifact, EXIT_SUCCESS
+        (tmp_path / "argus-results.json").write_text("{}")
+
+        rc = _check_view_artifact(str(tmp_path))
+        assert rc == EXIT_SUCCESS
+        out = capsys.readouterr().out
+        assert "OK:" in out
+        assert "argus-results.json" in out
+
+    def test_view_check_emits_diagnoser_when_results_missing(self, tmp_path, capsys, monkeypatch):
+        """--check fails clean with the diagnoser's remediation message —
+        no traceback, no launching viewer, EXIT_ERROR for CI gating."""
+        from argus.cli import _check_view_artifact, EXIT_ERROR
+        # No argus-results.json in tmp_path; no argus.yml either, so we
+        # exercise the generic-hint branch.
+        monkeypatch.chdir(tmp_path)
+
+        rc = _check_view_artifact(str(tmp_path))
+        assert rc == EXIT_ERROR
+        err = capsys.readouterr().err
+        # Original missing-file diagnostic is preserved...
+        assert "argus-results.json not found" in err
+        # ...and accompanied by both fix paths.
+        assert "argus scan --format json" in err
+        assert "reporting.formats" in err
 
     def test_view_positional_terminal(self):
         parser = build_parser()

--- a/argus/tests/viewers/terminal/test_loader.py
+++ b/argus/tests/viewers/terminal/test_loader.py
@@ -109,3 +109,35 @@ class TestFlattenFindings:
         summary = ScanSummary(results=[ScanResult(scanner="osv", findings=[f])])
         out = flatten_findings(summary)
         assert out[0].scanner == "osv"
+
+
+class TestMissingResultsRoutesThroughDiagnoser:
+    """Regression: locate_results' FileNotFoundError must include the
+    config-aware remediation hint, not just the bare "file not found"
+    message. Both viewers surface this exception verbatim."""
+
+    def test_error_includes_diagnoser_remediation(self, tmp_path, monkeypatch):
+        # No argus.yml anywhere → generic-hint branch of the diagnoser.
+        monkeypatch.chdir(tmp_path)
+        with pytest.raises(FileNotFoundError) as excinfo:
+            locate_results(str(tmp_path))
+        msg = str(excinfo.value)
+        # File is identified.
+        assert RESULTS_FILENAME in msg
+        # Both fix paths are surfaced.
+        assert "argus scan --format json" in msg
+        assert "reporting.formats" in msg
+
+    def test_error_calls_out_config_root_cause_when_json_omitted(self, tmp_path, monkeypatch):
+        """Targeted hint when argus.yml is present but missing 'json'."""
+        (tmp_path / "argus.yml").write_text(
+            "reporting:\n  formats:\n    - terminal\n    - sarif\n"
+        )
+        monkeypatch.chdir(tmp_path)
+        with pytest.raises(FileNotFoundError) as excinfo:
+            locate_results(str(tmp_path))
+        msg = str(excinfo.value)
+        # Targeted-branch markers.
+        assert "Detected" in msg
+        assert "argus.yml" in msg
+        assert "'terminal'" in msg and "'sarif'" in msg

--- a/argus/tests/viewers/test_diagnose.py
+++ b/argus/tests/viewers/test_diagnose.py
@@ -1,0 +1,189 @@
+"""Tests for argus.viewers.diagnose — missing-results-JSON remediation hints.
+
+Three branches matter:
+- argus.yml exists and `reporting.formats` omits `json` → targeted hint
+  identifying the config root cause.
+- argus.yml exists and lists `json` → fall back to the generic hint
+  (config isn't the cause).
+- no argus.yml found anywhere up the tree → generic hint.
+
+Plus defensive paths: malformed YAML, missing reporting key, etc., all
+fall back to the generic hint without raising.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from argus.viewers.diagnose import (
+    _find_nearby_argus_config,
+    _read_reporting_formats,
+    diagnose_missing_results,
+)
+
+
+# ───────────────────────────────────────────────
+# diagnose_missing_results — public surface
+# ───────────────────────────────────────────────
+
+
+class TestDiagnoseMissingResults:
+    def test_targeted_hint_when_config_omits_json(self, tmp_path, monkeypatch):
+        """argus.yml present, json NOT in reporting.formats → message names
+        the file, the actual formats value, and offers a one-shot CLI fix
+        plus the config-edit fix."""
+        config = tmp_path / "argus.yml"
+        config.write_text(
+            "reporting:\n  formats:\n    - terminal\n    - sarif\n"
+        )
+        monkeypatch.chdir(tmp_path)
+
+        msg = diagnose_missing_results(tmp_path / "argus-results.json")
+
+        # Required: identifies the file.
+        assert "argus-results.json" in msg
+        # Required: message names config root cause.
+        assert "argus.yml" in msg
+        assert "reporting.formats" in msg
+        assert "'terminal'" in msg and "'sarif'" in msg
+        # Required: at least one config fix and one CLI fix.
+        assert "Add 'json' to reporting.formats" in msg
+        assert "argus scan --format json" in msg
+        # Required: retry instruction echoes the searched path.
+        assert "argus view" in msg
+
+    def test_generic_hint_when_no_argus_yml(self, tmp_path, monkeypatch):
+        """No argus.yml anywhere up the tree → generic hint, no false claim
+        about config being the cause."""
+        # Use an isolated tmp dir as cwd; walk-up shouldn't find any
+        # config because tmp dirs are well outside the repo root.
+        sub = tmp_path / "isolated"
+        sub.mkdir()
+        monkeypatch.chdir(sub)
+
+        msg = diagnose_missing_results(sub / "argus-results.json")
+
+        # Still identifies the file + still gives both fix paths.
+        assert "argus-results.json" in msg
+        assert "Add 'json' to reporting.formats in argus.yml" in msg
+        assert "argus scan --format json" in msg
+        # Doesn't make a confident claim about a config we never found.
+        assert "Detected" not in msg
+
+    def test_generic_hint_when_config_includes_json(self, tmp_path, monkeypatch):
+        """Config has json — bug is somewhere else (wrong path, scan never
+        ran, output dir mismatch). Don't blame the config."""
+        config = tmp_path / "argus.yml"
+        config.write_text(
+            "reporting:\n  formats:\n    - terminal\n    - json\n"
+        )
+        monkeypatch.chdir(tmp_path)
+
+        msg = diagnose_missing_results(tmp_path / "argus-results.json")
+
+        # Generic hint path — not the targeted one.
+        assert "Detected" not in msg
+        # Both fixes still listed (user might still need to run the scan).
+        assert "argus scan --format json" in msg
+
+    def test_unparseable_argus_yml_falls_back_to_generic(self, tmp_path, monkeypatch):
+        """Broken YAML must NOT mask the original missing-file diagnostic
+        with a parse-error traceback. Falls back to the generic hint."""
+        config = tmp_path / "argus.yml"
+        config.write_text("reporting:\n  formats: [terminal,, : :")
+        monkeypatch.chdir(tmp_path)
+
+        msg = diagnose_missing_results(tmp_path / "argus-results.json")
+
+        # No traceback / exception leakage.
+        assert "Traceback" not in msg
+        assert "yaml" not in msg.lower()
+        # Falls back to generic path.
+        assert "Detected" not in msg
+        assert "argus-results.json" in msg
+
+    def test_argus_yml_without_reporting_key_falls_back(self, tmp_path, monkeypatch):
+        """Config exists but doesn't define reporting.formats → can't make
+        a confident 'json missing from formats' claim, generic hint fires."""
+        config = tmp_path / "argus.yml"
+        config.write_text("scanners:\n  bandit:\n    enabled: true\n")
+        monkeypatch.chdir(tmp_path)
+
+        msg = diagnose_missing_results(tmp_path / "argus-results.json")
+        assert "Detected" not in msg
+
+    def test_retry_arg_uses_parent_for_results_filename(self, tmp_path, monkeypatch):
+        """When the searched path ends in argus-results.json, the retry
+        hint should point at its parent dir (what argus view actually
+        accepts), not the JSON file itself."""
+        config = tmp_path / "argus.yml"
+        config.write_text("reporting:\n  formats: [terminal]\n")
+        monkeypatch.chdir(tmp_path)
+
+        run_dir = tmp_path / "argus-results" / "2026-05-05T10-00-00Z"
+        msg = diagnose_missing_results(run_dir / "argus-results.json")
+
+        assert f"argus view {run_dir}" in msg
+
+    def test_retry_arg_falls_back_to_placeholder_for_empty_path(self, tmp_path, monkeypatch):
+        """A relative '.' or empty path renders as a literal placeholder
+        rather than a useless 'argus view .' line."""
+        monkeypatch.chdir(tmp_path)
+        msg = diagnose_missing_results(Path("."))
+        assert "argus view <results-dir>" in msg
+
+
+# ───────────────────────────────────────────────
+# Helpers exercised separately for confidence at boundaries
+# ───────────────────────────────────────────────
+
+
+class TestFindNearbyArgusConfig:
+    def test_finds_in_starting_dir(self, tmp_path):
+        config = tmp_path / "argus.yml"
+        config.write_text("# empty\n")
+        assert _find_nearby_argus_config(tmp_path) == config
+
+    def test_walks_up_to_find_config(self, tmp_path):
+        nested = tmp_path / "a" / "b" / "c"
+        nested.mkdir(parents=True)
+        config = tmp_path / "argus.yml"
+        config.write_text("# empty\n")
+        assert _find_nearby_argus_config(nested) == config
+
+    def test_returns_none_when_no_config_in_tree(self, tmp_path):
+        # tmp_path's tree is well-isolated from any repo with argus.yml.
+        assert _find_nearby_argus_config(tmp_path) is None
+
+    def test_recognises_alternate_config_names(self, tmp_path):
+        # argus.yaml and the dotted variants are all valid filenames.
+        for name in ("argus.yaml", ".argus.yml", ".argus.yaml"):
+            sub = tmp_path / name.replace(".", "_")
+            sub.mkdir()
+            config = sub / name
+            config.write_text("# empty\n")
+            assert _find_nearby_argus_config(sub) == config
+
+
+class TestReadReportingFormats:
+    def test_reads_formats_list(self, tmp_path):
+        config = tmp_path / "argus.yml"
+        config.write_text(
+            "reporting:\n  formats:\n    - terminal\n    - json\n"
+        )
+        assert _read_reporting_formats(config) == ["terminal", "json"]
+
+    def test_returns_none_for_missing_reporting_key(self, tmp_path):
+        config = tmp_path / "argus.yml"
+        config.write_text("scanners:\n  bandit:\n    enabled: true\n")
+        assert _read_reporting_formats(config) is None
+
+    def test_returns_none_for_unparseable_yaml(self, tmp_path):
+        config = tmp_path / "argus.yml"
+        config.write_text("reporting: [{")
+        assert _read_reporting_formats(config) is None
+
+    def test_returns_none_when_formats_isnt_a_list(self, tmp_path):
+        config = tmp_path / "argus.yml"
+        config.write_text("reporting:\n  formats: terminal\n")
+        assert _read_reporting_formats(config) is None

--- a/argus/viewers/browser/app.py
+++ b/argus/viewers/browser/app.py
@@ -145,10 +145,13 @@ def _resolve_scan(
                 f"Use the picker to choose a specific run."
             )
 
-        return None, (
-            f"No {RESULTS_FILENAME} inside {target}. "
-            "Pick a results directory or pass a specific JSON path via ?scan=..."
-        )
+        # No results anywhere under the target. Defer to the shared
+        # diagnoser so the message identifies the likely root cause —
+        # most often the user's argus.yml lists 'reporting.formats'
+        # without 'json', so the previous scan never wrote the file
+        # the viewers consume.
+        from argus.viewers.diagnose import diagnose_missing_results
+        return None, diagnose_missing_results(direct)
 
     return None, f"Unsupported path kind: {target}"
 

--- a/argus/viewers/diagnose.py
+++ b/argus/viewers/diagnose.py
@@ -1,0 +1,150 @@
+"""Friendly diagnostics for the missing-``argus-results.json`` pitfall.
+
+UI-free helpers shared by the terminal and browser viewers (and the
+``argus view --check`` flag). When the user lands on ``argus view``
+without a results file, the most common root cause is *config* —
+``reporting.formats`` in ``argus.yml`` doesn't include ``json``, so
+the previous ``argus scan`` run wrote terminal/markdown/SARIF but not
+the JSON file the viewers actually consume. Surface that distinction
+in the error itself so users don't have to guess.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Same precedence as ``argus.core.config._DEFAULT_CONFIG_NAMES``. Kept
+# separate (not imported) so the diagnoser can run without dragging in
+# the rest of the config-loading machinery.
+_CONFIG_NAMES = ("argus.yml", "argus.yaml", ".argus.yml", ".argus.yaml")
+
+_RESULTS_FILENAME = "argus-results.json"
+
+
+def diagnose_missing_results(searched_path: Path) -> str:
+    """Build a remediation-rich error message for a missing results JSON.
+
+    The string returned is suitable for raising as a ``FileNotFoundError``
+    *and* for displaying verbatim in the browser viewer's empty-state.
+    Wrapping at ~78 columns so long terminals don't reflow it weirdly.
+    """
+    lines: list[str] = [
+        f"Error: {_RESULTS_FILENAME} not found at {searched_path}.",
+        "",
+        "Hint: argus view requires JSON scan output.",
+        "",
+    ]
+
+    config_path = _find_nearby_argus_config()
+    formats = _read_reporting_formats(config_path) if config_path else None
+
+    if config_path is not None and formats is not None and "json" not in formats:
+        # Targeted hint: we know exactly why the file is missing.
+        lines.extend([
+            f"Detected {config_path.name} at {config_path}, but its",
+            f"reporting.formats is {formats!r} — 'json' isn't included, so",
+            "argus scan didn't write the file argus view reads.",
+            "",
+            "Fix (choose one):",
+            f"  • Add 'json' to reporting.formats in {config_path.name}, then rerun:",
+            "      argus scan",
+            "  • Or, one-shot from the CLI:",
+            "      argus scan --format json --no-timestamp",
+            "",
+            f"Then retry: argus view {_retry_arg(searched_path)}",
+        ])
+    else:
+        # Generic hint: config is absent or already lists json (different
+        # cause — wrong path, scan never ran, output dir mismatch, etc.).
+        lines.extend([
+            "Run a scan that emits JSON, then retry. Two ways:",
+            "  • Add 'json' to reporting.formats in argus.yml and run:",
+            "      argus scan",
+            "  • Or, one-shot from the CLI:",
+            "      argus scan --format json --no-timestamp",
+            "",
+            f"Then retry: argus view {_retry_arg(searched_path)}",
+        ])
+
+    return "\n".join(lines)
+
+
+def _retry_arg(searched_path: Path) -> str:
+    """Best-guess argument the user should pass back to ``argus view``.
+
+    If the search hit a file (``…/argus-results.json``), point the user
+    at its parent directory. Otherwise, echo the directory we tried.
+    Falls back to a literal ``<results-dir>`` placeholder when the path
+    is empty/relative-only.
+    """
+    if searched_path.name == _RESULTS_FILENAME:
+        target = searched_path.parent
+    else:
+        target = searched_path
+    rendered = str(target)
+    return rendered if rendered not in ("", ".") else "<results-dir>"
+
+
+def _find_nearby_argus_config(start: Path | None = None) -> Path | None:
+    """Walk up from ``start`` (default cwd) looking for an argus config.
+
+    Returns the first ``argus.yml`` (or other accepted name) we find at
+    or above the starting directory. ``None`` if we hit the filesystem
+    root without finding one — that's the "no config" branch the
+    diagnoser falls back to a generic hint for.
+    """
+    current = (start or Path.cwd()).resolve()
+    while True:
+        for name in _CONFIG_NAMES:
+            candidate = current / name
+            if candidate.is_file():
+                return candidate
+        if current.parent == current:
+            return None
+        current = current.parent
+
+
+def _read_reporting_formats(config_path: Path) -> list[str] | None:
+    """Read ``reporting.formats`` from an argus config file.
+
+    Returns the list of format names, or ``None`` when:
+      - PyYAML can't parse the file (syntax error)
+      - the ``reporting.formats`` key is absent
+      - the value isn't a list
+
+    Any of those means we can't make a confident "json missing from
+    formats" claim, so the caller should fall back to the generic hint.
+    Defensive about exceptions because this runs from the error path —
+    we don't want a broken argus.yml to mask the original missing-file
+    diagnostic.
+    """
+    try:
+        import yaml
+    except ImportError:  # pragma: no cover — pyyaml is a hard SDK dep
+        return None
+
+    try:
+        text = config_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError:
+        return None
+
+    if not isinstance(data, dict):
+        return None
+
+    reporting = data.get("reporting")
+    if not isinstance(reporting, dict):
+        return None
+
+    formats = reporting.get("formats")
+    if not isinstance(formats, list):
+        return None
+
+    return [str(f) for f in formats]
+
+
+__all__ = ["diagnose_missing_results"]

--- a/argus/viewers/terminal/loader.py
+++ b/argus/viewers/terminal/loader.py
@@ -31,11 +31,14 @@ def locate_results(path: str | Path | None) -> Path:
         p = Path(path)
         candidate = p / RESULTS_FILENAME if p.is_dir() else p
     if not candidate.is_file():
-        raise FileNotFoundError(
-            f"Could not find {RESULTS_FILENAME} at {candidate}. "
-            "Run `argus scan --format json` first, or pass the path to "
-            "an existing results directory."
-        )
+        # Defer to the shared diagnoser so the message identifies the
+        # likely root cause (most often: ``reporting.formats`` in
+        # argus.yml omits ``json``) rather than just reporting the
+        # missing file. Both viewers raise this exception and surface
+        # the message verbatim, so users get the same actionable
+        # remediation regardless of which interface they invoked.
+        from argus.viewers.diagnose import diagnose_missing_results
+        raise FileNotFoundError(diagnose_missing_results(candidate))
     return candidate
 
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -299,7 +299,7 @@ Install:
 
 ```
 argus view [-h] [--interface {terminal,browser}] [--port PORT]
-                  [--no-open]
+                  [--no-open] [--check]
                   [INTERFACE|PATH] [PATH]
 ```
 
@@ -315,6 +315,7 @@ argus view [-h] [--interface {terminal,browser}] [--port PORT]
 | `--interface`, `-i` | Interface to open: terminal \| browser (alternative to positional) (terminal, browser) |  |
 | `--port` | TCP port for the browser interface (default: 8080) | `8080` |
 | `--no-open` | Don't auto-open the default web browser after startup (browser interface only). By default, the browser opens when stdout is a TTY; CI and other non-interactive contexts already skip auto-open without this flag. | `false` |
+| `--check` | Validate that the resolved scan directory contains argus-results.json and print actionable remediation if not. Doesn't launch the viewer — useful in CI and pre-flight checks. | `false` |
 
 ## Quick Reference
 


### PR DESCRIPTION
## Description

Two-part fix for the missing-`argus-results.json` pitfall:

1. **Option C — root-cause fix.** Make `argus-results.json` always emitted by the source-scan flow, regardless of `reporting.formats`. The canonical scan artifact (consumed by both viewers, the audit manifest, and `argus report`) is no longer something users can accidentally turn off via config. `reporting.formats` is redefined to mean "which *additional* human-readable reports to emit alongside the canonical JSON."

2. **Diagnoser — belt-and-suspenders.** When a user does land on a results dir that's missing the JSON (legacy results from before this contract; a wrong path; a scan that never ran), the error message identifies the likely root cause and gives both a config fix and a CLI fix in the same output. Preserves clear UX for the long tail of cases where (1) doesn't apply.

The user's principle was the right one: every artifact Argus produces should be readable by every Argus surface. (1) makes that true going forward; (2) makes the failure mode self-explanatory when it surfaces transitionally.

## Changes Made
- [ ] Added new scanner/workflow
- [x] Modified existing scanner/workflow
- [x] Updated documentation
- [x] Fixed bug
- [x] Other: contract change — `reporting.formats` no longer gates the canonical artifact

### Details — Part 1: Always-emit canonical JSON (commit `c9e4ca9`)

- New `argus.reporters.ensure_canonical_json(formats)` helper — idempotent, preserves user-configured ordering, appends `json` when absent. Lives next to `REPORTER_REGISTRY` and the new `CANONICAL_FORMAT` constant so the canonical artifact's identity is one module-level constant away.
- `argus/cli.py` source-scan dispatch loop iterates the helper-augmented format list.
- `argus.example.yml` comment block updated so users see the new contract: "argus-results.json is always written; this list is for additional reports."
- **Container and DAST flows are intentionally out of scope.** They have their own JSON helpers (`_write_container_json` / `_write_dast_json`) that produce domain-shaped summaries (`container_count`, `target_count`), not `ScanSummary.to_dict()`. They're consumed by their own handling, separate from `argus view`. Adding "always emit argus-results.json" to those flows would conflate two different artifacts; left for follow-up if a clear use case arises.

### Details — Part 2: Diagnoser (commits `dea921f` and earlier)

- New `argus.viewers.diagnose` module with one public entry point, `diagnose_missing_results(searched_path)`. Walks up from cwd looking for `argus.yml`/`.yaml` variants; if found and `reporting.formats` doesn't list `json`, emits a *targeted* hint that names the file and the actual `formats` value. Otherwise emits a *generic* hint. Both branches end with a config fix and a CLI fix.
- `argus/viewers/terminal/loader.py:locate_results` raises `FileNotFoundError` with the diagnoser's output. Browser viewer's `_resolve_scan` defers to the same diagnoser — same message in both interfaces.
- New `--check` flag on `argus view`. Validates that `argus-results.json` is reachable from the supplied path without launching the viewer. Prints `OK: <path> is readable.` on success or the diagnoser remediation on failure, with `EXIT_ERROR` on missing results.

### Example error output (when the diagnoser fires — e.g. legacy results dir)

Targeted hint (argus.yml omits `json`):

```
Error: argus-results.json not found at /repo/argus-results/argus-results.json.

Hint: argus view requires JSON scan output.

Detected argus.yml at /repo/argus.yml, but its
reporting.formats is ['terminal', 'sarif'] — 'json' isn't included, so
argus scan didn't write the file argus view reads.

Fix (choose one):
  • Add 'json' to reporting.formats in argus.yml, then rerun:
      argus scan
  • Or, one-shot from the CLI:
      argus scan --format json --no-timestamp

Then retry: argus view /repo/argus-results
```

Generic hint when no `argus.yml` is found anywhere up the tree.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results
- **Full SDK suite green: 1428 passed, 8 skipped, 7 deselected** (+30 from this PR).
- Manual smoke tests:
  - `argus view --check` in cwd without results → full diagnoser remediation, exits non-zero
  - `argus view --check /tmp/has-json` → `OK: …is readable.`, exits 0
  - Source scan with `formats: [terminal]` → `argus-results.json` is now written; the viewer can load it without intervention.

**New tests:**
- `argus/tests/viewers/test_diagnose.py` (15 cases): targeted/generic/config-with-json branches; unparseable YAML; alternate config filenames; walk-up; retry-arg parent extraction; placeholder fallback; helper boundaries.
- `argus/tests/viewers/terminal/test_loader.py` (2 cases): regression that `locate_results` routes through the diagnoser.
- `argus/tests/test_cli.py` (5 cases): `--check` default False / parses to True / success / failure exit; **integration regression** that source-scan flow always requests the json reporter even when `formats=[terminal]`.
- `argus/tests/reporters/test_registry.py` (7 cases): `ensure_canonical_json` idempotence, ordering preservation, no-mutation, empty input, constant-name sanity.

## Acceptance Criteria

| Criterion | Status |
|---|---|
| argus view clearly explains missing JSON output cause, not just missing file | ✅ Targeted hint when relevant; generic hint otherwise |
| Message includes at least one config fix and one CLI fix | ✅ Both branches list both: edit `argus.yml` OR run `argus scan --format json --no-timestamp` |
| Existing successful view flows are unchanged | ✅ Diagnoser only fires on the FileNotFoundError branch; loader still returns the resolved path on success |
| Add tests for: missing json in `reporting.formats` / config absent / json present (no warning) | ✅ All three branches covered + several edge cases |
| **Bonus — every Argus output should be readable by Argus** | ✅ Source-scan flow now always emits `argus-results.json`; the failure mode the diagnoser was built for becomes extremely rare |

## Security Considerations
- [x] No security impact
- [ ] Security enhancement
- [ ] Potential security implications

### Security Details
The diagnoser uses `yaml.safe_load` (not the unsafe loader) and treats parse failures as fall-throughs to the generic hint. The `--check` flag is read-only. The "always-emit JSON" change writes one additional file per scan to the user's already-configured output dir — no new sensitive data, no new file-system reach.

## AI Context Updates (.ai/)
- [x] N/A — internal viewer helper + reporter dispatch refinement; no architecture or workflow change

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (if applicable) — `argus.example.yml` comment + `docs/cli-reference.md` regenerated
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Closes # (n/a — UX improvement from in-product testing)
