### PR TITLE
fix(container): handle Grype source-scheme prefix collisions in image refs

### DIFF
--- a/argus/container/discovery.py
+++ b/argus/container/discovery.py
@@ -11,6 +11,63 @@ _DOCKERFILE_NAMES = {"Dockerfile"}
 _DOCKERFILE_PREFIX = "Dockerfile."
 _DOCKERFILE_SUFFIX = ".Dockerfile"
 
+# Grype reserves a set of CLI source-scheme prefixes (``docker:``,
+# ``podman:``, ``registry:``, etc.). When an image reference happens
+# to start with one of these — e.g. ``docker:argus-scan`` (image name
+# ``docker``, tag ``argus-scan``) — Grype mis-parses the colon as the
+# scheme separator and looks for a non-existent image ``argus-scan``
+# in the docker daemon, instead of an image ``docker`` with tag
+# ``argus-scan``. Trivy doesn't have this ambiguity (positional arg,
+# no scheme prefixes), so the collision is Grype-specific.
+#
+# We address it in two places:
+#   1. Config-load: warn the user so they can rename before the scan
+#      runs (less time wasted on a build that won't surface findings).
+#   2. Runtime: when scanning a locally-built image, prefix the ref
+#      with ``docker:`` so Grype's parser sees an explicit scheme
+#      regardless of what the user named the image. ``docker:foo``
+#      becomes ``docker:docker:foo`` — Grype treats the first as the
+#      scheme and the rest as the image identifier.
+GRYPE_RESERVED_PREFIXES: tuple[str, ...] = (
+    "docker:",
+    "podman:",
+    "registry:",
+    "dir:",
+    "sbom:",
+    "oci-archive:",
+    "oci-dir:",
+    "singularity:",
+    "attestation:",
+)
+
+
+def warn_on_grype_prefix_collision(image_ref: str) -> str | None:
+    """Return a remediation message when ``image_ref`` collides with a
+    Grype source-scheme prefix; ``None`` otherwise.
+
+    Surfaced at config-load time so users see the issue before the
+    Docker build runs (saves them ~10s on a typical local build that
+    will produce zero Grype findings).
+    """
+    if not isinstance(image_ref, str):
+        return None
+    for prefix in GRYPE_RESERVED_PREFIXES:
+        if image_ref.startswith(prefix):
+            # Suggest a rename that preserves the user's tag if any.
+            tag = image_ref[len(prefix):] if ":" in image_ref else "dev"
+            suggested = f"argus-app:{tag or 'dev'}"
+            return (
+                f"image '{image_ref}' starts with the Grype source-scheme "
+                f"prefix '{prefix}' — Grype will mis-parse this as a "
+                f"scheme request and look for an image named "
+                f"'{image_ref[len(prefix):]}' in the docker daemon, "
+                f"instead of an image '{prefix.rstrip(':')}' with tag "
+                f"'{image_ref[len(prefix):]}'. Rename to e.g. "
+                f"'{suggested}' or 'myorg/{image_ref.split(':', 1)[-1] or 'app'}:dev' "
+                f"to avoid the collision."
+            )
+    return None
+
 
 @dataclass
 class ContainerTarget:
@@ -95,6 +152,14 @@ def parse_container_config(config: dict) -> list[ContainerTarget]:
         image_ref = entry.get("image", "")
         if not image_ref:
             continue
+
+        # Surface Grype prefix-collisions at config-load — well before
+        # the build runs. The warning is non-fatal so users with
+        # build-only or trivy-only flows aren't blocked by a Grype-
+        # specific naming issue.
+        collision = warn_on_grype_prefix_collision(image_ref)
+        if collision:
+            logger.warning(collision)
 
         dockerfile_path = entry.get("dockerfile")
         context_path = entry.get("context")

