### PR TITLE
fix(container-scanner): handle empty/malformed grype output without traceback

### DIFF
--- a/argus/container/scanner.py
+++ b/argus/container/scanner.py
@@ -1,5 +1,6 @@
 """Scan container images with trivy and grype, deduplicate findings."""
 
+import json
 import logging
 import shutil
 import tempfile
@@ -232,6 +233,70 @@ def _container_vol_args(
     return args
 
 
+def _validate_scanner_output(
+    scanner_name: str,
+    output_file: Path,
+    result,
+) -> None:
+    """Raise RuntimeError when a sub-scanner's run looks unhealthy.
+
+    Container sub-scanners (trivy, grype) all hand off via the same
+    "subprocess writes JSON to a file path, we parse it" contract.
+    They all have the same failure modes:
+
+    1. subprocess exits non-zero — DB pull failed, image not
+       resolvable, registry auth missing, etc. Anything that prints
+       to stderr and bails before producing meaningful output.
+    2. output file isn't there — scanner crashed mid-run.
+    3. output file exists but is 0 bytes — common when a wrapper
+       process (e.g. ``docker run --rm``) exits non-zero from a
+       different stage than the scanner itself, leaving a stub
+       file from the redirect.
+
+    All three modes need to surface the scanner's own stderr (clipped
+    for terminal sanity), use ERROR-level logging without dumping a
+    Python traceback, and raise a single ``RuntimeError`` shape so
+    the caller can record it under ``scanner_errors`` consistently.
+
+    JSON parse failure is intentionally NOT validated here — every
+    sub-scanner uses a different parser, so the per-runner caller
+    owns that check (and translates exceptions into RuntimeError
+    via the same shape).
+    """
+    stderr = result.stderr.strip()[:500] if result.stderr else ""
+    stderr_label = stderr or "no stderr"
+
+    if result.returncode != 0:
+        logger.error(
+            "%s exited non-zero (%d): %s",
+            scanner_name, result.returncode, stderr_label,
+        )
+        raise RuntimeError(
+            f"{scanner_name} scan failed (exit {result.returncode}): "
+            f"{stderr or 'no output'}"
+        )
+
+    if not output_file.exists():
+        logger.error(
+            "%s produced no output file (exit %d): %s",
+            scanner_name, result.returncode, stderr_label,
+        )
+        raise RuntimeError(
+            f"{scanner_name} scan produced no output file "
+            f"(exit {result.returncode}): {stderr or 'no output'}"
+        )
+
+    if output_file.stat().st_size == 0:
+        logger.error(
+            "%s produced 0-byte output (exit %d): %s",
+            scanner_name, result.returncode, stderr_label,
+        )
+        raise RuntimeError(
+            f"{scanner_name} scan produced empty output file "
+            f"(exit {result.returncode}): {stderr or 'no output'}"
+        )
+
+
 def _run_trivy(
     image_ref: str, tmp_path: Path, local: bool = False,
 ) -> list[Finding]:
@@ -318,21 +383,21 @@ def _run_trivy(
         logger.error("trivy binary not found")
         return []
 
-    if not output_file.exists():
-        stderr = result.stderr.strip()[:500]
-        logger.error(
-            "trivy produced no output (exit %d): %s",
-            result.returncode, stderr,
-        )
-        raise RuntimeError(
-            f"trivy scan failed (exit {result.returncode}): {stderr or 'no output'}"
-        )
+    _validate_scanner_output("trivy", output_file, result)
 
     try:
         return _parser.parse_trivy_results(output_file)
-    except Exception:
-        logger.exception("Failed to parse trivy results for %s", image_ref)
-        raise
+    except json.JSONDecodeError as exc:
+        logger.error("trivy output JSON parse error for %s: %s", image_ref, exc)
+        raise RuntimeError(
+            f"trivy output JSON parse error: {exc}"
+        ) from exc
+    except Exception as exc:
+        # Non-decode parser errors (schema mismatch, missing keys) —
+        # log without traceback and re-raise as RuntimeError so the
+        # engine catches it as a structured scanner_errors entry.
+        logger.error("trivy output parse error for %s: %s", image_ref, exc)
+        raise RuntimeError(f"trivy output parse error: {exc}") from exc
 
 
 def _run_grype(
@@ -407,21 +472,26 @@ def _run_grype(
         logger.error("grype binary not found")
         return []
 
-    if not output_file.exists():
-        stderr = result.stderr.strip()[:500]
-        logger.error(
-            "grype produced no output (exit %d): %s",
-            result.returncode, stderr,
-        )
-        raise RuntimeError(
-            f"grype scan failed (exit {result.returncode}): {stderr or 'no output'}"
-        )
+    _validate_scanner_output("grype", output_file, result)
 
     try:
         return _parser.parse_grype_results(output_file)
-    except Exception:
-        logger.exception("Failed to parse grype results for %s", image_ref)
-        return []
+    except json.JSONDecodeError as exc:
+        # The user-reported regression: grype writes a 0-byte file
+        # when its image-resolution / catalog step fails after the
+        # output handle is created. Validation above catches that
+        # branch first, but JSON-shape errors (truncated output,
+        # malformed schema) still land here. Raise instead of
+        # swallowing — the engine catches the RuntimeError and
+        # records it under scanner_errors so the summary reflects
+        # reality instead of silently dropping grype's contribution.
+        logger.error("grype output JSON parse error for %s: %s", image_ref, exc)
+        raise RuntimeError(
+            f"grype output JSON parse error: {exc}"
+        ) from exc
+    except Exception as exc:
+        logger.error("grype output parse error for %s: %s", image_ref, exc)
+        raise RuntimeError(f"grype output parse error: {exc}") from exc
 
 
 def _run_syft(image_ref: str, tmp_path: Path) -> None:

--- a/argus/tests/test_container_scanner_runners.py
+++ b/argus/tests/test_container_scanner_runners.py
@@ -1,0 +1,304 @@
+"""Tests for argus.container.scanner runners — _run_grype, _run_trivy.
+
+Focuses on the failure-mode contract: every sub-scanner runner must
+raise a single ``RuntimeError`` shape so the orchestrator can record
+the error under ``scanner_errors`` and continue. JSON parse errors,
+non-zero exit codes, missing output files, and 0-byte output files
+all need to behave the same way — no traceback spam in normal CLI
+output, no silent downgrade of scanner coverage.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from argus.container.scanner import (
+    _run_grype,
+    _run_trivy,
+    _validate_scanner_output,
+)
+
+
+def _completed(returncode: int = 0, stdout: str = "", stderr: str = ""):
+    """Build a stand-in subprocess.CompletedProcess for mock returns."""
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=stderr,
+    )
+
+
+# ───────────────────────────────────────────────
+# Helper: _validate_scanner_output
+# ───────────────────────────────────────────────
+
+
+class TestValidateScannerOutput:
+    """Shared validator used by both Trivy and Grype runners.
+
+    Exercising it directly means the per-runner tests below can focus
+    on the parse path; the failure-mode contract is locked in here
+    once.
+    """
+
+    def test_returns_none_when_all_checks_pass(self, tmp_path):
+        out = tmp_path / "results.json"
+        out.write_text('{"matches": []}')
+        result = _completed(returncode=0)
+        # Healthy run — silent return.
+        assert _validate_scanner_output("trivy", out, result) is None
+
+    def test_raises_on_nonzero_exit(self, tmp_path):
+        out = tmp_path / "results.json"
+        out.write_text('{"matches": []}')
+        result = _completed(returncode=1, stderr="image not found in registry")
+        with pytest.raises(RuntimeError) as excinfo:
+            _validate_scanner_output("grype", out, result)
+        msg = str(excinfo.value)
+        # Exit code + stderr both surface in the message so the user
+        # sees the actual reason without bumping log level.
+        assert "exit 1" in msg
+        assert "image not found" in msg
+        assert "grype" in msg
+
+    def test_raises_when_output_file_missing(self, tmp_path):
+        # File never created by the scanner — common when the
+        # subprocess crashes before reaching the JSON-write step.
+        out = tmp_path / "results.json"
+        result = _completed(returncode=0)
+        with pytest.raises(RuntimeError) as excinfo:
+            _validate_scanner_output("grype", out, result)
+        assert "no output file" in str(excinfo.value)
+
+    def test_raises_when_output_file_is_zero_bytes(self, tmp_path):
+        # The user-reported bug: grype's wrapper exits 0 (or non-zero,
+        # depending on the failure mode) but the redirect target file
+        # is empty. ``output_file.exists()`` is True but
+        # ``json.loads("")`` would crash. The validator catches it.
+        out = tmp_path / "results.json"
+        out.touch()
+        assert out.stat().st_size == 0
+        result = _completed(returncode=0)
+        with pytest.raises(RuntimeError) as excinfo:
+            _validate_scanner_output("grype", out, result)
+        assert "empty output file" in str(excinfo.value)
+
+    def test_raises_on_zero_bytes_with_stderr_breadcrumb(self, tmp_path):
+        # When the scanner prints to stderr AND writes a 0-byte file,
+        # the message has to surface the stderr — that's the actual
+        # diagnostic the user needs.
+        out = tmp_path / "results.json"
+        out.touch()
+        result = _completed(returncode=2, stderr="catalog resolution failed: 401")
+        with pytest.raises(RuntimeError) as excinfo:
+            _validate_scanner_output("grype", out, result)
+        assert "catalog resolution failed" in str(excinfo.value)
+
+    def test_clipped_stderr_does_not_truncate_short_messages(self, tmp_path):
+        out = tmp_path / "results.json"
+        result = _completed(returncode=1, stderr="short reason")
+        with pytest.raises(RuntimeError) as excinfo:
+            _validate_scanner_output("trivy", out, result)
+        # Short stderr is preserved verbatim, no truncation marker.
+        assert "short reason" in str(excinfo.value)
+
+
+# ───────────────────────────────────────────────
+# Per-runner regression tests (the user's acceptance matrix)
+# ───────────────────────────────────────────────
+
+
+class TestRunGrype:
+    """The four scenarios from the user's bug report acceptance matrix."""
+
+    def _force_local_binary(self, monkeypatch):
+        # Pretend ``grype`` is installed locally so we exercise the
+        # binary-path branch (no docker fallback) — keeps the test
+        # focused on the validation/parse code.
+        monkeypatch.setattr(
+            "argus.container.scanner.shutil.which",
+            lambda name: "/usr/local/bin/grype" if name == "grype" else None,
+        )
+
+    def test_nonzero_exit_with_empty_file_raises_runtimeerror(
+        self, tmp_path, monkeypatch,
+    ):
+        """Acceptance: non-zero exit + empty file → no JSONDecodeError
+        traceback; structured RuntimeError carrying exit + stderr."""
+        self._force_local_binary(monkeypatch)
+        # Simulate the grype wrapper writing a 0-byte file then bailing.
+        def fake_run(cmd, **_kwargs):
+            (tmp_path / "grype-results.json").touch()
+            return _completed(
+                returncode=1,
+                stderr="catalog resolution failed: ENETUNREACH",
+            )
+        monkeypatch.setattr("subprocess.run", fake_run)
+
+        with pytest.raises(RuntimeError) as excinfo:
+            _run_grype("docker:argus-scan", tmp_path, local=True)
+        msg = str(excinfo.value)
+        assert "exit 1" in msg
+        assert "catalog resolution failed" in msg
+        # Critically, NOT a json.JSONDecodeError.
+        assert "Expecting value" not in msg
+
+    def test_zero_exit_with_empty_file_raises_runtimeerror(
+        self, tmp_path, monkeypatch,
+    ):
+        """Acceptance: zero exit + empty file → still treated as failure
+        (the wrapper or scanner crashed but the exit code didn't reflect
+        it). Defensive — empty JSON is never a valid grype result."""
+        self._force_local_binary(monkeypatch)
+        def fake_run(cmd, **_kwargs):
+            (tmp_path / "grype-results.json").touch()
+            return _completed(returncode=0)
+        monkeypatch.setattr("subprocess.run", fake_run)
+
+        with pytest.raises(RuntimeError) as excinfo:
+            _run_grype("docker:argus-scan", tmp_path, local=True)
+        assert "empty output file" in str(excinfo.value)
+
+    def test_malformed_json_raises_runtimeerror_not_jsondecodeerror(
+        self, tmp_path, monkeypatch,
+    ):
+        """Acceptance: malformed JSON → translated to RuntimeError so the
+        engine catches it under ``scanner_errors`` instead of bubbling a
+        bare JSONDecodeError to the user."""
+        self._force_local_binary(monkeypatch)
+        def fake_run(cmd, **_kwargs):
+            (tmp_path / "grype-results.json").write_text("{not-valid-json")
+            return _completed(returncode=0)
+        monkeypatch.setattr("subprocess.run", fake_run)
+
+        with pytest.raises(RuntimeError) as excinfo:
+            _run_grype("docker:argus-scan", tmp_path, local=True)
+        assert "JSON parse error" in str(excinfo.value)
+        # Per the contract: RuntimeError, not the underlying decoder
+        # exception type — even though __cause__ chains the original.
+        assert not isinstance(excinfo.value, json.JSONDecodeError)
+
+    def test_valid_json_passes_through_to_parser(self, tmp_path, monkeypatch):
+        """Acceptance: valid JSON → normal parse path returns findings.
+        Confirms the new validation gating doesn't break the happy path."""
+        self._force_local_binary(monkeypatch)
+        valid_grype_payload = {
+            "matches": [
+                {
+                    "vulnerability": {
+                        "id": "CVE-2024-1234",
+                        "severity": "High",
+                        "description": "test",
+                        "fix": {"versions": ["1.2.3"], "state": "fixed"},
+                    },
+                    "artifact": {
+                        "name": "openssl",
+                        "version": "1.1.1",
+                        "purl": "pkg:deb/openssl@1.1.1",
+                    },
+                },
+            ],
+        }
+        def fake_run(cmd, **_kwargs):
+            (tmp_path / "grype-results.json").write_text(
+                json.dumps(valid_grype_payload),
+            )
+            return _completed(returncode=0)
+        monkeypatch.setattr("subprocess.run", fake_run)
+
+        findings = _run_grype("docker:argus-scan", tmp_path, local=True)
+        assert len(findings) == 1
+        assert findings[0].cve == "CVE-2024-1234"
+
+
+class TestRunTrivy:
+    """Mirror coverage for trivy — same failure-mode contract via the
+    shared validator. Confirms grype isn't the only beneficiary of the
+    parse-path hardening."""
+
+    def _force_local_binary(self, monkeypatch):
+        monkeypatch.setattr(
+            "argus.container.scanner.shutil.which",
+            lambda name: "/usr/local/bin/trivy" if name == "trivy" else None,
+        )
+
+    def test_zero_exit_with_empty_file_raises_runtimeerror(
+        self, tmp_path, monkeypatch,
+    ):
+        self._force_local_binary(monkeypatch)
+        def fake_run(cmd, **_kwargs):
+            (tmp_path / "trivy-results.json").touch()
+            return _completed(returncode=0)
+        monkeypatch.setattr("subprocess.run", fake_run)
+
+        with pytest.raises(RuntimeError) as excinfo:
+            _run_trivy("docker:argus-scan", tmp_path, local=True)
+        assert "empty output file" in str(excinfo.value)
+
+    def test_malformed_json_raises_runtimeerror_not_jsondecodeerror(
+        self, tmp_path, monkeypatch,
+    ):
+        self._force_local_binary(monkeypatch)
+        def fake_run(cmd, **_kwargs):
+            (tmp_path / "trivy-results.json").write_text("{not-valid")
+            return _completed(returncode=0)
+        monkeypatch.setattr("subprocess.run", fake_run)
+
+        with pytest.raises(RuntimeError) as excinfo:
+            _run_trivy("docker:argus-scan", tmp_path, local=True)
+        assert "JSON parse error" in str(excinfo.value)
+
+
+# ───────────────────────────────────────────────
+# End-to-end orchestration: error is recorded, not silenced
+# ───────────────────────────────────────────────
+
+
+class TestOrchestratorRecordsScannerError:
+    """Closing the loop: when ``_run_grype`` raises RuntimeError, the
+    orchestrator must catch it and record under ``scanner_errors`` so
+    the summary reflects reality (Grype failed, not "Grype found 0
+    matches"). Trivy results in the same scan must still propagate."""
+
+    def test_grype_failure_does_not_silently_drop_other_scanner_findings(
+        self, tmp_path, monkeypatch,
+    ):
+        from argus.container.scanner import scan_image
+        from argus.container.discovery import ContainerTarget
+        from argus.core.models import Finding, Severity
+
+        target = ContainerTarget(name="app", image_ref="docker:argus-scan")
+
+        # Trivy succeeds with one finding.
+        def fake_trivy(image_ref, tmp_path, local=False):
+            return [Finding(
+                id="CVE-2024-9999", severity=Severity.HIGH, title="test",
+                cve="CVE-2024-9999", scanner="trivy",
+            )]
+
+        # Grype raises the new structured RuntimeError.
+        def fake_grype(image_ref, tmp_path, local=False):
+            raise RuntimeError(
+                "grype scan failed (exit 1): catalog resolution failed"
+            )
+
+        monkeypatch.setattr("argus.container.scanner._run_trivy", fake_trivy)
+        monkeypatch.setattr("argus.container.scanner._run_grype", fake_grype)
+
+        result = scan_image(
+            target, scanners=["trivy", "grype"], sbom=False,
+        )
+
+        # Trivy's contribution is preserved.
+        assert len(result.trivy_findings) == 1
+        # Grype's failure is recorded structurally — the engine /
+        # reporters can surface it instead of pretending grype ran
+        # cleanly with zero findings.
+        assert "grype" in result.scanner_errors
+        assert "catalog resolution failed" in result.scanner_errors["grype"]
+        # Combined view doesn't claim grype's missing data is "no
+        # vulnerabilities" — it's simply trivy's findings.
+        assert len(result.combined_findings) == 1


### PR DESCRIPTION
## Description

Fixes the user-reported `JSONDecodeError` traceback from Grype's container scan when the grype subprocess writes an empty `grype-results.json` (typically after image resolution / catalog failures). Also closes the related silent-downgrade path where Grype's parse failure was swallowed and the summary claimed "0 findings" instead of "scanner failed."

## Root cause

`argus/container/scanner.py:_run_grype` checked only `output_file.exists()` before calling `parse_grype_results`, but Grype's wrapper can:
1. Print to stderr,
2. Exit non-zero,
3. Still leave a 0-byte `grype-results.json` from the redirect target.

`output_file.exists()` is True for a 0-byte file, so the existing guard skipped — and `json.loads("")` raised `JSONDecodeError`. The function's `except Exception: logger.exception(...); return []` swallowed it after dumping a traceback to stderr. Engine never saw a `RuntimeError`, so `scanner_errors["grype"]` was never set; the summary reported "Grype: 0 findings" as if the scan succeeded.

Trivy had a similar shape — `logger.exception` on parse failure dumped a traceback even though it correctly re-raised.

## Fix

New shared helper **`_validate_scanner_output(scanner_name, output_file, result)`** that validates in order:
1. `result.returncode == 0`
2. `output_file.exists()`
3. `output_file.stat().st_size > 0`

On any failure: logs at `ERROR` (clipped stderr, no traceback) and raises a single `RuntimeError(f"<scanner> scan failed (exit N): <stderr>")` shape.

`_run_grype` and `_run_trivy` both call the helper after their subprocess returns, then translate JSON parse errors into the same `RuntimeError` shape — instead of bare `JSONDecodeError` (Grype) or silent `return []` (Grype). `logger.exception` → `logger.error` on parse-failure paths so users don't see a Python traceback for an expected scanner failure mode.

The orchestrator's existing `try/except RuntimeError` around `_run_grype` / `_run_trivy` already records errors under `scanner_errors`; this PR makes the runners *actually* raise the right shape instead of silencing.

## Changes Made
- [ ] Added new scanner/workflow
- [x] Modified existing scanner/workflow
- [ ] Updated documentation
- [x] Fixed bug
- [ ] Other

## Acceptance Criteria

| Criterion | Status |
|---|---|
| No `JSONDecodeError` traceback from empty Grype output | ✅ `_validate_scanner_output` catches the empty file before parse; parse errors translate to `RuntimeError` |
| Grype failure clearly reported as scanner error with reason | ✅ `RuntimeError(f"grype scan failed (exit {N}): {stderr}")` — exit code + clipped stderr both surface |
| Container scan summary remains accurate (no false-success implication for failed Grype) | ✅ Orchestrator records `scanner_errors["grype"]`; combined view doesn't claim Grype's missing data is "no vulnerabilities" |
| Regression test: non-zero exit + empty file | ✅ `test_nonzero_exit_with_empty_file_raises_runtimeerror` |
| Regression test: zero exit + empty file | ✅ `test_zero_exit_with_empty_file_raises_runtimeerror` |
| Regression test: malformed JSON file | ✅ `test_malformed_json_raises_runtimeerror_not_jsondecodeerror` |
| Regression test: valid JSON file passes parse path | ✅ `test_valid_json_passes_through_to_parser` |

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

### Test Results
- **Full SDK suite green: 1451 passed, 8 skipped, 7 deselected** (+13 from this PR).

**New tests (`argus/tests/test_container_scanner_runners.py`):**

- `TestValidateScannerOutput` (6 cases) — helper acceptance matrix: healthy silent, non-zero exit raises with stderr, missing file, 0-byte file, stderr+0-byte combo, short-stderr verbatim.
- `TestRunGrype` (4 cases) — exactly the user's acceptance matrix: non-zero+empty, zero+empty, malformed JSON, valid JSON happy path.
- `TestRunTrivy` (2 cases) — mirror coverage proving Trivy benefits from the same fix.
- `TestOrchestratorRecordsScannerError` (1 case) — end-to-end: Grype's `RuntimeError` flows up to `scanner_errors["grype"]` AND Trivy's findings still propagate in the same scan. Closes the loop on "preserve partial results from other scanners but clearly surface the failure."

## Security Considerations
- [x] No security impact
- [ ] Security enhancement
- [ ] Potential security implications

### Security Details
This is a robustness fix on already-validated input (subprocess output from a trusted scanner binary). Stderr is clipped to 500 chars before logging to avoid pathological output sizes flooding the terminal. No new file-system reach or attack surface.

## AI Context Updates (.ai/)
- [x] N/A — internal scanner runner refactor; no architecture or workflow change

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (if applicable) — comments in scanner.py document the new contract
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Closes # (n/a — Codex-style user prompt from in-product testing on 0.7.2.dev83)
