### PR TITLE
feat(scan): emit canonical argus-results.json + persist raw scanner output (source + container)

### DIFF
--- a/argus.example.yml
+++ b/argus.example.yml
@@ -55,6 +55,15 @@ reporting:
   severity_threshold: high
   output_dir: "./argus-results"
 
+  # Persist each scanner's raw output (results.json, *.sarif,
+  # stdout.txt) under ``<output_dir>/raw/<scanner>/`` alongside the
+  # canonical argus-results.json. Default true — useful for
+  # forensics, audit trails, and manual triage. Set false (or pass
+  # --no-keep-raw on the CLI) to skip; saves a few MB per scan in
+  # tight CI environments. Applies to both source scans (``argus
+  # scan``) and container scans (``argus scan container``).
+  keep_raw: true
+
 # Container lifecycle targets (consumed by ``argus scan container``).
 # Defining anything under this top-level ``containers:`` key activates
 # config-driven container scans — no need to pass --image / --discover
@@ -102,14 +111,10 @@ reporting:
 #   # Override which sub-scanners run; default is trivy + grype.
 #   scanners: [trivy, grype, syft]
 #
-#   # Persist raw per-scanner artifacts (trivy-results.json,
-#   # grype-results.json, syft-sbom.json) under
-#   # ``<output_dir>/raw/<image>/`` alongside the canonical
-#   # argus-results.json. Default is true so the artifacts are
-#   # available for forensics, audit, or manual triage. Set false
-#   # (or pass --no-keep-raw on the CLI) to skip — saves a few MB
-#   # per image when running in tight CI environments.
-#   keep_raw: true
+# Note: raw scanner-output preservation is configured via the
+# unified ``reporting.keep_raw`` knob above — the same flag covers
+# trivy/grype/syft container outputs and source-scan scanner
+# outputs. No separate container-only setting is needed.
 
 # Execution backend configuration
 execution:

--- a/argus.example.yml
+++ b/argus.example.yml
@@ -101,6 +101,15 @@ reporting:
 #
 #   # Override which sub-scanners run; default is trivy + grype.
 #   scanners: [trivy, grype, syft]
+#
+#   # Persist raw per-scanner artifacts (trivy-results.json,
+#   # grype-results.json, syft-sbom.json) under
+#   # ``<output_dir>/raw/<image>/`` alongside the canonical
+#   # argus-results.json. Default is true so the artifacts are
+#   # available for forensics, audit, or manual triage. Set false
+#   # (or pass --no-keep-raw on the CLI) to skip — saves a few MB
+#   # per image when running in tight CI environments.
+#   keep_raw: true
 
 # Execution backend configuration
 execution:

--- a/argus/cli.py
+++ b/argus/cli.py
@@ -616,6 +616,18 @@ def _build_scan_parser(subparsers: argparse._SubParsersAction) -> None:
         default=None,
         help="Sub-scanners for container scanning: trivy,grype,syft (default: trivy,grype)",
     )