--- a/argus/container/scanner.py
+++ b/argus/container/scanner.py
@@ -429,6 +429,24 @@ def _run_grype(
         use_container = True
         logger.info("Running grype via container: %s", image)
 
+    # Grype's CLI uses source-scheme prefixes (``docker:``, ``podman:``,
+    # etc.). When we're scanning a locally-built image, force the
+    # docker-daemon source by prepending ``docker:`` to the user's ref.
+    # Two effects:
+    #   (a) For "normal" refs like ``myapp:dev``, this reads as
+    #       "use docker daemon, image ``myapp:dev``" — the desired path.
+    #   (b) For refs that happen to collide with a scheme prefix
+    #       (``docker:argus-scan`` etc.), the explicit prefix flips
+    #       Grype's parser back to "scheme=docker, identifier=<the
+    #       whole user ref>" — so the user's literal name is preserved
+    #       and resolved against the local daemon, not mis-parsed as
+    #       a scheme request.
+    #
+    # For remote (registry) scans we leave the ref untouched — that
+    # path was working before, and forcing a local-daemon source for
+    # an image that doesn't exist locally would itself break.
+    grype_target = f"docker:{image_ref}" if local else image_ref
+
     if use_container:
         from argus import container_runtime
         from argus.containers import get_image
@@ -450,13 +468,13 @@ def _run_grype(
             )
 
         cmd = [rt, "run", "--rm"] + vol_args + [
-            image, image_ref,
+            image, grype_target,
             "-o", "json",
             "--file", "/output/grype-results.json",
         ]
     else:
         cmd = [
-            "grype", image_ref,
+            "grype", grype_target,
             "-o", "json",
             "--file", str(output_file),
         ]

--- a/argus/tests/test_container_discovery.py
+++ b/argus/tests/test_container_discovery.py
@@ -275,3 +275,74 @@ class TestParseContainerConfigUnwrappedShape:
         targets = parse_container_config({"images": [{"image": ref}]})
         assert len(targets) == 1
         assert targets[0].image_ref == ref
+
+
+class TestGrypePrefixCollisionWarning:
+    """Image refs that collide with Grype's CLI source-scheme prefixes
+    (``docker:``, ``podman:``, ``registry:``, etc.) get mis-parsed by
+    Grype as scheme requests. Argus warns at config-load so users see
+    the issue before the build runs."""
+
+    def test_warn_on_docker_prefix(self):
+        from argus.container.discovery import warn_on_grype_prefix_collision
+        msg = warn_on_grype_prefix_collision("docker:argus-scan")
+        assert msg is not None
+        # Names the actual prefix and explains the misparse.
+        assert "docker:" in msg
+        assert "scheme" in msg.lower() or "mis-parse" in msg.lower()
+        # Suggests a rename path.
+        assert "Rename" in msg or "rename" in msg
+
+    def test_warn_on_each_reserved_prefix(self):
+        from argus.container.discovery import (
+            GRYPE_RESERVED_PREFIXES,
+            warn_on_grype_prefix_collision,
+        )
+        # Sanity: the documented reserved-prefix list is non-empty
+        # and every entry triggers the warning.
+        assert len(GRYPE_RESERVED_PREFIXES) >= 5
+        for prefix in GRYPE_RESERVED_PREFIXES:
+            ref = f"{prefix}myapp"
+            msg = warn_on_grype_prefix_collision(ref)
+            assert msg is not None, f"expected warning for {ref!r}"
+
+    def test_no_warning_for_clean_refs(self):
+        from argus.container.discovery import warn_on_grype_prefix_collision
+        for ref in (
+            "myapp:dev",
+            "argus-app:dev",
+            "myorg/app:1.0",
+            "ghcr.io/myorg/app:1.0",
+            "alpine:3.20@sha256:abc123",
+        ):
+            assert warn_on_grype_prefix_collision(ref) is None, (
+                f"unexpected warning for {ref!r}"
+            )
+
+    def test_warning_logged_during_parse(self, caplog):
+        # Integration: parse_container_config logs the warning when
+        # an image ref collides. caplog captures it via the
+        # ``argus.container`` logger.
+        import logging
+        caplog.set_level(logging.WARNING, logger="argus.container")
+
+        config = {
+            "images": [
+                {"image": "docker:argus-scan", "dockerfile": "Dockerfile"},
+            ],
+        }
+        targets = parse_container_config(config)
+        # Target is still resolved — the warning is non-fatal.
+        assert len(targets) == 1
+        # And the warning surfaced.
+        assert any(
+            "docker:argus-scan" in record.message
+            and "scheme" in record.message.lower()
+            for record in caplog.records
+        ), "expected a Grype prefix-collision warning during parse"
+
+    def test_non_string_image_ref_does_not_crash(self):
+        from argus.container.discovery import warn_on_grype_prefix_collision
+        # Defensive — never raise on malformed input.
+        assert warn_on_grype_prefix_collision(None) is None  # type: ignore[arg-type]
+        assert warn_on_grype_prefix_collision(123) is None  # type: ignore[arg-type]

--- a/argus/tests/test_container_scanner_runners.py
+++ b/argus/tests/test_container_scanner_runners.py
@@ -214,6 +214,82 @@ class TestRunGrype:
         assert findings[0].cve == "CVE-2024-1234"
 
 
+class TestRunGrypeLocalDaemonScheme:
+    """When Grype scans a locally-built image, its CLI source-scheme
+    prefix collides with image refs that happen to start with
+    ``docker:`` (etc.). The runner forces the docker-daemon source
+    explicitly so user-supplied refs are never misparsed.
+    """
+
+    def _force_local_binary(self, monkeypatch):
+        monkeypatch.setattr(
+            "argus.container.scanner.shutil.which",
+            lambda name: "/usr/local/bin/grype" if name == "grype" else None,
+        )
+
+    def test_local_target_is_prefixed_with_docker_scheme(
+        self, tmp_path, monkeypatch,
+    ):
+        """The image ref grype sees gets a ``docker:`` scheme prefix
+        when ``local=True``, so the daemon source is unambiguous."""
+        self._force_local_binary(monkeypatch)
+        captured = {}
+
+        def fake_run(cmd, **_kwargs):
+            captured["cmd"] = list(cmd)
+            (tmp_path / "grype-results.json").write_text(
+                '{"matches": []}'
+            )
+            return _completed(returncode=0)
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+        _run_grype("docker:argus-scan", tmp_path, local=True)
+
+        # The argument grype receives is the user's literal ref,
+        # prefixed with the scheme. ``docker:argus-scan`` becomes
+        # ``docker:docker:argus-scan`` — first half is the scheme,
+        # the rest is the daemon image identifier.
+        assert "docker:docker:argus-scan" in captured["cmd"]
+        # And the bare un-prefixed ref isn't accidentally also there.
+        assert captured["cmd"].count("docker:argus-scan") == 0
+
+    def test_local_target_with_clean_ref_still_gets_prefix(
+        self, tmp_path, monkeypatch,
+    ):
+        """Refs that don't collide still get the prefix — uniform
+        behavior is easier to reason about than "sometimes prefix"."""
+        self._force_local_binary(monkeypatch)
+        captured = {}
+
+        def fake_run(cmd, **_kwargs):
+            captured["cmd"] = list(cmd)
+            (tmp_path / "grype-results.json").write_text('{"matches": []}')
+            return _completed(returncode=0)
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+        _run_grype("myapp:dev", tmp_path, local=True)
+        assert "docker:myapp:dev" in captured["cmd"]
+
+    def test_remote_target_is_not_prefixed(self, tmp_path, monkeypatch):
+        """For registry scans (``local=False``), the original ref
+        passes through untouched — the docker-daemon scheme would
+        force grype to look at a daemon that doesn't have the image."""
+        self._force_local_binary(monkeypatch)
+        captured = {}
+
+        def fake_run(cmd, **_kwargs):
+            captured["cmd"] = list(cmd)
+            (tmp_path / "grype-results.json").write_text('{"matches": []}')
+            return _completed(returncode=0)
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+        _run_grype("registry.example/myapp:1.0", tmp_path, local=False)
+
+        assert "registry.example/myapp:1.0" in captured["cmd"]
+        # No accidental scheme prefix on remote scans.
+        assert "docker:registry.example/myapp:1.0" not in captured["cmd"]
+
+
 class TestRunTrivy:
     """Mirror coverage for trivy — same failure-mode contract via the
     shared validator. Confirms grype isn't the only beneficiary of the


### PR DESCRIPTION
fix(container): handle Grype source-scheme prefix collisions in image refs

Background
- User config: ``image: docker:argus-scan, dockerfile: docker/Dockerfile,
  context: .``
- Argus's builder correctly runs ``docker build --tag docker:argus-scan
  --file docker/Dockerfile .`` and tags the image locally.
- Grype's CLI then mis-parses ``docker:argus-scan``: ``docker:`` is a
  reserved Grype source-scheme prefix (alongside ``podman:``,
  ``registry:``, ``dir:``, ``sbom:``, ``oci-archive:``, ``oci-dir:``,
  ``singularity:``, ``attestation:``). Grype reads the colon as the
  scheme separator, looks for an image named ``argus-scan`` in the
  docker daemon, and fails — the user's locally-built image
  ``docker:argus-scan`` (image ``docker``, tag ``argus-scan``) is
  never resolved.
- Trivy doesn't have this ambiguity (positional arg, no scheme
  prefixes), so the same target works under Trivy.

Two-pronged fix
1. Config-load warning. ``warn_on_grype_prefix_collision`` checks
   each image ref against the reserved-prefix list at parse time
   and logs a remediation message ("rename to e.g. ``argus-app:dev``")
   before the Docker build runs — saves the user a wasted build
   cycle. Non-fatal so Trivy-only or build-only workflows aren't
   blocked.
2. Runtime escape in ``_run_grype``. When ``local=True``, the
   user's ref is prefixed with ``docker:`` so Grype's parser sees
   an explicit scheme regardless of what the user named the image:
     ``docker:argus-scan`` → ``docker:docker:argus-scan`` (scheme
     ``docker``, identifier ``docker:argus-scan``)
     ``myapp:dev``         → ``docker:myapp:dev`` (scheme
     ``docker``, identifier ``myapp:dev``)
   For remote (registry) scans we leave the ref untouched — that
   path was working before, and forcing the daemon source for an
   image that doesn't exist locally would break it.

Behavior preserved
- Trivy invocation unchanged.
- Healthy Grype scans (clean ref, ``local=True`` or ``local=False``)
  resolve identically; the new prefix is a no-op for daemon-resident
  images.

Tests (+8)
- ``TestGrypePrefixCollisionWarning`` (5): warning fires for each
  documented prefix, doesn't fire for clean refs, surfaces during
  ``parse_container_config``, defensive on non-string input,
  message includes a rename suggestion.
- ``TestRunGrypeLocalDaemonScheme`` (3): local target gets the
  ``docker:`` prefix uniformly (collision case AND clean-ref case),
  remote target does not.

Validation
- Full SDK suite: 1459 passed (+8), 8 skipped.