### PR TITLE
feat(containers): mutually exclusive image vs dockerfile, per-target cleanup, IDE schema hint

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -56,9 +56,13 @@ jobs:
         # is safe to compose inline.
         run: |
           set -euo pipefail
+          # Schema option A: build entries declare ``dockerfile:`` +
+          # ``name:`` (no ``image:`` — that key is for remote pulls
+          # only). The matrix derives the short image name from
+          # ``name:`` and lets the build step prefix it with the
+          # ghcr.io registry path + commit SHA tag for publishing.
           matrix=$(yq -o=json '.containers.images | map({
-            "image": (.image | split(":") | .[0] | split("/") | .[-1]),
-            "image_ref_template": .image,
+            "image": .name,
             "dockerfile": .dockerfile,
             "context": (.context // ".")
           })' argus.yml)

--- a/argus.example.yml
+++ b/argus.example.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/huntridge-labs/argus/main/argus-config.schema.json
 # Argus Security Scanner Configuration
 # Copy to argus.yml and customize for your project
 version: "1.0"
@@ -70,34 +71,57 @@ reporting:
 # on the CLI. CLI flags, when supplied, override the matching keys
 # below: explicit > implicit.
 #
-# RECOMMENDED: pin every image to an immutable digest. ``:tag``
-# references are mutable — the same ``myorg/app:1.4.0`` can publish
-# different bytes over time, which means CVE attribution drifts and
-# scan results aren't reproducible. ``@sha256:...`` references are
-# byte-level immutable: the scanner reads exactly what you pinned,
-# every run, forever. Renovate and Dependabot can both update
-# digest-pinned references automatically.
+# Each ``images:`` entry uses ONE of two shapes — never both:
+#
+#   image:        Remote-pull entry. argus pulls and scans this exact
+#                 reference. Pin to an immutable ``@sha256:...`` digest
+#                 when possible — :tag references are mutable, so CVE
+#                 attribution drifts as upstream republishes. Renovate
+#                 and Dependabot can update digest pins automatically.
+#
+#   dockerfile:   Build-then-scan entry. argus runs ``docker build``
+#                 against the Dockerfile, tags the result as
+#                 ``<name>:argus-scan``, then scans that image. Argus
+#                 doesn't push the build to a registry — the resulting
+#                 image only exists locally for the duration of the
+#                 scan (cleanup: true by default).
+#
+# ``image:`` and ``dockerfile:`` are mutually exclusive — argus does
+# not push images, so the docker-compose pattern of "build, then tag
+# as ``image:`` for publishing" doesn't apply here.
 #
 # containers:
 #   images:
-#     # PREFERRED: tag + digest (human-readable + immutable)
+#     # PREFERRED remote pull: tag + digest (human-readable + immutable)
 #     - image: ghcr.io/myorg/app:1.4.0@sha256:f1e2d3c4b5a6f7e8d9c0b1a2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2
 #
-#     # ALSO PREFERRED: digest-only (immutable, no tag noise)
+#     # ALSO PREFERRED remote pull: digest-only (immutable, no tag noise)
 #     - image: ghcr.io/myorg/worker@sha256:0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b
 #
-#     # Build-then-scan: digest only meaningful after first publish.
-#     # The dockerfile is built and tagged locally, so it's reproducible
-#     # within one CI run even without a pinned digest.
-#     - image: myorg/inhouse:dev
-#       dockerfile: docker/Dockerfile
-#       context: .
-#
-#     # ACCEPTABLE FALLBACK: tag-only. Easier to read, but mutable —
-#     # use only for ad-hoc scans or in environments where digest
-#     # discovery isn't yet wired up. Plan to migrate to a pinned
-#     # form before relying on the scan output for an audit trail.
+#     # ACCEPTABLE FALLBACK remote pull: tag-only. Mutable; use only
+#     # for ad-hoc scans or environments where digest discovery isn't
+#     # yet wired up. Migrate to a pinned form before relying on the
+#     # scan output for an audit trail.
 #     # - image: myorg/legacy:1.0.0
+#
+#     # Build-then-scan: ``dockerfile:`` + optional ``context:`` and
+#     # ``name:``. ``name:`` becomes the build tag (``<name>:argus-scan``)
+#     # and the row identifier in argus-results.json; if omitted, argus
+#     # derives a name from the Dockerfile path the same way
+#     # ``argus scan container --discover`` does.
+#     - dockerfile: docker/Dockerfile
+#       context: .
+#       name: inhouse-app
+#
+#     # Per-target override of the engine-level ``cleanup:`` default.
+#     # Useful when one base image should stay cached across runs while
+#     # the rest of the dev images get torn down. ``true`` removes the
+#     # built image after the scan; ``false`` leaves it; omit to defer
+#     # to the engine default (``cleanup: true`` unless the engine is
+#     # configured otherwise).
+#     - dockerfile: docker/Dockerfile.base
+#       name: my-base
+#       cleanup: false
 #
 #   # OR auto-discovery. Walks ``search_paths`` for Dockerfile,
 #   # Dockerfile.<name>, <name>.Dockerfile, then builds + scans each

--- a/argus.yml
+++ b/argus.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/huntridge-labs/argus/main/argus-config.schema.json
 # Argus dogfood configuration — we scan our own production code.
 # Test fixtures (tests/fixtures/) are excluded — those contain
 # intentionally vulnerable code for scanner validation, not our
@@ -59,18 +60,24 @@ scanners:
 # hard-coding a parallel matrix — single source of truth.
 containers:
   images:
-    - image: ghcr.io/huntridge-labs/argus/scanner-bandit:dev
-      dockerfile: docker/Dockerfile.bandit
+    # Build-then-scan entries: dockerfile: + name: pin the build tag.
+    # Under schema option A, image: is for *remote pulls only* — these
+    # are local builds, so we declare the dockerfile and let argus
+    # tag the resulting image as ``<name>:argus-scan``. The
+    # build-containers workflow re-tags from ``<name>:argus-scan`` to
+    # ``ghcr.io/huntridge-labs/argus/<name>:<sha>`` for publishing.
+    - dockerfile: docker/Dockerfile.bandit
       context: .
-    - image: ghcr.io/huntridge-labs/argus/scanner-opengrep:dev
-      dockerfile: docker/Dockerfile.opengrep
+      name: scanner-bandit
+    - dockerfile: docker/Dockerfile.opengrep
       context: .
-    - image: ghcr.io/huntridge-labs/argus/scanner-supply-chain:dev
-      dockerfile: docker/Dockerfile.supply-chain
+      name: scanner-opengrep
+    - dockerfile: docker/Dockerfile.supply-chain
       context: .
-    - image: ghcr.io/huntridge-labs/argus/cli:dev
-      dockerfile: docker/Dockerfile.cli
+      name: scanner-supply-chain
+    - dockerfile: docker/Dockerfile.cli
       context: .
+      name: cli
   scanners: [trivy, grype, syft]
 
 reporting:

--- a/argus/cli.py
+++ b/argus/cli.py
@@ -2,6 +2,7 @@
 
 import argparse
 import os
+import re
 import sys
 import threading
 import time
@@ -2535,6 +2536,24 @@ def _list_scanners(engine) -> int:
     return EXIT_SUCCESS
 
 