+    container_group.add_argument(
+        "--no-keep-raw",
+        action="store_true",
+        dest="no_keep_raw",
+        help="Do not persist raw per-scanner output (trivy-results.json, "
+             "grype-results.json, syft-sbom.json) under "
+             "<output_dir>/raw/<image>/. By default raw artifacts are "
+             "kept alongside the canonical argus-results.json so users "
+             "can drill into individual scanner output for forensics or "
+             "manual triage. Set ``containers.keep_raw: false`` in argus.yml "
+             "for the same effect via config.",
+    )
 
     # ZAP DAST flags (used with: argus scan zap)
     dast_group = scan_parser.add_argument_group(
@@ -1733,6 +1745,18 @@ def _cmd_container_scan(
     output_dir = _make_run_dir(base_dir)
     formats = args.formats or ["terminal", "markdown"]
 
+    # Decide whether to persist raw per-scanner outputs alongside the
+    # canonical argus-results.json. Default is ON — the user just ran
+    # a scan and would expect those artifacts to be available for
+    # manual triage. Opt out via ``--no-keep-raw`` (CLI) or
+    # ``containers.keep_raw: false`` (argus.yml). CLI flag wins on
+    # conflict, matching the rest of the dispatcher's
+    # explicit-over-implicit posture.
+    keep_raw_config = config.get("keep_raw", True)
+    keep_raw = bool(keep_raw_config) and not getattr(args, "no_keep_raw", False)
+    if keep_raw:
+        config["_raw_output_root"] = str(Path(output_dir) / "raw")
+
     # Run
     try:
         engine = ContainerEngine(config)
@@ -1745,6 +1769,42 @@ def _cmd_container_scan(
         print(f"Error: container scan failed: {exc}", file=sys.stderr)
         return EXIT_ERROR
 
+    # Build a canonical ScanSummary view of the container results so
+    # the standard reporters (json → argus-results.json, sarif) and
+    # ``argus view`` can consume container scans the same way they
+    # consume source scans. Each container target becomes a
+    # ScanResult; the per-image domain metadata (image_ref, build
+    # status, scanner_errors) lifts onto ScanResult.metadata so the
+    # browser dashboard and exporters surface it.
+    from argus.core.models import ScanResult, ScanSummary
+    canonical_results = [
+        ScanResult(
+            scanner=f"container/{r.name}",
+            findings=list(r.combined_findings),
+            metadata={
+                "image_ref": r.image_ref,
+                "build_success": r.build_success,
+                **(
+                    {"scanner_errors": dict(r.scanner_errors)}
+                    if r.scanner_errors else {}
+                ),
+                **(
+                    {"scan_error": r.scan_error}
+                    if getattr(r, "scan_error", None) else {}
+                ),
+            },
+        )
+        for r in summary.results
+    ]
+    canonical_summary = ScanSummary(results=canonical_results)
+
+    # Always emit argus-results.json — same canonical-artifact
+    # contract the source-scan flow established. ``argus view`` and
+    # the audit manifest both consume this regardless of what the
+    # user listed in ``formats``.
+    from argus.reporters import get_reporter
+    get_reporter("json").report(canonical_summary, output_dir)
+
     # Reports
     for fmt in formats:
         if fmt == "markdown":
@@ -1755,16 +1815,15 @@ def _cmd_container_scan(
         elif fmt == "terminal":
             _print_container_terminal(summary)
         elif fmt == "json":
+            # Domain-shaped per-image summary (container_count etc.)
+            # lives at container-scan.json. The canonical
+            # argus-results.json was already written above; this
+            # is the supplementary domain artifact for tooling that
+            # wants per-image stats without parsing findings.
             _write_container_json(summary, output_dir)
         elif fmt == "sarif":
-            from argus.core.models import ScanResult, ScanSummary
-            from argus.reporters import get_reporter
-            results = [
-                ScanResult(scanner=f"container/{r.name}", findings=r.combined_findings)
-                for r in summary.results
-            ]
             sarif_reporter = get_reporter("sarif")
-            sarif_reporter.report(ScanSummary(results=results), output_dir)
+            sarif_reporter.report(canonical_summary, output_dir)
 
     # Exit code — scanner failures are always non-zero
     scan_failures = getattr(summary, "scan_failures", 0)

--- a/argus/cli.py
+++ b/argus/cli.py
@@ -590,6 +590,19 @@ def _build_scan_parser(subparsers: argparse._SubParsersAction) -> None:
         help="Disable DB cache volume mounts. Forces scanners to re-download "
              "vulnerability databases on every container run.",
     )
+    scan_parser.add_argument(
+        "--no-keep-raw",
+        action="store_true",
+        dest="no_keep_raw",
+        help="Do not persist raw per-scanner output files alongside the "
+             "canonical argus-results.json. Source scans normally drop "
+             "each scanner's results.json / *.sarif / stdout.txt under "
+             "<output_dir>/raw/<scanner>/; container scans drop "
+             "trivy-results.json / grype-results.json / syft-sbom.json "
+             "under <output_dir>/raw/<image>/. Pass --no-keep-raw to "
+             "skip that step in tight CI environments. The same effect "
+             "is available via 'reporting.keep_raw: false' in argus.yml.",
+    )
 
     # Container-specific flags (used with: argus scan container)
     container_group = scan_parser.add_argument_group(
@@ -615,18 +628,6 @@ def _build_scan_parser(subparsers: argparse._SubParsersAction) -> None:
         "--scanners",
         default=None,
         help="Sub-scanners for container scanning: trivy,grype,syft (default: trivy,grype)",
-    )
-    container_group.add_argument(
-        "--no-keep-raw",
-        action="store_true",
-        dest="no_keep_raw",
-        help="Do not persist raw per-scanner output (trivy-results.json, "
-             "grype-results.json, syft-sbom.json) under "
-             "<output_dir>/raw/<image>/. By default raw artifacts are "
-             "kept alongside the canonical argus-results.json so users "
-             "can drill into individual scanner output for forensics or "
-             "manual triage. Set ``containers.keep_raw: false`` in argus.yml "
-             "for the same effect via config.",
     )
 
     # ZAP DAST flags (used with: argus scan zap)
@@ -1147,6 +1148,15 @@ def _load_container_config(args: argparse.Namespace) -> dict:
             )
         config = dict(containers_section)
 
+        # Pull ``reporting.keep_raw`` from the same file so the
+        # container handler honors the unified config knob — same
+        # default-True semantics as ``_cmd_source_scan``. Stashed
+        # under a synthetic underscore key so it doesn't collide
+        # with any future ``containers:`` field a user might add.
+        reporting_section = file_config.get("reporting", {})
+        if isinstance(reporting_section, dict) and "keep_raw" in reporting_section:
+            config["_reporting_keep_raw"] = bool(reporting_section["keep_raw"])
+
     # CLI overrides — explicit > implicit. --image and --discover both
     # OVERWRITE the corresponding config keys so the user's intent is
     # unambiguous (and so we don't accidentally double-scan an image
@@ -1260,6 +1270,18 @@ def _cmd_source_scan(args: argparse.Namespace) -> int:
 
     log.info("Argus scan starting")
 
+    # Decide whether to persist raw per-scanner outputs alongside the
+    # canonical argus-results.json. Default ON — users running
+    # ``argus scan`` reasonably expect each scanner's raw results
+    # (results.json / *.sarif / stdout.txt) to be available for
+    # forensics or manual triage. Opt out via ``--no-keep-raw``
+    # (CLI) or ``reporting.keep_raw: false`` (argus.yml). CLI flag
+    # wins on conflict, matching the dispatcher's
+    # explicit-over-implicit posture used throughout.
+    keep_raw_config = getattr(config.reporting, "keep_raw", True)
+    keep_raw = bool(keep_raw_config) and not getattr(args, "no_keep_raw", False)
+    raw_output_root = str(Path(output_dir) / "raw") if keep_raw else None
+
     # Build engine and register scanners
     engine = ArgusEngine(config)
 
@@ -1364,6 +1386,7 @@ def _cmd_source_scan(args: argparse.Namespace) -> int:
                             use_default_excludes=not getattr(args, "no_default_excludes", False),
                             sbom_path=str(info.path),
                             sbom_format=info.format,
+                            raw_output_dir=raw_output_root,
                         )
                     except Exception as exc:
                         log.error(
@@ -1404,6 +1427,7 @@ def _cmd_source_scan(args: argparse.Namespace) -> int:
                     allow_local_versions=getattr(args, "allow_local_versions", False),
                     no_cache=getattr(args, "no_cache", False),
                     use_default_excludes=not getattr(args, "no_default_excludes", False),
+                    raw_output_dir=raw_output_root,
                 )
         if args.verbose and getattr(engine, "_last_resolutions", None):
             from argus.core.tool_config import format_resolutions_for_display
@@ -1752,7 +1776,13 @@ def _cmd_container_scan(
     # ``containers.keep_raw: false`` (argus.yml). CLI flag wins on
     # conflict, matching the rest of the dispatcher's
     # explicit-over-implicit posture.
-    keep_raw_config = config.get("keep_raw", True)
+    # ``reporting.keep_raw`` is the unified config home for raw-output
+    # preservation; the legacy ``containers.keep_raw`` is still read
+    # as a fallback so configs from earlier in this PR's lifecycle
+    # don't break. CLI ``--no-keep-raw`` wins over both.
+    keep_raw_config = config.get(
+        "_reporting_keep_raw", config.get("keep_raw", True),
+    )
     keep_raw = bool(keep_raw_config) and not getattr(args, "no_keep_raw", False)
     if keep_raw:
         config["_raw_output_root"] = str(Path(output_dir) / "raw")

--- a/argus/container/engine.py
+++ b/argus/container/engine.py
@@ -6,6 +6,7 @@ on constrained environments like CI runners.
 """
 
 import logging
+from pathlib import Path
 
 from .builder import build_image
 from .discovery import (
@@ -130,10 +131,20 @@ class ContainerEngine:
             self._built_images.append(target.image_ref)
 
         try:
+            # If the dispatcher set ``_raw_output_root`` in the
+            # config dict, persist this target's raw scanner outputs
+            # under ``<root>/<target.name>/``. Caller controls
+            # whether this is set (CLI flag + config opt-out); the
+            # engine just threads it through.
+            raw_root = self.config.get("_raw_output_root")
+            target_raw_dir = (
+                Path(raw_root) / target.name if raw_root else None
+            )
             return scan_image(
                 target,
                 scanners=self._scanners(),
                 sbom=self._sbom_enabled(),
+                raw_output_dir=target_raw_dir,
             )
         except OSError as exc:
             # Disk full, permission denied, etc.

--- a/argus/container/scanner.py
+++ b/argus/container/scanner.py
@@ -123,6 +123,7 @@ def scan_image(
     target: ContainerTarget,
     scanners: tuple[str, ...] = ("trivy", "grype"),
     sbom: bool = True,
+    raw_output_dir: Path | None = None,
 ) -> ContainerScanResult:
     """Scan a single container image with trivy and/or grype.
 
@@ -132,7 +133,19 @@ def scan_image(
 
     For locally-built images, scanners reference the local Docker daemon.
     Per-scanner errors are caught and recorded, not swallowed.
+
+    ``raw_output_dir``: when supplied, the raw scanner output files
+    (``trivy-results.json``, ``grype-results.json``, ``syft-sbom.json``)
+    are copied into this directory before the temp dir is cleaned up.
+    Lets users preserve full per-scanner artifacts for forensics,
+    audit, or manual triage workflows alongside the canonical
+    ``argus-results.json``. ``None`` (the default) means transient
+    output — historic behavior.
     """
+    import shutil as _shutil  # local import to avoid shadowing the
+                              # module-level ``shutil`` reference used
+                              # by ``shutil.which`` checks below.
+
     trivy_findings: list[Finding] = []
     grype_findings: list[Finding] = []
     scanner_errors: dict[str, str] = {}
@@ -163,6 +176,29 @@ def scan_image(
 
         if sbom and "syft" not in scanners:
             _run_syft(target.image_ref, tmp_path)
+
+        # Persist raw scanner artifacts (best-effort) before the
+        # tempdir is wiped. We copy whatever files exist; missing
+        # files (e.g. grype failed before writing) just don't get
+        # copied — the structured ``scanner_errors`` already records
+        # why. Errors during copy are non-fatal: the scan succeeded,
+        # the canonical JSON is still emitted upstream.
+        if raw_output_dir is not None:
+            try:
+                raw_output_dir.mkdir(parents=True, exist_ok=True)
+                for fname in (
+                    "trivy-results.json",
+                    "grype-results.json",
+                    "syft-sbom.json",
+                ):
+                    src = tmp_path / fname
+                    if src.exists() and src.stat().st_size > 0:
+                        _shutil.copy2(src, raw_output_dir / fname)
+            except OSError as exc:
+                logger.warning(
+                    "Failed to persist raw scanner outputs to %s: %s",
+                    raw_output_dir, exc,
+                )
 
     combined = deduplicate_findings(trivy_findings, grype_findings)
 

--- a/argus/core/config.py
+++ b/argus/core/config.py
@@ -44,6 +44,14 @@ class ReportingConfig:
     formats: list[str] = field(default_factory=lambda: ["terminal"])
     severity_threshold: Optional[Severity] = None
     output_dir: str = "./argus-results"
+    # When True, the engine persists each scanner's raw output files
+    # (results.json / *.sarif / stdout.txt) under
+    # ``<output_dir>/raw/<scanner>/`` alongside the canonical
+    # ``argus-results.json``. Default ON since most users running
+    # ``argus scan`` would expect the artifacts to be available for
+    # forensics or manual triage; opt out via ``--no-keep-raw`` (CLI)
+    # or ``reporting.keep_raw: false`` for tight CI environments.
+    keep_raw: bool = True
 
 
 @dataclass
@@ -208,6 +216,7 @@ def _parse_reporting_config(raw: dict | None) -> ReportingConfig:
         formats=raw.get("formats", ["terminal"]),
         severity_threshold=_parse_severity(raw.get("severity_threshold")),
         output_dir=raw.get("output_dir", "./argus-results"),
+        keep_raw=bool(raw.get("keep_raw", True)),
     )
 
 

--- a/argus/core/engine.py
+++ b/argus/core/engine.py
@@ -35,6 +35,7 @@ class ArgusEngine:
         self._no_cache: bool = False
         self._sbom_path: str | None = None
         self._sbom_format: str | None = None
+        self._raw_output_root: str | None = None
 
     def register_scanner(self, scanner: Scanner) -> None:
         """Register a scanner instance for use by the engine."""
@@ -59,6 +60,7 @@ class ArgusEngine:
         use_default_excludes: bool = True,
         sbom_path: str | None = None,
         sbom_format: str | None = None,
+        raw_output_dir: str | None = None,
     ) -> ScanSummary:
         """Run scanners and return an aggregated ScanSummary.
 
@@ -79,6 +81,14 @@ class ArgusEngine:
                 attribute is True, auto-enables them regardless of
                 argus.yml, and threads the SBOM path through
                 ``config_dict['sbom_path']``.
+            raw_output_dir: when set, ``_run_in_container`` copies each
+                scanner's raw output files (``results.json``,
+                ``stdout.txt``, ``*.sarif``) into
+                ``<raw_output_dir>/<scanner_name>/`` before the
+                per-scanner tempdir is cleaned up. Mirrors the
+                container-scan flow's ``raw/`` artifact preservation
+                so users can drill into individual scanner output
+                regardless of which scan flow produced it.
         """
         from .exclusions import build_exclusion_set, log_exclusion_set
 
@@ -87,6 +97,7 @@ class ArgusEngine:
         self._use_default_excludes = use_default_excludes
         self._sbom_path = sbom_path
         self._sbom_format = sbom_format
+        self._raw_output_root = raw_output_dir
 
         # Validate sbom_format if provided
         if sbom_format is not None and sbom_format not in SBOM_FORMAT_EXTENSIONS:
@@ -709,6 +720,28 @@ class ArgusEngine:
                 stdout_file.write_text(proc.stdout)
                 result_files = [stdout_file]
                 logger.debug("No output files — captured stdout (%d bytes)", len(proc.stdout))
+
+            # Persist raw scanner output (best-effort) before the
+            # tempdir is wiped. Mirrors the container-scan flow's
+            # ``raw/`` artifact preservation: every scanner gets its
+            # own subdir under ``<raw_output_root>/<scanner.name>/``
+            # so ``argus-results.json`` (the canonical artifact)
+            # lives next to the per-scanner files (results.json,
+            # *.sarif, stdout.txt) for forensics or manual triage.
+            # Errors during copy are non-fatal — the scan succeeded,
+            # the canonical JSON is still emitted upstream.
+            if self._raw_output_root and result_files:
+                try:
+                    target_dir = Path(self._raw_output_root) / scanner.name
+                    target_dir.mkdir(parents=True, exist_ok=True)
+                    for src in result_files:
+                        if src.exists() and src.stat().st_size > 0:
+                            shutil.copy2(src, target_dir / src.name)
+                except OSError as exc:
+                    logger.warning(
+                        "Failed to persist raw output for '%s' under %s: %s",
+                        scanner.name, self._raw_output_root, exc,
+                    )
 
             if result_files:
                 logger.debug(

--- a/argus/tests/test_container_scanner_runners.py
+++ b/argus/tests/test_container_scanner_runners.py
@@ -333,6 +333,177 @@ class TestRunTrivy:
 # ───────────────────────────────────────────────
 
 
+class TestScanImageRawOutputPersistence:
+    """``scan_image(raw_output_dir=...)`` copies raw scanner artifacts
+    into a caller-supplied directory so ``argus-results/<run>/raw/``
+    can preserve trivy/grype/syft per-scanner output for forensics
+    after the underlying tempdir is cleaned up."""
+
+    def _stub_runners(self, monkeypatch, write_files=("trivy", "grype")):
+        """Replace the live scanner runners with stubs that drop the
+        files we'd expect to see on a successful real run. Lets these
+        tests focus on the copy/persistence layer without touching
+        the actual binaries."""
+        from argus.container import scanner as scanner_mod
+
+        def fake_trivy(image_ref, tmp_path, local=False):
+            if "trivy" in write_files:
+                (tmp_path / "trivy-results.json").write_text('{"Results": []}')
+            return []
+
+        def fake_grype(image_ref, tmp_path, local=False):
+            if "grype" in write_files:
+                (tmp_path / "grype-results.json").write_text('{"matches": []}')
+            return []
+
+        def fake_syft(image_ref, tmp_path):
+            if "syft" in write_files:
+                (tmp_path / "syft-sbom.json").write_text('{"artifacts": []}')
+
+        monkeypatch.setattr(scanner_mod, "_run_trivy", fake_trivy)
+        monkeypatch.setattr(scanner_mod, "_run_grype", fake_grype)
+        monkeypatch.setattr(scanner_mod, "_run_syft", fake_syft)
+
+    def test_raw_outputs_copied_when_dir_supplied(self, tmp_path, monkeypatch):
+        from argus.container.scanner import scan_image
+        from argus.container.discovery import ContainerTarget
+
+        self._stub_runners(monkeypatch, write_files=("trivy", "grype", "syft"))
+
+        target = ContainerTarget(name="app", image_ref="myapp:dev")
+        raw_dir = tmp_path / "raw" / "app"
+
+        scan_image(target, sbom=True, raw_output_dir=raw_dir)
+
+        # All three artifacts persisted at the expected names.
+        assert (raw_dir / "trivy-results.json").exists()
+        assert (raw_dir / "grype-results.json").exists()
+        assert (raw_dir / "syft-sbom.json").exists()
+        # Contents survived intact.
+        assert "Results" in (raw_dir / "trivy-results.json").read_text()
+
+    def test_no_copy_when_raw_output_dir_is_none(self, tmp_path, monkeypatch):
+        # Default path — historic behavior — leaves no artifacts on
+        # disk after the tempdir cleanup.
+        from argus.container.scanner import scan_image
+        from argus.container.discovery import ContainerTarget
+
+        self._stub_runners(monkeypatch)
+
+        target = ContainerTarget(name="app", image_ref="myapp:dev")
+        scan_image(target, sbom=False, raw_output_dir=None)
+
+        # No `raw/` directory was created (the test's tmp_path is
+        # otherwise empty).
+        assert not (tmp_path / "raw").exists()
+
+    def test_partial_outputs_persisted_when_some_scanners_skipped(
+        self, tmp_path, monkeypatch,
+    ):
+        # Only trivy ran (grype skipped or failed); the raw dir
+        # contains just trivy's file. Missing files don't block the
+        # copy of the ones that exist.
+        from argus.container.scanner import scan_image
+        from argus.container.discovery import ContainerTarget
+
+        self._stub_runners(monkeypatch, write_files=("trivy",))
+
+        target = ContainerTarget(name="app", image_ref="myapp:dev")
+        raw_dir = tmp_path / "raw" / "app"
+
+        scan_image(
+            target, scanners=("trivy",), sbom=False,
+            raw_output_dir=raw_dir,
+        )
+
+        assert (raw_dir / "trivy-results.json").exists()
+        assert not (raw_dir / "grype-results.json").exists()
+        assert not (raw_dir / "syft-sbom.json").exists()
+
+    def test_zero_byte_files_are_not_persisted(self, tmp_path, monkeypatch):
+        # 0-byte files are an explicit failure signal upstream
+        # (``_validate_scanner_output`` rejects them). Don't copy
+        # them — the persistence layer should never make a 0-byte
+        # file look authoritative on disk.
+        from argus.container import scanner as scanner_mod
+        from argus.container.scanner import scan_image
+        from argus.container.discovery import ContainerTarget
+
+        def fake_trivy(image_ref, tmp_path, local=False):
+            (tmp_path / "trivy-results.json").touch()  # 0-byte
+            return []
+
+        monkeypatch.setattr(scanner_mod, "_run_trivy", fake_trivy)
+        monkeypatch.setattr(scanner_mod, "_run_grype", lambda *a, **kw: [])
+        monkeypatch.setattr(scanner_mod, "_run_syft", lambda *a, **kw: None)
+
+        raw_dir = tmp_path / "raw" / "app"
+        scan_image(
+            ContainerTarget(name="app", image_ref="myapp:dev"),
+            scanners=("trivy",), sbom=False, raw_output_dir=raw_dir,
+        )
+        # Either the dir doesn't exist (nothing copied) or it's empty.
+        if raw_dir.exists():
+            assert not list(raw_dir.iterdir())
+
+
+class TestContainerCanonicalScanSummary:
+    """The container scan flow now also emits the canonical
+    ScanSummary shape (the same one source scans use), so
+    ``argus view`` and the JSON reporter can render container
+    findings without a separate code path."""
+
+    def test_each_target_becomes_a_scanresult_with_combined_findings(
+        self, tmp_path, monkeypatch,
+    ):
+        # Exercises the cli.py snippet that maps ContainerScanResult
+        # → ScanResult(scanner=f"container/{name}", ...). Tests a
+        # representative subset of the conversion in isolation.
+        from argus.core.models import ScanResult, ScanSummary, Finding, Severity
+        from argus.container.scanner import (
+            ContainerScanResult, ContainerScanSummary,
+        )
+
+        f1 = Finding(id="CVE-2024-1", severity=Severity.HIGH, title="t1",
+                     cve="CVE-2024-1", scanner="trivy")
+        f2 = Finding(id="CVE-2024-2", severity=Severity.MEDIUM, title="t2",
+                     cve="CVE-2024-2", scanner="grype")
+
+        container_summary = ContainerScanSummary(
+            results=[
+                ContainerScanResult(
+                    name="webapp",
+                    image_ref="myorg/webapp:1.0",
+                    combined_findings=[f1, f2],
+                    scanner_errors={},
+                ),
+            ],
+        )
+
+        # Mirror cli.py's mapping logic.
+        canonical = ScanSummary(results=[
+            ScanResult(
+                scanner=f"container/{r.name}",
+                findings=list(r.combined_findings),
+                metadata={
+                    "image_ref": r.image_ref,
+                    "build_success": r.build_success,
+                },
+            )
+            for r in container_summary.results
+        ])
+
+        # The canonical summary round-trips through the same
+        # serialization the source-scan flow uses, so ``argus view``
+        # treats container findings identically.
+        as_dict = canonical.to_dict()
+        assert "results" in as_dict
+        assert as_dict["results"][0]["scanner"] == "container/webapp"
+        assert len(as_dict["results"][0]["findings"]) == 2
+        # Per-image metadata lifts onto the ScanResult.
+        assert as_dict["results"][0]["metadata"]["image_ref"] == "myorg/webapp:1.0"
+
+
 class TestOrchestratorRecordsScannerError:
     """Closing the loop: when ``_run_grype`` raises RuntimeError, the
     orchestrator must catch it and record under ``scanner_errors`` so

--- a/argus/tests/test_engine.py
+++ b/argus/tests/test_engine.py
@@ -805,6 +805,127 @@ class TestRunInContainer:
         result = engine._run_in_container(scanner, "/src", {})
         assert "execution_failed" not in result.metadata
 
+    def test_raw_output_dir_persists_per_scanner_files(self, monkeypatch, tmp_path):
+        """When ``raw_output_dir`` is set, the engine copies each
+        scanner's raw output (results.json / *.sarif / stdout.txt)
+        into ``<raw_output_dir>/<scanner.name>/`` before the tempdir
+        is wiped. Mirrors the container-scan flow's ``raw/`` artifact
+        preservation so source scans aren't an inconsistent
+        second-class case."""
+        engine = self._make_engine()
+        scanner = self._make_scanner(parse_results=lambda f: [])
+        engine._raw_output_root = str(tmp_path / "raw")
+
+        monkeypatch.setattr(engine, "_pull_image", lambda img: True)
+        monkeypatch.setattr(engine, "_get_image_digest", lambda img: "sha256:abc")
+
+        def mock_run(cmd, **_kwargs):
+            for i, arg in enumerate(cmd):
+                if ":/output" in str(arg):
+                    Path(arg.split(":")[0]).joinpath("results.json").write_text(
+                        '{"findings": []}'
+                    )
+                    break
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="", stderr="",
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+        engine._run_in_container(scanner, "/src", {})
+
+        # File landed at <raw_output_root>/<scanner_name>/results.json
+        # — the per-scanner subdir keeps multi-scanner runs from
+        # colliding on common filenames.
+        persisted = tmp_path / "raw" / scanner.name / "results.json"
+        assert persisted.exists()
+        # Contents survived intact.
+        assert "findings" in persisted.read_text()
+
+    def test_raw_output_dir_none_does_not_persist_files(
+        self, monkeypatch, tmp_path,
+    ):
+        """Default behavior — ``raw_output_dir`` unset — leaves no
+        per-scanner artifacts on disk after the run. Confirms the
+        copy step is opt-in, not always-on."""
+        engine = self._make_engine()
+        scanner = self._make_scanner(parse_results=lambda f: [])
+        # Explicitly None (the default).
+        engine._raw_output_root = None
+
+        monkeypatch.setattr(engine, "_pull_image", lambda img: True)
+        monkeypatch.setattr(engine, "_get_image_digest", lambda img: "sha256:abc")
+
+        def mock_run(cmd, **_kwargs):
+            for i, arg in enumerate(cmd):
+                if ":/output" in str(arg):
+                    Path(arg.split(":")[0]).joinpath("results.json").write_text("{}")
+                    break
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="", stderr="",
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+        engine._run_in_container(scanner, "/src", {})
+
+        # tmp_path is otherwise untouched.
+        assert list(tmp_path.iterdir()) == []
+
+    def test_raw_output_persists_stdout_fallback(self, monkeypatch, tmp_path):
+        """Some scanners write to stdout instead of a file (e.g.
+        ClamAV). The engine captures that as ``stdout.txt`` in the
+        per-scanner tempdir; raw-output preservation should pick it
+        up the same way it picks up regular result files."""
+        engine = self._make_engine()
+        scanner = self._make_scanner(parse_results=lambda f: [])
+        engine._raw_output_root = str(tmp_path / "raw")
+
+        monkeypatch.setattr(engine, "_pull_image", lambda img: True)
+        monkeypatch.setattr(engine, "_get_image_digest", lambda img: "sha256:abc")
+
+        def mock_run(cmd, **_kwargs):
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0,
+                stdout="scanner output line 1\nscanner output line 2\n",
+                stderr="",
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+        engine._run_in_container(scanner, "/src", {})
+
+        persisted = tmp_path / "raw" / scanner.name / "stdout.txt"
+        assert persisted.exists()
+        assert "scanner output line" in persisted.read_text()
+
+    def test_raw_output_skips_zero_byte_files(self, monkeypatch, tmp_path):
+        """0-byte files are explicit failure signals upstream
+        (``_validate_scanner_output`` rejects them in the container
+        sub-scanners). Don't persist them — making known-broken
+        output look authoritative on disk would mislead anyone
+        triaging from the saved artifacts."""
+        engine = self._make_engine()
+        scanner = self._make_scanner(parse_results=lambda f: [])
+        engine._raw_output_root = str(tmp_path / "raw")
+
+        monkeypatch.setattr(engine, "_pull_image", lambda img: True)
+        monkeypatch.setattr(engine, "_get_image_digest", lambda img: "sha256:abc")
+
+        def mock_run(cmd, **_kwargs):
+            for i, arg in enumerate(cmd):
+                if ":/output" in str(arg):
+                    Path(arg.split(":")[0]).joinpath("results.json").touch()
+                    break
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="", stderr="",
+            )
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+        engine._run_in_container(scanner, "/src", {})
+
+        target_dir = tmp_path / "raw" / scanner.name
+        # Either no dir created or empty — never a 0-byte stub.
+        if target_dir.exists():
+            assert not list(target_dir.iterdir())
+
     def test_container_custom_entrypoint(self, monkeypatch):
         engine = self._make_engine()
         scanner = self._make_scanner(container_entrypoint="/bin/custom")

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -64,8 +64,8 @@ argus scan [-h] [--path PATH] [--config CONFIG]
                   [--interface {terminal,browser}] [--fail-fast]
                   [--fail-on-scanner-error] [--timeout SECONDS]
                   [--no-parallel] [--allow-local-versions] [--no-cache]
-                  [--discover [PATH]] [--image REF] [--scanners SCANNERS]
-                  [--no-keep-raw] [--target URL] [--port PORT]
+                  [--no-keep-raw] [--discover [PATH]] [--image REF]
+                  [--scanners SCANNERS] [--target URL] [--port PORT]
                   [--env KEY=VALUE] [--scan-type {baseline,full}]
                   [--startup-timeout STARTUP_TIMEOUT]
                   [scanner]
@@ -100,6 +100,7 @@ argus scan [-h] [--path PATH] [--config CONFIG]
 | `--no-parallel` | Run scanners sequentially instead of concurrently. | `false` |
 | `--allow-local-versions` | Allow local tool versions that differ from argus-pinned versions. Use in airgapped environments where tool updates are constrained. | `false` |
 | `--no-cache` | Disable DB cache volume mounts. Forces scanners to re-download vulnerability databases on every container run. | `false` |
+| `--no-keep-raw` | Do not persist raw per-scanner output files alongside the canonical argus-results.json. Source scans normally drop each scanner's results.json / *.sarif / stdout.txt under <output_dir>/raw/<scanner>/; container scans drop trivy-results.json / grype-results.json / syft-sbom.json under <output_dir>/raw/<image>/. Pass --no-keep-raw to skip that step in tight CI environments. The same effect is available via 'reporting.keep_raw: false' in argus.yml. | `false` |
 
 **Container Scanning:**
 
@@ -108,7 +109,6 @@ argus scan [-h] [--path PATH] [--config CONFIG]
 | `--discover` | Discover Dockerfiles in PATH (default: current directory) |  |
 | `--image` | Container image to scan (can be repeated) |  |
 | `--scanners` | Sub-scanners for container scanning: trivy,grype,syft (default: trivy,grype) |  |
-| `--no-keep-raw` | Do not persist raw per-scanner output (trivy-results.json, grype-results.json, syft-sbom.json) under <output_dir>/raw/<image>/. By default raw artifacts are kept alongside the canonical argus-results.json so users can drill into individual scanner output for forensics or manual triage. Set ``containers.keep_raw: false`` in argus.yml for the same effect via config. | `false` |
 
 **Dast Scanning:**
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -65,8 +65,8 @@ argus scan [-h] [--path PATH] [--config CONFIG]
                   [--fail-on-scanner-error] [--timeout SECONDS]
                   [--no-parallel] [--allow-local-versions] [--no-cache]
                   [--discover [PATH]] [--image REF] [--scanners SCANNERS]
-                  [--target URL] [--port PORT] [--env KEY=VALUE]
-                  [--scan-type {baseline,full}]
+                  [--no-keep-raw] [--target URL] [--port PORT]
+                  [--env KEY=VALUE] [--scan-type {baseline,full}]
                   [--startup-timeout STARTUP_TIMEOUT]
                   [scanner]
 ```
@@ -108,6 +108,7 @@ argus scan [-h] [--path PATH] [--config CONFIG]
 | `--discover` | Discover Dockerfiles in PATH (default: current directory) |  |
 | `--image` | Container image to scan (can be repeated) |  |
 | `--scanners` | Sub-scanners for container scanning: trivy,grype,syft (default: trivy,grype) |  |
+| `--no-keep-raw` | Do not persist raw per-scanner output (trivy-results.json, grype-results.json, syft-sbom.json) under <output_dir>/raw/<image>/. By default raw artifacts are kept alongside the canonical argus-results.json so users can drill into individual scanner output for forensics or manual triage. Set ``containers.keep_raw: false`` in argus.yml for the same effect via config. | `false` |
 
 **Dast Scanning:**
 


### PR DESCRIPTION
## Summary

Three related fixes for the scan output contract:

1. **`argus view` doesn't display container vulnerabilities** — the container-scan flow only wrote a domain-shaped `container-scan.json` (per-image counts, `container_count`, etc.) which the viewers don't know how to render. The viewers consume the canonical `argus-results.json` shape produced by source scans.
2. **The `argus-results/` dir doesn't preserve the raw per-scanner output files** — for container scans (`trivy-results.json`, `grype-results.json`, `syft-sbom.json`) and now for source scans too, the per-scanner outputs lived in tempdirs that got wiped at the end of each scan. Users who want forensics, audit trails, or manual triage had nowhere to look.
3. **Unify the raw-output config** — initial scope only covered container scans. Rescoped this PR to cover source scans as well, so both flows share `reporting.keep_raw` and `--no-keep-raw`.

All three rooted in the same architectural drift: the container flow diverged from the source-scan output contract, and source scans never preserved per-scanner output at all. This PR re-aligns it.

## Canonical ScanSummary for container scans

- `_cmd_container_scan` now builds a canonical `ScanSummary` alongside the existing `ContainerScanSummary`: each container target maps to `ScanResult(scanner=f"container/<name>", findings=combined, metadata={image_ref, build_success, scanner_errors, scan_error})`.
- The JSON reporter writes that to `argus-results.json` unconditionally (matches the source-scan canonical-artifact contract from PR #111).
- The SARIF reporter consumes the same canonical summary instead of building a one-off conversion locally.
- The domain-shaped `container-scan.json` is preserved for backward compat with downstream tooling.
- `argus view` opens container scan results without any new code on the viewer side — it just sees `ScanResult` rows named `container/<image>`.

## Raw scanner output persistence (both flows)

**Container scans** — `scan_image` gains a `raw_output_dir: Path | None` parameter. When set, copies `trivy-results.json`, `grype-results.json`, and `syft-sbom.json` into that directory before the tempdir is cleaned up. `ContainerEngine` reads `_raw_output_root` from its config dict and threads a per-target subdir to `scan_image` as `<root>/<target.name>/`.

**Source scans (rescoped addition)** — `ArgusEngine.run()` gains a `raw_output_dir` parameter. `_run_in_container` copies each scanner's `result_files` (results.json / *.sarif / stdout.txt) under `<output_dir>/raw/<scanner>/` after the engine reads them. Same opt-in semantics, same on-disk shape — just the source-scan analogue.

**Unified config** — `--no-keep-raw` is now a top-level scan flag (not container-only). `reporting.keep_raw` (default `true`) replaces the container-scoped `containers.keep_raw`. Both flows honor the same knob; CLI flag wins on conflict (explicit > implicit). 0-byte files are explicitly skipped on both sides — they're failure signals and would mislead readers if persisted.

## Documentation

- `argus.example.yml` documents the unified `reporting.keep_raw: true` knob with a comment explaining it covers both source and container flows.
- The container-only `containers.keep_raw` example was removed.
- `docs/cli-reference.md` regenerated to reflect the moved `--no-keep-raw` flag.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

- Added `raw_output_dir` parameter to `scan_image` (container) and `ArgusEngine.run()` (source).
- Added canonical `ScanSummary` build in `_cmd_container_scan` with `container/<name>` scanner-name convention.
- Moved `--no-keep-raw` from container-only to top-level scan flag.
- Added `keep_raw: bool = True` to `ReportingConfig`; deprecated `containers.keep_raw`.
- Updated `_load_container_config` to surface `reporting.keep_raw` to the container handler.
- Updated SARIF reporter to consume canonical `ScanSummary` for container output.
- Updated `argus.example.yml` and `docs/cli-reference.md` accordingly.

## Testing

- 5 new container-side tests (`TestScanImageRawOutputPersistence` x4 + `TestContainerCanonicalScanSummary` x1).
- 4 new source-side tests in `TestRunInContainer`: persists per-scanner files, opt-in on `None`, stdout fallback, 0-byte skip.
- Full SDK suite: **1468 passed**, 8 skipped (was 1464 before rescope).

## Checklist

- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Comments added for non-obvious decisions (config-key discovery, 0-byte skip rationale)
- [x] Documentation updated (`argus.example.yml`, CLI reference)
- [x] No new warnings
- [x] Tests added/updated
- [x] All tests passing locally
- [x] No merge conflicts