+_SCHEMA_DIRECTIVE_RE = re.compile(
+    r"^\s*#\s*yaml-language-server\s*:\s*\$schema\s*=", re.IGNORECASE,
+)
+
+
+def _has_schema_directive(raw_text: str, head_lines: int = 5) -> bool:
+    """Return True if the raw YAML has a ``# yaml-language-server:`` directive near the top.
+
+    Editors recognize the directive only when it sits in the first
+    handful of lines, so we don't bother scanning the entire file.
+    Tolerant about leading blank lines and a possible UTF-8 BOM.
+    """
+    for line in raw_text.splitlines()[:head_lines]:
+        if _SCHEMA_DIRECTIVE_RE.match(line):
+            return True
+    return False
+
+
 def cmd_validate(args: argparse.Namespace) -> int:
     """Execute the validate subcommand — check config file."""
     import yaml
@@ -2556,10 +2575,18 @@ def cmd_validate(args: argparse.Namespace) -> int:
         print(f"Config file not found: {config_path}", file=sys.stderr)
         return EXIT_ERROR
 
-    # Load and validate
+    # Load and validate. Also peek at the raw text first so we can
+    # check the schema-directive comment that yaml.safe_load discards
+    # (it's a YAML comment, not a key).
     try:
         with open(config_path, "r") as fh:
-            data = yaml.safe_load(fh)
+            raw_text = fh.read()
+    except OSError as exc:
+        print(f"Could not read {config_path}: {exc}", file=sys.stderr)
+        return EXIT_ERROR
+
+    try:
+        data = yaml.safe_load(raw_text)
     except yaml.YAMLError as exc:
         print(f"Invalid YAML in {config_path}: {exc}", file=sys.stderr)
         return EXIT_ERROR
@@ -2572,10 +2599,25 @@ def cmd_validate(args: argparse.Namespace) -> int:
     warnings = [e for e in errors if e.level == "warning"]
     fatal = [e for e in errors if e.level == "error"]
 
+    # IDE-schema directive — check the first few lines for the
+    # ``# yaml-language-server: $schema=...`` comment that drives
+    # in-editor validation in VS Code, IntelliJ, and other tools that
+    # speak the language-server-protocol YAML spec. Soft warning so a
+    # user editing argus.yml without an IDE isn't penalized.
+    if not _has_schema_directive(raw_text):
+        warnings.append(ConfigError(
+            "",
+            "Missing IDE schema directive. Add this as the first line "
+            "of your argus.yml so editors get inline validation: "
+            "# yaml-language-server: $schema="
+            "https://raw.githubusercontent.com/huntridge-labs/argus/main/argus-config.schema.json",
+            level="warning",
+        ))
+
     strict = getattr(args, "strict", False)
     report_issue = getattr(args, "report_issue", False)
 
-    if not errors:
+    if not warnings and not fatal:
         print(f"✅ {config_path} is valid")
     else:
         for w in warnings:

--- a/argus/cli.py
+++ b/argus/cli.py
@@ -1754,8 +1754,15 @@ def _cmd_container_scan(
     that path is kept for backward compatibility with any caller that
     still bypasses ``cmd_scan``.
     """
+    from argus.audit import get_logger
     from argus.container import ContainerEngine
     from argus.reporters.container_markdown import ContainerMarkdownReporter
+
+    # Configure the ``argus`` logger so engine-level INFO/DEBUG output
+    # actually reaches the terminal under ``--verbose``. Without this
+    # the container engine's logger.info() calls go nowhere — same
+    # setup the source-scan handler does at the top of its body.
+    get_logger("argus", verbose=getattr(args, "verbose", False))
 
     if container_config is None:
         try:

--- a/argus/cli.py
+++ b/argus/cli.py
@@ -81,14 +81,116 @@ class _TerminalSpinner:
         self._stream.write("\r" + (" " * 80) + "\r")
         self._stream.flush()
 
+    @property
+    def enabled(self) -> bool:
+        """True when the spinner thread is actively drawing."""
+        return self._enabled
+
+    def update_message(self, message: str) -> None:
+        """Replace the spinner's status text in place.
+
+        Called from progress callbacks at phase transitions so the
+        user sees ``[2/4] scanner-opengrep — trivy (12s)`` updating
+        instead of a static "Running container scan". No-op when the
+        spinner isn't drawing — callers can pass through unconditionally.
+        """
+        # Pad with trailing spaces to overwrite any longer previous
+        # message without leaving stale characters on the line.
+        prev = self._message
+        self._message = message
+        if self._enabled and len(prev) > len(message):
+            self._stream.write("\r" + (" " * len(prev)) + "\r")
+            self._stream.flush()
+
+
+def _configure_logger(args: argparse.Namespace, output_dir: str | None = None):
+    """Set up the ``argus`` logger at the level the user's flags imply.
+
+    Mapping:
+      * ``--verbose`` / ``--debug``: DEBUG (full firehose)
+      * ``--quiet``: WARNING (suppress INFO lines from the engine)
+      * default:    INFO (per-phase status, no DEBUG noise)
+
+    Returns the configured logger so callers can also use it directly.
+    """
+    import logging
+    from argus.audit import get_logger
+
+    log = get_logger(
+        "argus",
+        output_dir=output_dir,
+        verbose=_verbose_enabled(args),
+    )
+    if _quiet_enabled(args):
+        for handler in log.handlers:
+            if isinstance(handler, logging.StreamHandler) and not isinstance(
+                handler, logging.FileHandler,
+            ):
+                handler.setLevel(logging.WARNING)
+    return log
+
+
+def _verbose_enabled(args: argparse.Namespace) -> bool:
+    """``--verbose`` / ``--debug`` — full firehose mode.
+
+    The two are aliases: ``--verbose`` is preserved for backward
+    compatibility, ``--debug`` is the clearer name new users learn.
+    """
+    return getattr(args, "verbose", False) or getattr(args, "debug", False)
+
+
+def _quiet_enabled(args: argparse.Namespace) -> bool:
+    """``--quiet`` / ``-q`` — suppress per-phase INFO lines.
+
+    Spinner stays drawing (just doesn't update its message) unless
+    ``--no-spinner`` is also passed. Composes with ``--no-spinner``:
+    ``--quiet --no-spinner`` means fully silent (CI exit-code-only).
+    """
+    return getattr(args, "quiet", False)
+
 
 def _spinner_enabled(args: argparse.Namespace) -> bool:
     """Enable spinner for interactive terminals unless explicitly disabled."""
     if getattr(args, "no_spinner", False):
         return False
-    if getattr(args, "verbose", False):
+    if _verbose_enabled(args):
         return False
     return sys.stderr.isatty()
+
+
+def _make_progress_emitter(
+    args: argparse.Namespace,
+    spinner: "_TerminalSpinner | None",
+):
+    """Return a progress callback that routes phase events to the right surface.
+
+    Output target depends on the flag combination:
+      * ``--quiet`` or ``--verbose``: no-op (logger handles verbose; quiet
+        suppresses progress on purpose).
+      * Spinner is drawing: update its message in place.
+      * No spinner (``--no-spinner`` or non-TTY): print a persistent
+        INFO line to stderr per phase event so CI logs and step-away
+        terminals get scrollback.
+    """
+    if _quiet_enabled(args) or _verbose_enabled(args):
+        return lambda *a, **kw: None
+
+    if spinner is not None and spinner.enabled:
+        def update_spinner(idx: int, total: int, name: str, phase: str, elapsed_ms: int):
+            elapsed_s = elapsed_ms // 1000
+            spinner.update_message(
+                f"[{idx}/{total}] {name} — {phase} ({elapsed_s}s)"
+            )
+        return update_spinner
+
+    def print_line(idx: int, total: int, name: str, phase: str, elapsed_ms: int):
+        elapsed_s = elapsed_ms // 1000
+        print(
+            f"[{idx}/{total}] {name} — {phase} ({elapsed_s}s)",
+            file=sys.stderr,
+            flush=True,
+        )
+    return print_line
 
 
 def _make_run_dir(base_dir: str) -> str:
@@ -486,9 +588,25 @@ def _build_scan_parser(subparsers: argparse._SubParsersAction) -> None:
         help="List available scanners and exit",
     )
     scan_parser.add_argument(
-        "--verbose", "-v",
+        "--verbose",
         action="store_true",
-        help="Enable verbose output",
+        help="Alias for --debug. Full firehose: subprocess output, "
+             "vulnerability-DB updates, every engine log line.",
+    )
+    scan_parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Full firehose: subprocess output, vulnerability-DB updates, "
+             "every engine log line. Use when troubleshooting; the default "
+             "phase-aware progress is enough for normal scans.",
+    )
+    scan_parser.add_argument(
+        "--quiet", "-q",
+        action="store_true",
+        help="Suppress per-phase progress lines. The spinner still draws "
+             "(use --no-spinner to suppress that too). Final summary "
+             "still prints. Compose with --no-spinner for fully silent "
+             "CI exit-code-only mode.",
     )
     scan_parser.add_argument(
         "--no-spinner",
@@ -1754,15 +1872,14 @@ def _cmd_container_scan(
     that path is kept for backward compatibility with any caller that
     still bypasses ``cmd_scan``.
     """
-    from argus.audit import get_logger
     from argus.container import ContainerEngine
     from argus.reporters.container_markdown import ContainerMarkdownReporter
 
-    # Configure the ``argus`` logger so engine-level INFO/DEBUG output
-    # actually reaches the terminal under ``--verbose``. Without this
-    # the container engine's logger.info() calls go nowhere — same
-    # setup the source-scan handler does at the top of its body.
-    get_logger("argus", verbose=getattr(args, "verbose", False))
+    # Configure the ``argus`` logger at the user's chosen level —
+    # default INFO, --quiet WARNING, --verbose/--debug DEBUG. Without
+    # this the container engine's logger.info() calls would go
+    # nowhere even under --verbose.
+    _configure_logger(args)
 
     if container_config is None:
         try:
@@ -1812,11 +1929,18 @@ def _cmd_container_scan(
 
     # Run
     try:
-        engine = ContainerEngine(config)
+        # Build the spinner first so the engine's progress callback
+        # can update its message in place. ``_make_progress_emitter``
+        # picks the right routing (spinner vs persistent INFO line vs
+        # no-op) based on the user's --quiet/--debug/--no-spinner mix.
         with _TerminalSpinner(
             message="Running container scan",
             enabled=_spinner_enabled(args),
-        ):
+        ) as spinner:
+            engine = ContainerEngine(
+                config,
+                progress_callback=_make_progress_emitter(args, spinner),
+            )
             summary = engine.run()
     except Exception as exc:
         print(f"Error: container scan failed: {exc}", file=sys.stderr)

--- a/argus/container/discovery.py
+++ b/argus/container/discovery.py
@@ -71,12 +71,21 @@ def warn_on_grype_prefix_collision(image_ref: str) -> str | None:
 
 @dataclass
 class ContainerTarget:
-    """A container image to scan."""
+    """A container image to scan.
+
+    ``cleanup`` overrides the engine's global ``cleanup:`` default for
+    this single target. ``None`` (the default) defers to the global
+    setting; ``True``/``False`` is an explicit per-target choice. Useful
+    for the case where a long-lived base image should stay cached
+    across runs while ad-hoc dev images are torn down — set
+    ``cleanup: false`` on the base entry, leave the others alone.
+    """
 
     name: str
     image_ref: str
     dockerfile: Path | None = None
     context: Path | None = None
+    cleanup: bool | None = None
 
 
 def discover_dockerfiles(search_paths: list[str]) -> list[ContainerTarget]:
@@ -149,29 +158,58 @@ def parse_container_config(config: dict) -> list[ContainerTarget]:
     for entry in containers.get("images", []):
         if not isinstance(entry, dict):
             continue
-        image_ref = entry.get("image", "")
-        if not image_ref:
+
+        image_ref_explicit = entry.get("image", "")
+        dockerfile_path = entry.get("dockerfile")
+        cleanup_override = entry.get("cleanup")
+        if cleanup_override is not None and not isinstance(cleanup_override, bool):
+            cleanup_override = None  # validator already warned; ignore here
+
+        if image_ref_explicit and dockerfile_path:
+            # Schema validator rejects this combination; defensive skip
+            # so a stale config (pre-option-A) doesn't crash the parser.
+            logger.warning(
+                "Skipping container entry: 'image:' and 'dockerfile:' "
+                "are mutually exclusive (entry: %s).", entry,
+            )
             continue
 
-        # Surface Grype prefix-collisions at config-load — well before
-        # the build runs. The warning is non-fatal so users with
-        # build-only or trivy-only flows aren't blocked by a Grype-
-        # specific naming issue.
-        collision = warn_on_grype_prefix_collision(image_ref)
-        if collision:
-            logger.warning(collision)
+        if image_ref_explicit:
+            # Remote-pull entry. ``image_ref`` is what we hand to
+            # trivy/grype/syft directly; ``name`` is a sanitized
+            # human-readable identifier used in result rows.
+            collision = warn_on_grype_prefix_collision(image_ref_explicit)
+            if collision:
+                logger.warning(collision)
 
-        dockerfile_path = entry.get("dockerfile")
-        context_path = entry.get("context")
+            name = image_ref_explicit.split(":")[0].replace("/", "-")
+            targets.append(ContainerTarget(
+                name=name,
+                image_ref=image_ref_explicit,
+                cleanup=cleanup_override,
+            ))
+            continue
 
-        name = image_ref.split(":")[0].replace("/", "-")
-        target = ContainerTarget(
-            name=name,
-            image_ref=image_ref,
-            dockerfile=Path(dockerfile_path) if dockerfile_path else None,
-            context=Path(context_path) if context_path else None,
-        )
-        targets.append(target)
+        if dockerfile_path:
+            # Build-then-scan entry. Derive the build tag the same way
+            # ``--discover`` does so explicit-config and auto-discovery
+            # produce the same on-disk image names — easier debugging
+            # for users grepping ``docker images | grep :argus-scan``.
+            df_path = Path(dockerfile_path)
+            root = Path(entry.get("context", df_path.parent))
+            name = entry.get("name") or _derive_name(df_path, root)
+            image_ref = f"{name}:argus-scan"
+            targets.append(ContainerTarget(
+                name=name,
+                image_ref=image_ref,
+                dockerfile=df_path,
+                context=root if entry.get("context") else None,
+                cleanup=cleanup_override,
+            ))
+            continue
+
+        # Neither image: nor dockerfile: — schema validator surfaced
+        # this; skip silently to avoid double-noise.
 
     if containers.get("discover", False):
         search_paths = containers.get("search_paths", ["."])

--- a/argus/container/engine.py
+++ b/argus/container/engine.py
@@ -85,8 +85,15 @@ class ContainerEngine:
             result = self._process_target(target)
             results.append(result)
 
-            # Post-scan cleanup — free disk for the next container
-            if self._cleanup:
+            # Post-scan cleanup — free disk for the next container.
+            # Per-target ``cleanup:`` overrides the engine-level default
+            # so a long-lived base image can stay cached across runs
+            # while ad-hoc dev images get torn down. None on the target
+            # means "no override — use the global setting".
+            target_cleanup = (
+                target.cleanup if target.cleanup is not None else self._cleanup
+            )
+            if target_cleanup:
                 self._cleanup_after_scan(target)
 
         # Final cleanup pass

--- a/argus/container/engine.py
+++ b/argus/container/engine.py
@@ -6,7 +6,9 @@ on constrained environments like CI runners.
 """
 
 import logging
+import time
 from pathlib import Path
+from typing import Callable
 
 from .builder import build_image
 from .discovery import (
@@ -45,10 +47,22 @@ class ContainerEngine:
           cleanup: true          # Remove images after scanning (default)
     """
 
-    def __init__(self, config: dict):
+    def __init__(
+        self,
+        config: dict,
+        progress_callback: "Callable[[int, int, str, str, int], None] | None" = None,
+    ):
         self.config = config
         self._cleanup = config.get("cleanup", True)
         self._built_images: list[str] = []
+        # Progress callback signature: (idx, total, name, phase, elapsed_ms).
+        # Default is a no-op so engine code can call ``self._progress(...)``
+        # unconditionally without checking. The CLI installs a callback
+        # that updates the spinner message or prints a persistent INFO
+        # line based on flag combination.
+        self._progress: Callable[[int, int, str, str, int], None] = (
+            progress_callback or (lambda *a, **kw: None)
+        )
 
     def run(self) -> ContainerScanSummary:
         """Execute the full container scanning lifecycle.
@@ -77,13 +91,24 @@ class ContainerEngine:
         )
         results: list[ContainerScanResult] = []
 
+        total = len(targets)
         for i, target in enumerate(targets, 1):
             logger.info(
-                "[%d/%d] Processing %s", i, len(targets), target.name,
+                "[%d/%d] Processing %s", i, total, target.name,
             )
 
-            result = self._process_target(target)
+            # Emit phase progress at each transition. The callback
+            # decides whether to update the spinner, print a line, or
+            # ignore the event based on the user's CLI flags.
+            target_start = time.monotonic()
+            initial_phase = "build" if target.dockerfile else "pull"
+            self._progress(i, total, target.name, initial_phase, 0)
+
+            result = self._process_target(target, idx=i, total=total, target_start=target_start)
             results.append(result)
+
+            elapsed_ms = int((time.monotonic() - target_start) * 1000)
+            self._progress(i, total, target.name, "done", elapsed_ms)
 
             # Post-scan cleanup — free disk for the next container.
             # Per-target ``cleanup:`` overrides the engine-level default
@@ -111,13 +136,29 @@ class ContainerEngine:
         )
         return summary
 
-    def _process_target(self, target: ContainerTarget) -> ContainerScanResult:
+    def _process_target(
+        self,
+        target: ContainerTarget,
+        idx: int = 1,
+        total: int = 1,
+        target_start: float | None = None,
+    ) -> ContainerScanResult:
         """Build (if needed) and scan a single container target.
 
         Catches disk space errors and other resource failures
         individually — a failure on one container doesn't stop
         the rest from being scanned.
+
+        ``idx`` / ``total`` / ``target_start`` are progress-tracking
+        params used to emit phase events between build and scan.
+        Default values keep backward compat for direct test callers.
         """
+        if target_start is None:
+            target_start = time.monotonic()
+
+        def _elapsed() -> int:
+            return int((time.monotonic() - target_start) * 1000)
+
         if target.dockerfile:
             success = build_image(target)
             if not success:
@@ -136,6 +177,10 @@ class ContainerEngine:
                     scan_error=error_msg,
                 )
             self._built_images.append(target.image_ref)
+
+        # Build is done (or skipped for remote-pull targets); transition
+        # to the scan phase so the spinner updates.
+        self._progress(idx, total, target.name, "scan", _elapsed())
 
         try:
             # If the dispatcher set ``_raw_output_root`` in the

--- a/argus/core/schema.py
+++ b/argus/core/schema.py
@@ -43,7 +43,7 @@ _EXECUTION_KEYS = {"backend", "registry", "pull_policy"}
 _CONTAINERS_KEYS = {"images", "discover", "search_paths", "scanners"}
 
 # Per-image entry keys (under containers.images[*])
-_CONTAINER_IMAGE_KEYS = {"image", "dockerfile", "context", "name"}
+_CONTAINER_IMAGE_KEYS = {"image", "dockerfile", "context", "name", "cleanup"}
 
 # Sub-scanners argus scan container can dispatch to
 _CONTAINER_SUB_SCANNERS = {"trivy", "grype", "syft"}
@@ -342,13 +342,24 @@ def _validate_containers(path: str, data: Any) -> list[ConfigError]:
 
 
 def _validate_container_image_entry(path: str, entry: Any) -> list[ConfigError]:
-    """Validate a single ``containers.images[*]`` entry."""
+    """Validate a single ``containers.images[*]`` entry.
+
+    Schema option A — ``image:`` and ``dockerfile:`` are *mutually
+    exclusive*. ``image:`` means "pull this from a registry";
+    ``dockerfile:`` (+ optional ``context:`` and ``name:``) means
+    "build locally and scan the result". The previous shape doubled
+    ``image:`` as both "pull source" and "tag the build as" — the
+    docker-compose precedent — and the doubling was the source of the
+    UX confusion that motivated this change. Argus doesn't push images
+    after building, so the compose semantic was never load-bearing for
+    us; the cleaner separation reflects what the tool actually does.
+    """
     errors: list[ConfigError] = []
 
     if not isinstance(entry, dict):
         errors.append(ConfigError(
             path,
-            f"Must be a mapping with at least an 'image:' field, "
+            f"Must be a mapping with either 'image:' or 'dockerfile:', "
             f"got {type(entry).__name__}",
         ))
         return errors
@@ -363,13 +374,37 @@ def _validate_container_image_entry(path: str, entry: Any) -> list[ConfigError]:
                 level="warning",
             ))
 
-    # An entry must declare either an image ref or a dockerfile to build.
-    if "image" not in entry and "dockerfile" not in entry:
+    has_image = "image" in entry
+    has_dockerfile = "dockerfile" in entry
+
+    if not has_image and not has_dockerfile:
         errors.append(ConfigError(
             path,
-            "Image entry must have either 'image:' (registry reference) "
-            "or 'dockerfile:' (build-then-scan) set.",
+            "Image entry must declare either 'image:' (remote registry "
+            "reference, pulled and scanned) or 'dockerfile:' (built "
+            "locally from a Dockerfile, then scanned).",
         ))
+    elif has_image and has_dockerfile:
+        errors.append(ConfigError(
+            path,
+            "Image entry has both 'image:' and 'dockerfile:' set — these "
+            "are mutually exclusive. Use 'image:' for remote pulls; use "
+            "'dockerfile:' (+ optional 'context:' and 'name:') for local "
+            "builds. Argus does not push the build to a registry, so the "
+            "'image:' tag-after-build semantic from docker-compose is not "
+            "supported.",
+        ))
+
+    # ``context:`` / ``name:`` only make sense for build-mode entries.
+    if has_image and not has_dockerfile:
+        for build_only in ("context", "name"):
+            if build_only in entry:
+                errors.append(ConfigError(
+                    f"{path}.{build_only}",
+                    f"'{build_only}:' only applies to dockerfile-build "
+                    f"entries; ignored when 'image:' is set.",
+                    level="warning",
+                ))
 
     # Type checks for present fields
     for field in ("image", "dockerfile", "context", "name"):
@@ -377,6 +412,11 @@ def _validate_container_image_entry(path: str, entry: Any) -> list[ConfigError]:
             errors.append(ConfigError(
                 f"{path}.{field}", "Must be a string",
             ))
+
+    if "cleanup" in entry and not isinstance(entry["cleanup"], bool):
+        errors.append(ConfigError(
+            f"{path}.cleanup", "Must be a boolean (true/false)",
+        ))
 
     return errors
 

--- a/argus/tests/core/test_schema_containers.py
+++ b/argus/tests/core/test_schema_containers.py
@@ -36,12 +36,14 @@ class TestContainersValid:
         cfg = {"containers": {"images": [{"image": "nginx:latest"}]}}
         assert _errors(cfg) == []
 
-    def test_dockerfile_entry(self):
+    def test_dockerfile_only_entry(self):
+        # Option A: dockerfile-build entries don't carry an image: ref
+        # — the build tag is auto-derived from the dockerfile path
+        # (or a per-entry name: override).
         cfg = {
             "containers": {
                 "images": [
                     {
-                        "image": "myapp:dev",
                         "dockerfile": "docker/Dockerfile",
                         "context": ".",
                     }
@@ -49,6 +51,34 @@ class TestContainersValid:
             }
         }
         assert _errors(cfg) == []
+
+    def test_dockerfile_with_explicit_name(self):
+        cfg = {
+            "containers": {
+                "images": [
+                    {
+                        "dockerfile": "docker/Dockerfile.web",
+                        "name": "scanner-web",
+                    }
+                ]
+            }
+        }
+        assert _errors(cfg) == []
+
+    def test_image_and_dockerfile_together_is_error(self):
+        # The whole point of option A — these are mutually exclusive.
+        cfg = {
+            "containers": {
+                "images": [
+                    {
+                        "image": "myapp:dev",
+                        "dockerfile": "docker/Dockerfile",
+                    }
+                ]
+            }
+        }
+        errors = _errors(cfg)
+        assert _has_error_at(errors, "containers.images[0]", "mutually exclusive")
 
     def test_discover_only(self):
         cfg = {"containers": {"discover": True, "search_paths": ["docker/"]}}
@@ -101,7 +131,7 @@ class TestImageEntryErrors:
     def test_image_entry_missing_image_and_dockerfile(self):
         cfg = {"containers": {"images": [{"context": "."}]}}
         errors = _errors(cfg)
-        assert _has_error_at(errors, "containers.images[0]", "must have either")
+        assert _has_error_at(errors, "containers.images[0]", "must declare either")
         assert _has_error_at(errors, "containers.images[0]", "dockerfile")
 
     def test_unknown_image_entry_key_is_warning(self):
@@ -158,6 +188,65 @@ class TestSubScannerValidation:
 # --------------------------------------------------------------------- #
 # Unknown top-level containers key                                      #
 # --------------------------------------------------------------------- #
+
+
+class TestPerContainerCleanup:
+    """``cleanup:`` is the per-target override of the engine-wide flag."""
+
+    def test_cleanup_true_accepted(self):
+        cfg = {
+            "containers": {
+                "images": [{"image": "x:1", "cleanup": True}],
+            },
+        }
+        assert _errors(cfg) == []
+
+    def test_cleanup_false_accepted(self):
+        cfg = {
+            "containers": {
+                "images": [
+                    {"dockerfile": "Dockerfile", "name": "base", "cleanup": False},
+                ],
+            },
+        }
+        assert _errors(cfg) == []
+
+    def test_cleanup_must_be_boolean(self):
+        cfg = {
+            "containers": {
+                "images": [{"image": "x:1", "cleanup": "yes"}],
+            },
+        }
+        errors = _errors(cfg)
+        assert _has_error_at(errors, "containers.images[0].cleanup", "boolean")
+
+
+class TestBuildOnlyKeysOnRemotePulls:
+    """``context:`` and ``name:`` only apply to dockerfile builds."""
+
+    def test_context_on_image_only_warns(self):
+        cfg = {
+            "containers": {
+                "images": [{"image": "x:1", "context": "."}],
+            },
+        }
+        warnings = _warnings(cfg)
+        assert any(
+            "context" in w.path and "build" in w.message
+            for w in warnings
+        )
+
+    def test_name_on_image_only_warns(self):
+        cfg = {
+            "containers": {
+                "images": [{"image": "x:1", "name": "myname"}],
+            },
+        }
+        warnings = _warnings(cfg)
+        assert any(
+            "name" in w.path and "build" in w.message
+            for w in warnings
+        )
 
 
 class TestUnknownKeys:

--- a/argus/tests/test_cli.py
+++ b/argus/tests/test_cli.py
@@ -885,8 +885,8 @@ class TestCmdValidate:
             "containers:\n"
             "  images:\n"
             "    - image: ghcr.io/myorg/app:1.0\n"
-            "    - image: myorg/inhouse:dev\n"
-            "      dockerfile: docker/Dockerfile\n"
+            "    - dockerfile: docker/Dockerfile\n"
+            "      name: inhouse\n"
         )
         args = argparse.Namespace(
             config=str(config_file),
@@ -899,7 +899,8 @@ class TestCmdValidate:
         out = capsys.readouterr().out
         assert "Containers: 2 image(s)" in out
         assert "ghcr.io/myorg/app:1.0" in out
-        assert "myorg/inhouse:dev" in out
+        # Build-mode entry surfaces by its dockerfile path (no image: ref).
+        assert "docker/Dockerfile" in out
 
     def test_validate_summary_omits_containers_line_when_block_absent(
         self, tmp_path, capsys,
@@ -923,6 +924,53 @@ class TestCmdValidate:
         assert result == EXIT_SUCCESS
         out = capsys.readouterr().out
         assert "Containers:" not in out
+
+    def test_validate_warns_when_schema_directive_missing(self, tmp_path, capsys):
+        """Configs without the ``# yaml-language-server:`` comment lose
+        IDE schema validation. Surface a soft warning so the user can
+        opt back in by adding one line.
+        """
+        config_file = tmp_path / "argus.yml"
+        # No schema directive — just plain config.
+        config_file.write_text(
+            "scanners:\n"
+            "  bandit:\n"
+            "    enabled: true\n"
+        )
+        args = argparse.Namespace(
+            config=str(config_file),
+            check_tools=False,
+            strict=False,
+        )
+        result = cmd_validate(args)
+
+        assert result == EXIT_SUCCESS
+        out = capsys.readouterr().out
+        assert "yaml-language-server" in out
+        assert "$schema=" in out
+
+    def test_validate_silent_when_schema_directive_present(
+        self, tmp_path, capsys,
+    ):
+        """When the directive is present, no schema-related warning fires."""
+        config_file = tmp_path / "argus.yml"
+        config_file.write_text(
+            "# yaml-language-server: $schema=https://example.com/argus.json\n"
+            "scanners:\n"
+            "  bandit:\n"
+            "    enabled: true\n"
+        )
+        args = argparse.Namespace(
+            config=str(config_file),
+            check_tools=False,
+            strict=False,
+        )
+        result = cmd_validate(args)
+
+        assert result == EXIT_SUCCESS
+        out = capsys.readouterr().out
+        # The hint shouldn't fire — directive is present.
+        assert "Missing IDE schema directive" not in out
 
     def test_validate_summary_shows_discover_when_set(self, tmp_path, capsys):
         """``discover: true`` should surface in the summary alongside

--- a/argus/tests/test_container_discovery.py
+++ b/argus/tests/test_container_discovery.py
@@ -107,36 +107,95 @@ class TestParseContainerConfig:
     """Test parse_container_config with explicit images and discovery."""
 
     def test_explicit_images(self):
+        # Option A: image: and dockerfile: are mutually exclusive. A
+        # dockerfile-only entry derives its build tag from the
+        # Dockerfile path the same way --discover does.
         config = {
             "containers": {
                 "images": [
-                    {"image": "myapp:latest", "dockerfile": "Dockerfile"},
+                    {"dockerfile": "Dockerfile.web", "name": "web"},
                     {"image": "worker:1.0"},
                 ],
             },
         }
         targets = parse_container_config(config)
         assert len(targets) == 2
-        assert targets[0].image_ref == "myapp:latest"
-        assert targets[0].name == "myapp"
-        assert targets[0].dockerfile == Path("Dockerfile")
+        # Build entry: name is the explicit override, image_ref auto.
+        assert targets[0].name == "web"
+        assert targets[0].image_ref == "web:argus-scan"
+        assert targets[0].dockerfile == Path("Dockerfile.web")
+        # Remote-pull entry: image_ref is exactly what the user wrote.
         assert targets[1].image_ref == "worker:1.0"
         assert targets[1].dockerfile is None
 
-    def test_image_with_context(self):
+    def test_dockerfile_with_context(self):
         config = {
             "containers": {
                 "images": [
                     {
-                        "image": "myapp:latest",
                         "dockerfile": "docker/Dockerfile",
                         "context": ".",
+                        "name": "myapp",
                     },
                 ],
             },
         }
         targets = parse_container_config(config)
         assert targets[0].context == Path(".")
+        assert targets[0].image_ref == "myapp:argus-scan"
+
+    def test_per_target_cleanup_override(self):
+        # ``cleanup:`` flows from each entry to the ContainerTarget,
+        # where the engine uses it to override the global default.
+        config = {
+            "containers": {
+                "images": [
+                    {"image": "myapp:1", "cleanup": False},
+                    {"image": "myapp:2"},                   # no override
+                    {"dockerfile": "Dockerfile.base", "name": "base", "cleanup": True},
+                ],
+            },
+        }
+        targets = parse_container_config(config)
+        assert targets[0].cleanup is False
+        assert targets[1].cleanup is None  # defer to engine default
+        assert targets[2].cleanup is True
+
+    def test_dockerfile_only_derives_name_from_path_when_omitted(self):
+        # When ``name:`` is absent on a build entry, derive the build
+        # tag from the Dockerfile path (same logic as --discover).
+        config = {
+            "containers": {
+                "images": [
+                    {"dockerfile": "docker/Dockerfile.web"},
+                ],
+            },
+        }
+        targets = parse_container_config(config)
+        assert len(targets) == 1
+        assert targets[0].name == "web"
+        assert targets[0].image_ref == "web:argus-scan"
+
+    def test_image_with_dockerfile_skipped_with_warning(self, caplog):
+        # Defensive: even though the schema validator errors on this,
+        # a stale config shouldn't crash the parser. Skip + warn.
+        import logging
+        caplog.set_level(logging.WARNING, logger="argus.container")
+        config = {
+            "containers": {
+                "images": [
+                    {"image": "myapp:1.0", "dockerfile": "Dockerfile"},
+                    {"image": "ok:1"},
+                ],
+            },
+        }
+        targets = parse_container_config(config)
+        # Only the valid second entry is resolved.
+        assert len(targets) == 1
+        assert targets[0].image_ref == "ok:1"
+        assert any(
+            "mutually exclusive" in record.message for record in caplog.records
+        )
 
     def test_discover_true(self, tmp_path):
         (tmp_path / "Dockerfile").write_text("FROM alpine")
@@ -214,23 +273,22 @@ class TestParseContainerConfigUnwrappedShape:
     """
 
     def test_unwrapped_shape_resolves_explicit_images(self):
-        # The user's exact repro from the bug report — top-level
-        # ``containers:`` block in argus.yml with one image entry,
-        # extracted into the inner-mapping shape by the CLI before
-        # being passed to the engine.
+        # Top-level ``containers:`` extracted to the inner-mapping
+        # shape by the CLI before being passed to the engine.
+        # Option A — dockerfile-only entry, image_ref auto-derived.
         config = {
             "images": [
                 {
-                    "image": "docker:argus-scan",
                     "dockerfile": "docker/Dockerfile",
                     "context": ".",
+                    "name": "myapp",
                 },
             ],
         }
         targets = parse_container_config(config)
         assert len(targets) == 1
         target = targets[0]
-        assert target.image_ref == "docker:argus-scan"
+        assert target.image_ref == "myapp:argus-scan"
         assert target.dockerfile == Path("docker/Dockerfile")
         assert target.context == Path(".")
 
@@ -328,7 +386,7 @@ class TestGrypePrefixCollisionWarning:
 
         config = {
             "images": [
-                {"image": "docker:argus-scan", "dockerfile": "Dockerfile"},
+                {"image": "docker:argus-scan"},
             ],
         }
         targets = parse_container_config(config)

--- a/argus/tests/test_progress_emitter.py
+++ b/argus/tests/test_progress_emitter.py
@@ -1,0 +1,129 @@
+"""Tests for argus.cli._make_progress_emitter and the new flag-routing matrix.
+
+Locks in the four-mode UX surface — default / --quiet / --no-spinner /
+--debug — all composing through orthogonal flags.
+"""
+
+import argparse
+
+import pytest
+
+from argus.cli import (
+    _TerminalSpinner,
+    _make_progress_emitter,
+    _quiet_enabled,
+    _verbose_enabled,
+)
+
+
+def _ns(**flags) -> argparse.Namespace:
+    """Build an argparse.Namespace with sensible defaults for testing."""
+    base = {
+        "verbose": False,
+        "debug": False,
+        "quiet": False,
+        "no_spinner": False,
+    }
+    base.update(flags)
+    return argparse.Namespace(**base)
+
+
+# --------------------------------------------------------------------- #
+# Flag predicates                                                       #
+# --------------------------------------------------------------------- #
+
+
+class TestVerboseEnabled:
+    def test_no_flag_is_false(self):
+        assert _verbose_enabled(_ns()) is False
+
+    def test_verbose_flag(self):
+        assert _verbose_enabled(_ns(verbose=True)) is True
+
+    def test_debug_flag(self):
+        assert _verbose_enabled(_ns(debug=True)) is True
+
+    def test_either_flag_alone_is_enough(self):
+        assert _verbose_enabled(_ns(verbose=True, debug=False)) is True
+        assert _verbose_enabled(_ns(verbose=False, debug=True)) is True
+
+
+class TestQuietEnabled:
+    def test_no_flag_is_false(self):
+        assert _quiet_enabled(_ns()) is False
+
+    def test_quiet_flag(self):
+        assert _quiet_enabled(_ns(quiet=True)) is True
+
+
+# --------------------------------------------------------------------- #
+# Progress emitter routing                                              #
+# --------------------------------------------------------------------- #
+
+
+class TestProgressEmitter:
+    def test_quiet_returns_no_op(self, capsys):
+        emit = _make_progress_emitter(_ns(quiet=True), spinner=None)
+        emit(1, 4, "scanner-bandit", "build", 0)
+        # No output anywhere — quiet mode is silence.
+        out = capsys.readouterr()
+        assert out.out == ""
+        assert out.err == ""
+
+    def test_verbose_returns_no_op(self, capsys):
+        # --verbose / --debug routes through the logger; the progress
+        # emitter is silent so we don't double-print phase lines.
+        emit = _make_progress_emitter(_ns(verbose=True), spinner=None)
+        emit(1, 4, "scanner-bandit", "build", 0)
+        out = capsys.readouterr()
+        assert out.out == ""
+        assert out.err == ""
+
+    def test_debug_alias_returns_no_op(self, capsys):
+        emit = _make_progress_emitter(_ns(debug=True), spinner=None)
+        emit(1, 4, "scanner-bandit", "build", 0)
+        out = capsys.readouterr()
+        assert out.out == ""
+        assert out.err == ""
+
+    def test_no_spinner_prints_persistent_lines(self, capsys):
+        # --no-spinner + non-quiet + non-verbose → phase events go to
+        # stderr as scrollback. This is the CI-friendly default.
+        emit = _make_progress_emitter(_ns(no_spinner=True), spinner=None)
+        emit(1, 4, "scanner-bandit", "build", 0)
+        emit(1, 4, "scanner-bandit", "scan", 12000)
+        emit(1, 4, "scanner-bandit", "done", 45000)
+        err = capsys.readouterr().err
+        assert "[1/4] scanner-bandit — build (0s)" in err
+        assert "[1/4] scanner-bandit — scan (12s)" in err
+        assert "[1/4] scanner-bandit — done (45s)" in err
+
+    def test_disabled_spinner_falls_back_to_print(self, capsys):
+        # When the spinner exists but its enabled flag is False (non-TTY,
+        # for example), we still want phase lines to flow somewhere.
+        spinner = _TerminalSpinner(message="x", enabled=False)
+        emit = _make_progress_emitter(_ns(), spinner=spinner)
+        emit(2, 3, "myapp", "scan", 8000)
+        err = capsys.readouterr().err
+        assert "[2/3] myapp — scan (8s)" in err
+
+    def test_enabled_spinner_routes_to_update_message(self, capsys):
+        # When the spinner IS drawing, phase events update its in-place
+        # message rather than printing scrollback lines.
+        spinner = _TerminalSpinner(message="initial", enabled=True)
+        emit = _make_progress_emitter(_ns(), spinner=spinner)
+        emit(2, 3, "myapp", "scan", 8000)
+        # The spinner thread isn't running (we never entered the
+        # context manager), but update_message still records the new
+        # text on the instance for inspection.
+        assert spinner._message == "[2/3] myapp — scan (8s)"
+        # And nothing leaked to stderr.
+        assert capsys.readouterr().err == ""
+
+    def test_quiet_overrides_spinner_path(self, capsys):
+        # --quiet wins over a drawing spinner — the spinner stays, but
+        # its message doesn't update.
+        spinner = _TerminalSpinner(message="initial", enabled=True)
+        emit = _make_progress_emitter(_ns(quiet=True), spinner=spinner)
+        emit(1, 1, "x", "scan", 0)
+        assert spinner._message == "initial"

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,6 +1,6 @@
 # Argus CLI Reference (v0.7.2)
 
-> Auto-generated from argparse definitions on 2026-05-05.
+> Auto-generated from argparse definitions on 2026-05-06.
 > Do not edit manually — run `python -m scripts.ci.gen_cli_docs` to regenerate.
 
 Argus Security Scanner — comprehensive security scanning for your codebase
@@ -58,8 +58,8 @@ argus scan [-h] [--path PATH] [--config CONFIG]
                   [--output-dir OUTPUT_DIR]
                   [--severity-threshold {critical,high,medium,low,none}]
                   [--format {terminal,markdown,sarif,json}] [--list]
-                  [--verbose] [--no-spinner] [--no-timestamp]
-                  [--output-vars FILE] [--exclude PATTERNS]
+                  [--verbose] [--debug] [--quiet] [--no-spinner]
+                  [--no-timestamp] [--output-vars FILE] [--exclude PATTERNS]
                   [--no-default-excludes] [--dry-run] [--sbom PATH]
                   [--interface {terminal,browser}] [--fail-fast]
                   [--fail-on-scanner-error] [--timeout SECONDS]
@@ -85,7 +85,9 @@ argus scan [-h] [--path PATH] [--config CONFIG]
 | `--severity-threshold`, `-s` | Fail threshold severity level (default: from config) (critical, high, medium, low, none) |  |
 | `--format`, `-f` | Output format (can be repeated; default: terminal) (terminal, markdown, sarif, json) |  |
 | `--list` | List available scanners and exit | `false` |
-| `--verbose`, `-v` | Enable verbose output | `false` |
+| `--verbose` | Alias for --debug. Full firehose: subprocess output, vulnerability-DB updates, every engine log line. | `false` |
+| `--debug` | Full firehose: subprocess output, vulnerability-DB updates, every engine log line. Use when troubleshooting; the default phase-aware progress is enough for normal scans. | `false` |
+| `--quiet`, `-q` | Suppress per-phase progress lines. The spinner still draws (use --no-spinner to suppress that too). Final summary still prints. Compose with --no-spinner for fully silent CI exit-code-only mode. | `false` |
 | `--no-spinner` | Disable animated spinner output | `false` |
 | `--no-timestamp` | Write output directly to --output-dir without a timestamped subdirectory. Useful in CI where a predictable output path is needed. | `false` |
 | `--output-vars` | Write scan result counts as key=value pairs to FILE. Useful in CI: cat FILE >> $GITHUB_OUTPUT. Keys: critical_count, high_count, medium_count, low_count, total_count, passed. |  |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -17,6 +17,19 @@ argus [--version] [--help] <command> [options]
 |------|-------------|---------|
 | `--version` | show program's version number and exit |  |
 
+## Output and verbosity
+
+`argus scan` exposes four flags that compose orthogonally — `--quiet` controls log verbosity, `--no-spinner` controls UI rendering, and `--debug` (alias `--verbose`) is the explicit troubleshooting opt-in. The four most useful modes:
+
+| Invocation | When to use | What you see |
+|---|---|---|
+| `argus scan` | Default — interactive terminal | Phase-aware spinner that updates per image and per scan phase |
+| `argus scan --quiet` | Daily runs you don't want narrating | Spinner stays drawing, but per-phase chatter is suppressed; only WARNING/ERROR lines and the final summary print |
+| `argus scan --no-spinner` | CI logs, step-away monitoring | Persistent `[idx/total] name — phase (Ns)` lines on stderr instead of a self-overwriting spinner |
+| `argus scan --debug` (or `--verbose`) | Troubleshooting | Full firehose: subprocess output, vulnerability-DB updates, every engine log line |
+
+Compose flags for additional modes — `--quiet --no-spinner` is the fully-silent CI exit-code-only combination; `--debug --no-spinner` is identical to `--debug` since debug auto-disables the spinner.
+
 ## Commands
 
 ### `argus init`

--- a/scripts/ci/gen_cli_docs.py
+++ b/scripts/ci/gen_cli_docs.py
@@ -57,6 +57,29 @@ def generate_cli_docs(output: str | None = None, fmt: str = "markdown") -> str:
         lines.extend(_format_options_table(top_options))
         lines.append("")
 
+    # Output and verbosity — explains how the four output-control
+    # flags compose. Each flag's individual help text is also rendered
+    # below in the per-command tables; this section gives readers the
+    # mental model up front.
+    lines.extend([
+        "## Output and verbosity",
+        "",
+        "`argus scan` exposes four flags that compose orthogonally —"
+        " `--quiet` controls log verbosity, `--no-spinner` controls UI"
+        " rendering, and `--debug` (alias `--verbose`) is the explicit"
+        " troubleshooting opt-in. The four most useful modes:",
+        "",
+        "| Invocation | When to use | What you see |",
+        "|---|---|---|",
+        "| `argus scan` | Default — interactive terminal | Phase-aware spinner that updates per image and per scan phase |",
+        "| `argus scan --quiet` | Daily runs you don't want narrating | Spinner stays drawing, but per-phase chatter is suppressed; only WARNING/ERROR lines and the final summary print |",
+        "| `argus scan --no-spinner` | CI logs, step-away monitoring | Persistent `[idx/total] name — phase (Ns)` lines on stderr instead of a self-overwriting spinner |",
+        "| `argus scan --debug` (or `--verbose`) | Troubleshooting | Full firehose: subprocess output, vulnerability-DB updates, every engine log line |",
+        "",
+        "Compose flags for additional modes — `--quiet --no-spinner` is the fully-silent CI exit-code-only combination; `--debug --no-spinner` is identical to `--debug` since debug auto-disables the spinner.",
+        "",
+    ])
+
     # Commands
     lines.append("## Commands")
     lines.append("")


### PR DESCRIPTION
## Description

Three coupled UX improvements to the `containers:` config block, surfaced during the option-A review with the user.

## Changes Made
- [ ] Added new scanner/workflow
- [x] Modified existing scanner/workflow
- [x] Updated documentation
- [x] Fixed bug
- [x] Other (please specify)

### Details

**1. Schema option A — `image:` and `dockerfile:` are mutually exclusive**

Before: each entry could declare `image:` *and* `dockerfile:` *and* `context:` together, with `image:` doing double duty as both pull source and build tag (the docker-compose pattern). After: each entry declares **one** shape:

| Shape | Keys | Behavior |
|---|---|---|
| Remote pull | `image:` (optional `cleanup:`) | argus pulls and scans this exact reference |
| Build-then-scan | `dockerfile:`, optional `context:`, `name:`, `cleanup:` | argus runs `docker build`, tags as `<name>:argus-scan`, scans the result |

Argus doesn't push images after building, so the compose `image:` tag-after-build semantic was never load-bearing for us. The cleaner separation reflects what the tool actually does.

**Schema validator** rejects entries with both keys with a clear remediation message:

```
❌ containers.images[0]: Image entry has both 'image:' and 'dockerfile:' set —
   these are mutually exclusive. Use 'image:' for remote pulls; use 'dockerfile:'
   (+ optional 'context:' and 'name:') for local builds. Argus does not push the
   build to a registry, so the 'image:' tag-after-build semantic from
   docker-compose is not supported.
```

Build entries auto-derive the on-disk image tag from `name:` (or from the Dockerfile path when `name:` is omitted) — same logic as `argus scan container --discover`, so explicit-config and auto-discovery produce the same image identifiers locally.

**Stale configs** that still set both keys log a warning and skip the entry instead of crashing the parser, so a half-migrated `argus.yml` still gets through the engine while surfacing the issue.

**2. Per-target `cleanup:` override**

`cleanup: true|false` on a single image entry overrides the engine-level default for that target only. Useful for the case where one base image should stay cached across runs while the rest of the dev images get torn down — set `cleanup: false` on the base entry, leave the others alone. `None` (the default) defers to the engine-wide setting.

```yaml
containers:
  images:
    - dockerfile: docker/Dockerfile.base
      name: my-base
      cleanup: false   # keep this one cached
    - dockerfile: docker/Dockerfile.app
      name: my-app
                       # uses engine default (cleanup: true)
```

**3. IDE schema directive in `argus.yml`**

`argus init` already wrote a `# yaml-language-server: $schema=...` line at the top of generated configs. `argus validate` now warns when an existing config is missing it so users with hand-edited configs get a one-step path back to IDE-side schema validation in VS Code, IntelliJ, and similar tools.

The dogfood `argus.yml` and `argus.example.yml` both gain the directive at line 1.

**Workflow update** — `.github/workflows/build-containers.yml` matrix preflight previously read `.image` from each `argus.yml` entry. The dogfood entries now use the build-only shape, so the yq query reads `.name` instead and the build step still produces the same `ghcr.io/huntridge-labs/argus/<name>:<sha>` tag for publishing.

**Documentation** — `argus.example.yml`'s `containers:` comment block was rewritten to walk through both shapes side by side, with the mutual-exclusion rule called out and the `cleanup:` per-target override documented.

### Verification

- `argus validate`: `✅ argus.yml is valid` with the new shape; summary lists all 4 dogfood Dockerfiles
- `argus scan container --config argus.yml`: 4 images built and scanned end-to-end (145 findings, 102 unique). Build tags surface as `scanner-bandit:argus-scan` etc., consistent with `--discover`.
- `argus validate` against a config without the schema directive prints the IDE-hint warning; config with directive is silent
- 1567 SDK tests pass (was 1557; +10 net)

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] Tested with different scanner combinations

### Test Results

- New schema validator tests: per-target cleanup type-checking; build-only-keys-on-remote-pulls warnings; the mutual-exclusion error
- New CLI tests: schema-directive warning fires when missing, silent when present
- New container discovery tests: per-target cleanup flows through; auto-derive name from Dockerfile path when `name:` omitted; defensive parser handling for stale configs with both keys
- Existing tests that asserted the old image+dockerfile shape were updated to use option A

## Security Considerations
- [x] No security impact

## AI Context Updates (.ai/)
- [ ] N/A - No .ai/ updates needed (no architecture or workflow changes; the conceptual shift is documented in `argus.example.yml`)

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (`argus.example.yml` containers block + IDE-schema warning hint)
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**