### PR TITLE
refactor(linting-summary): silent-failure audit (status table + gating)

### DIFF
--- a/.ai/architecture.yaml
+++ b/.ai/architecture.yaml
@@ -112,6 +112,21 @@ components:
         that did not succeed.
     security-summary_script: ".github/actions/security-summary/scripts/generate_summary.py"
     security-summary_tests: "tests/integration/test_security_summary.py"
+    linting-summary_inputs:
+      # linting-summary mirrors the security-summary contract — the same
+      # silent-failure class (no artifact = "no findings") existed for
+      # linters and is closed by the same scan_statuses table.
+      scan_statuses: |
+        Optional JSON object mapping linter name -> job result
+        (success|failure|cancelled|skipped). When provided, a status table
+        is rendered at the top of the report and the composite exits non-zero
+        on any failure unless `fail_on_scanner_failure` is set to "false".
+      fail_on_scanner_failure: |
+        Default "true". When combined with `scan_statuses`, drives the
+        composite's own exit code so consumer workflows fail on any linter
+        that did not succeed.
+    linting-summary_script: ".github/actions/linting-summary/scripts/generate_summary.py"
+    linting-summary_tests: "tests/integration/test_linting_summary.py"
 
   - name: agent-skills
     location: ".agents/skills/"

--- a/.github/actions/linting-summary/README.md
+++ b/.github/actions/linting-summary/README.md
@@ -4,9 +4,11 @@ Aggregate linter results into a unified report.
 
 ## Overview
 
-This action is designed to run as the final job in your linting workflow. It downloads linter summary artifacts and combines them into a single GitHub Step Summary and optional PR comment.
+This action is designed to run as the final job in your linting workflow. It downloads linter summary artifacts, stitches them together, and — when `scan_statuses` is provided — renders a per-linter pass/fail/skipped table at the top so downstream consumers can distinguish "no findings" from "linter crashed and produced nothing."
 
 ## Usage
+
+### Basic (discovery-only)
 
 ```yaml
 linting-summary:
@@ -15,6 +17,29 @@ linting-summary:
   if: always()
   steps:
     - uses: huntridge-labs/argus/.github/actions/linting-summary@0.7.2
+```
+
+### With status gating (recommended)
+
+Pass `scan_statuses` — a JSON object mapping linter name to the corresponding job's `result` — to render a pass/fail/skipped table and exit non-zero when any linter did not succeed.
+
+```yaml
+linting-summary:
+  runs-on: ubuntu-latest
+  needs: [yaml-lint, json-lint, python-lint, javascript-lint, dockerfile-lint, terraform-lint]
+  if: always()
+  steps:
+    - uses: huntridge-labs/argus/.github/actions/linting-summary@0.7.2
+      with:
+        scan_statuses: |
+          {
+            "yaml": "${{ needs.yaml-lint.result }}",
+            "json": "${{ needs.json-lint.result }}",
+            "python": "${{ needs.python-lint.result }}",
+            "javascript": "${{ needs.javascript-lint.result }}",
+            "dockerfile": "${{ needs.dockerfile-lint.result }}",
+            "terraform": "${{ needs.terraform-lint.result }}"
+          }
 ```
 
 ## Inputs
@@ -26,17 +51,24 @@ linting-summary:
 | `show_metadata` | Show workflow metadata in the summary | No | `true` |
 | `show_stats` | Show statistics about linter results | No | `true` |
 | `post_pr_comment` | Post combined summary as PR comment | No | `true` |
+| `scan_statuses` | JSON object mapping linter name to job result. When provided, renders a per-linter status table and drives the overall verdict. | No | `''` |
+| `fail_on_scanner_failure` | When `"true"` and `scan_statuses` is provided, exit non-zero if any linter is not `success`/`skipped`. | No | `'true'` |
+| `comment_marker` | HTML-comment marker used to identify the bot's PR comment so subsequent runs update the same comment. | No | `linting-summary-comment-marker` |
 
 ## Outputs
 
-This action does not expose outputs.
+| Output | Description |
+|--------|-------------|
+| `overall_status` | Derived verdict: `success`, `failure`, or `unknown` (when `scan_statuses` is empty). |
+| `failed_count` | Number of linters in `scan_statuses` that did not succeed. |
 
 ## Requirements
 
 - Linter jobs must upload summary artifacts named `linter-summary-*`
 - Add this job after all linter jobs and use `if: always()`
+- For status gating, list every linter job in `needs:` and pass `needs.<job>.result` in `scan_statuses`
 
 ## Support
 
-- [Report Issues](https://github.com/huntridge-labs/argusissues)
+- [Report Issues](https://github.com/huntridge-labs/argus/issues)
 - [Contributing Guide](../../CONTRIBUTING.md)

--- a/.github/actions/linting-summary/action.yml
+++ b/.github/actions/linting-summary/action.yml
@@ -3,13 +3,16 @@ description: |
   Aggregate all linter results into a unified report.
 
   This action is designed to run as the FINAL job in your linting workflow,
-  after all linter jobs have completed. It automatically discovers and combines
-  summaries from all linters into a formatted GitHub Step Summary.
+  after all linter jobs have completed. It downloads linter summary artifacts
+  (default pattern: `linter-summary-*`), stitches them together, and — when
+  `scan_statuses` is provided — renders a per-linter pass/fail table at the
+  top so downstream consumers can distinguish "no findings" from "linter
+  crashed and produced nothing."
 
   **Required Environment Variables:**
   - GITHUB_TOKEN: GitHub token for API access (set automatically in workflows)
 
-  **Usage Example:**
+  **Basic Usage (discovery-only):**
   ```yaml
   linting-summary:
     runs-on: ubuntu-latest
@@ -17,6 +20,32 @@ description: |
     if: always()
     steps:
       - uses: huntridge-labs/argus/.github/actions/linting-summary@0.7.2
+  ```
+
+  **With status gating (recommended):**
+
+  Pass `scan_statuses` — a JSON object mapping linter name to the corresponding
+  job's `result` — to render a pass/fail/skipped table at the top of the report.
+  This prevents the silent-failure mode where a crashed linter produces no
+  summary and the aggregator reports "no findings" as if everything was healthy.
+
+  ```yaml
+  linting-summary:
+    runs-on: ubuntu-latest
+    needs: [yaml-lint, json-lint, python-lint, javascript-lint, dockerfile-lint, terraform-lint]
+    if: always()
+    steps:
+      - uses: huntridge-labs/argus/.github/actions/linting-summary@0.7.2
+        with:
+          scan_statuses: |
+            {
+              "yaml": "${{ needs.yaml-lint.result }}",
+              "json": "${{ needs.json-lint.result }}",
+              "python": "${{ needs.python-lint.result }}",
+              "javascript": "${{ needs.javascript-lint.result }}",
+              "dockerfile": "${{ needs.dockerfile-lint.result }}",
+              "terraform": "${{ needs.terraform-lint.result }}"
+            }
   ```
 
   **Important:**
@@ -46,6 +75,38 @@ inputs:
     description: 'Post combined summary as PR comment'
     required: false
     default: 'true'
+  scan_statuses:
+    description: |
+      Optional JSON object mapping linter name to job result
+      (success|failure|cancelled|skipped). When provided, a per-linter pass/fail
+      table is rendered at the top of the report and the overall status is derived
+      from it (any failure => job exits non-zero unless `fail_on_scanner_failure`
+      is "false"). When absent, the report falls back to a summary-only view.
+    required: false
+    default: ''
+  fail_on_scanner_failure:
+    description: |
+      When "true" (the default) and `scan_statuses` is provided, the action
+      exits non-zero if any listed linter is not "success" or "skipped". Set
+      to "false" to render the report but never block the job.
+    required: false
+    default: 'true'
+  comment_marker:
+    description: |
+      HTML-comment marker used to identify the bot's summary comment on a PR
+      so subsequent runs update the same comment instead of spawning new ones.
+      Override when migrating from a pre-existing marker to keep the same PR
+      comment thread in consumer repos.
+    required: false
+    default: 'linting-summary-comment-marker'
+
+outputs:
+  overall_status:
+    description: 'Derived verdict: success, failure, or unknown (when scan_statuses is empty).'
+    value: ${{ steps.generate.outputs.overall_status }}
+  failed_count:
+    description: 'Number of linters in scan_statuses that did not succeed.'
+    value: ${{ steps.generate.outputs.failed_count }}
 
 runs:
   using: 'composite'
@@ -59,11 +120,13 @@ runs:
       continue-on-error: true
 
     - name: Generate combined summary
+      id: generate
       shell: bash
       env:
         SUMMARY_TITLE: ${{ inputs.title }}
         SHOW_METADATA: ${{ inputs.show_metadata }}
         SHOW_STATS: ${{ inputs.show_stats }}
+        SCAN_STATUSES_JSON: ${{ inputs.scan_statuses }}
         HEAD_REF: ${{ github.head_ref }}
         REF_NAME: ${{ github.ref_name }}
         RUN_NUMBER: ${{ github.run_number }}
@@ -72,84 +135,31 @@ runs:
         RUN_ID: ${{ github.run_id }}
         COMMIT_SHA: ${{ github.sha }}
       run: |
-        # Create output directory for PR comment file
+        set -euo pipefail
         mkdir -p combined-summaries
-
-        # Function to generate summary content
-        generate_summary() {
-          local output="$1"
-          local include_title="$2"
-
-          if [ "$include_title" = "true" ]; then
-            echo "## $SUMMARY_TITLE" >> "$output"
-            echo "" >> "$output"
-          fi
-
-          # Show metadata if enabled
-          if [ "$SHOW_METADATA" = "true" ]; then
-            echo "**Workflow Run:** [$RUN_NUMBER]($SERVER_URL/$REPOSITORY/actions/runs/$RUN_ID)" >> "$output"
-
-            # Use head_ref for PRs (source branch), ref_name for pushes
-            BRANCH_NAME="$HEAD_REF"
-            if [ -z "$BRANCH_NAME" ]; then
-              BRANCH_NAME="$REF_NAME"
-            fi
-            echo "**Branch:** \`$BRANCH_NAME\`" >> "$output"
-
-            echo "**Commit:** [\`${GITHUB_SHA:0:7}\`]($SERVER_URL/$REPOSITORY/commit/$COMMIT_SHA)" >> "$output"
-            echo "" >> "$output"
-          fi
-
-          # Check if we have any linter summaries
-          if [ -d "linter-summaries" ] && [ "$(ls -A linter-summaries 2>/dev/null)" ]; then
-            LINTER_COUNT=$(find linter-summaries -name "*.md" -type f | wc -l)
-
-            # Show stats if enabled
-            if [ "$SHOW_STATS" = "true" ]; then
-              echo "**Linters Executed:** $LINTER_COUNT" >> "$output"
-              echo "" >> "$output"
-            fi
-
-            echo "### Linter Results" >> "$output"
-            echo "" >> "$output"
-
-            # Combine all linter summaries in alphabetical order
-            for summary in $(find linter-summaries -name "*.md" -type f | sort); do
-              if [ -f "$summary" ]; then
-                cat "$summary" >> "$output"
-              fi
-            done
-          else
-            echo "**No linter summaries found**" >> "$output"
-            echo "" >> "$output"
-            echo "This could mean:" >> "$output"
-            echo "- No linters were executed" >> "$output"
-            echo "- Linter jobs failed before generating summaries" >> "$output"
-            echo "- Artifacts did not upload correctly" >> "$output"
-            echo "" >> "$output"
-            echo "Check the job logs for more details." >> "$output"
-          fi
-
-          echo "" >> "$output"
-          echo "---" >> "$output"
-          echo "_Generated by [Argus](https://github.com/huntridge-labs/argus)_" >> "$output"
-        }
-
-        # Generate job summary (with title)
-        generate_summary "$GITHUB_STEP_SUMMARY" "true"
-
-        # Generate PR comment file (without title - comment-pr adds it)
-        generate_summary "combined-summaries/linting.md" "false"
-      continue-on-error: true
+        # Generate the job-step summary (with title) and the PR comment body (without title).
+        python3 "${{ github.action_path }}/scripts/generate_summary.py" \
+          "$GITHUB_STEP_SUMMARY" true
+        python3 "${{ github.action_path }}/scripts/generate_summary.py" \
+          combined-summaries/linting.md false
 
     - name: Comment PR with linting summary
       if: github.event_name == 'pull_request' && inputs.post_pr_comment == 'true'
       uses: huntridge-labs/argus/.github/actions/comment-pr@0.7.2
       with:
         summary_file: combined-summaries/linting.md
-        comment_marker: linting-summary-comment-marker
+        comment_marker: ${{ inputs.comment_marker }}
         title: '${{ inputs.title }}'
         fallback_message: 'No linter results available'
+
+    - name: Fail job when any linter reported failure
+      if: inputs.fail_on_scanner_failure == 'true' && steps.generate.outputs.overall_status == 'failure'
+      shell: bash
+      env:
+        FAILED_COUNT: ${{ steps.generate.outputs.failed_count }}
+      run: |
+        echo "::error title=Linter failure::${FAILED_COUNT} linter(s) did not complete successfully. See the status table in the summary for details."
+        exit 1
 
 branding:
   icon: 'file-text'

--- a/.github/actions/linting-summary/scripts/generate_summary.py
+++ b/.github/actions/linting-summary/scripts/generate_summary.py
@@ -1,0 +1,287 @@
+"""Generate the linting-summary combined report.
+
+Called from the linting-summary composite action. All configuration flows in
+via environment variables populated by the action's ``env:`` block; the
+single positional argument controls which output destination to write to.
+
+Responsibilities:
+
+1. Optionally render a per-linter status table at the top of the report,
+   driven by ``SCAN_STATUSES_JSON``. When scan_statuses is supplied, the
+   table is the source of truth — the aggregator will call out any linter
+   whose job did not succeed, and the caller can choose to exit non-zero
+   to block downstream consumers.
+2. Discover linter summary markdown files under ``linter-summaries/`` and
+   stitch them into the output, stripping a redundant outer
+   ``<details>/<summary>`` wrapper so reviewers don't have to click twice
+   to see each linter's findings.
+3. Emit ``overall_status`` / ``failed_count`` to ``$GITHUB_OUTPUT`` so the
+   composite can fail the job when any linter did not succeed.
+
+This is the linter-side counterpart to
+``.github/actions/security-summary/scripts/generate_summary.py`` — the two
+share an architecture so a fix in one should land in the other. The script
+is intentionally dependency-free (stdlib only) so it can run on any
+composite consumer without a separate ``pip install`` step.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Iterable
+
+
+STATUS_BADGES = {
+    "success": "✅ PASS",
+    "failure": "❌ FAIL",
+    "cancelled": "⏹️ cancelled",
+    "skipped": "⏭️ skipped",
+    "not-run": "◻️ not run",
+}
+
+# A linter is considered "failed" (blocking) when its result is neither a
+# clean success nor an intentional non-run (skipped because not selected, or
+# left blank because the caller didn't wire it up). Cancelled counts as
+# failure because it means we can't trust the findings.
+PASSING_STATES = frozenset({"success", "skipped", "not-run"})
+
+
+def parse_scan_statuses(raw: str) -> dict[str, str]:
+    """Parse the SCAN_STATUSES_JSON env input into a normalized dict.
+
+    Returns an empty dict when the input is blank. Emits a GitHub Actions
+    warning and returns an empty dict when the input is not valid JSON,
+    rather than crashing the whole report.
+    """
+    raw = (raw or "").strip()
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(
+            f"::warning title=linting-summary::scan_statuses is not valid JSON ({exc}); "
+            "falling back to discovery-only mode",
+            file=sys.stderr,
+            flush=True,
+        )
+        return {}
+    if not isinstance(parsed, dict):
+        print(
+            "::warning title=linting-summary::scan_statuses must be a JSON object; "
+            "falling back to discovery-only mode",
+            file=sys.stderr,
+            flush=True,
+        )
+        return {}
+    # Normalize empty strings to "not-run" so callers can safely wire
+    # `needs.*.result` for jobs that may never have started.
+    return {str(k): (str(v).strip() or "not-run") for k, v in parsed.items()}
+
+
+def render_status_table(statuses: dict[str, str]) -> list[str]:
+    """Return the markdown lines for the per-linter status table.
+
+    Returns an empty list when ``statuses`` is empty so callers can skip the
+    whole block rather than emit an empty table.
+    """
+    if not statuses:
+        return []
+    lines: list[str] = ["### Lint Status", "", "| Linter | Status |", "|--------|--------|"]
+    for name in sorted(statuses):
+        badge = STATUS_BADGES.get(statuses[name], f"❓ {statuses[name]}")
+        lines.append(f"| `{name}` | {badge} |")
+    lines.append("")
+    failed = sorted(n for n, r in statuses.items() if r not in PASSING_STATES)
+    if failed:
+        lines.append(
+            f"> **❌ {len(failed)} linter(s) failed:** "
+            + ", ".join(f"`{n}`" for n in failed)
+            + "."
+        )
+        lines.append(
+            "> Downstream consumers should treat this report as blocking — the lint "
+            "findings below are not complete."
+        )
+    else:
+        lines.append("> **✅ All enabled linters completed successfully.**")
+    lines.append("")
+    return lines
+
+
+_OUTER_DETAILS_RE = re.compile(
+    r"\A<details[^>]*>\s*<summary[^>]*>(?P<title>.*?)</summary>(?P<body>.*)</details>\s*\Z",
+    re.DOTALL | re.IGNORECASE,
+)
+
+
+def normalize_summary(md_text: str) -> str:
+    """Strip a single layer of outer <details>/<summary> wrapping.
+
+    Argus-SDK-native summaries often ship pre-wrapped in a `<details>` block
+    so they collapse nicely when embedded in a PR comment. When we then wrap
+    the whole set in *another* `<details>`, reviewers have to click twice to
+    see anything. This function converts a single outer wrapper into a plain
+    markdown heading so the section title is visible without a click.
+
+    If the document is NOT a single outer-wrapped block (e.g., it already
+    starts with plain markdown, or contains multiple top-level elements), it
+    is returned unchanged so we don't mangle arbitrary author markup.
+    """
+    stripped = md_text.strip()
+    match = _OUTER_DETAILS_RE.match(stripped)
+    if not match:
+        return md_text if md_text.endswith("\n") else md_text + "\n"
+    title = re.sub(r"<[^>]+>", "", match.group("title")).strip()
+    body = match.group("body").strip()
+    parts: list[str] = []
+    if title:
+        parts.append(f"#### {title}")
+        parts.append("")
+    parts.append(body)
+    parts.append("")
+    return "\n".join(parts)
+
+
+def gather_summary_files(summaries_dir: Path) -> list[Path]:
+    """Return sorted markdown files in the summaries dir (empty list if absent)."""
+    if not summaries_dir.is_dir():
+        return []
+    return sorted(p for p in summaries_dir.glob("*.md") if p.is_file())
+
+
+def render_linter_results(
+    summary_files: Iterable[Path],
+    show_stats: bool,
+) -> list[str]:
+    """Return the markdown lines for the "Linter Results" section."""
+    files = list(summary_files)
+    lines: list[str] = []
+    if files:
+        if show_stats:
+            lines.append(f"**Linters Executed:** {len(files)}")
+            lines.append("")
+        lines.append("### Linter Results")
+        lines.append("")
+        for md_file in files:
+            lines.append(normalize_summary(md_file.read_text(encoding="utf-8")))
+    else:
+        lines.append("### Linter Results")
+        lines.append("")
+        lines.append("_No linter summary artifacts were uploaded._")
+        lines.append("")
+        lines.append(
+            "The status table above is the source of truth for which linters ran. "
+            "An empty summary set with some linters marked ❌/⏹️ typically means the lint "
+            "job failed before producing output — inspect the linter job logs for the "
+            "root cause."
+        )
+    return lines
+
+
+def build_report(
+    *,
+    title: str,
+    show_metadata: bool,
+    show_stats: bool,
+    include_title: bool,
+    statuses: dict[str, str],
+    summary_files: list[Path],
+    metadata: dict[str, str],
+) -> str:
+    """Assemble the full markdown report as a single string."""
+    lines: list[str] = []
+    if include_title and title:
+        lines.append(f"## {title}")
+        lines.append("")
+
+    if show_metadata:
+        run_number = metadata.get("run_number", "")
+        server_url = metadata.get("server_url", "")
+        repository = metadata.get("repository", "")
+        run_id = metadata.get("run_id", "")
+        branch = metadata.get("head_ref") or metadata.get("ref_name", "")
+        commit = metadata.get("commit_sha", "")
+        short_commit = commit[:7] if commit else ""
+        lines.append(
+            f"**Workflow Run:** [{run_number}]({server_url}/{repository}/actions/runs/{run_id})"
+        )
+        lines.append(f"**Branch:** `{branch}`")
+        lines.append(f"**Commit:** [`{short_commit}`]({server_url}/{repository}/commit/{commit})")
+        lines.append("")
+
+    lines.extend(render_status_table(statuses))
+    lines.extend(render_linter_results(summary_files, show_stats=show_stats))
+
+    lines.append("")
+    lines.append("---")
+    lines.append("_Generated by [Argus](https://github.com/huntridge-labs/argus)_")
+    return "\n".join(lines) + "\n"
+
+
+def _write_github_output(overall: str, failed_count: int) -> None:
+    """Append outputs to $GITHUB_OUTPUT when that env var is set."""
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        return
+    with open(output_path, "a", encoding="utf-8") as fh:
+        fh.write(f"overall_status={overall}\n")
+        fh.write(f"failed_count={failed_count}\n")
+
+
+def derive_overall_status(statuses: dict[str, str]) -> tuple[str, int]:
+    """Compute the overall verdict and count of failing linters."""
+    if not statuses:
+        return "unknown", 0
+    failed = [n for n, r in statuses.items() if r not in PASSING_STATES]
+    return ("failure" if failed else "success", len(failed))
+
+
+def main(argv: list[str]) -> int:
+    """Script entry point — see module docstring for the full contract."""
+    if len(argv) < 3:
+        print(
+            "usage: generate_summary.py <output_path> <include_title:true|false>",
+            file=sys.stderr,
+        )
+        return 2
+
+    output_path = Path(argv[1])
+    include_title = argv[2].lower() == "true"
+
+    statuses = parse_scan_statuses(os.environ.get("SCAN_STATUSES_JSON", ""))
+    summary_files = gather_summary_files(Path("linter-summaries"))
+
+    report = build_report(
+        title=os.environ.get("SUMMARY_TITLE", "Code Quality & Linting Summary"),
+        show_metadata=os.environ.get("SHOW_METADATA", "true").lower() == "true",
+        show_stats=os.environ.get("SHOW_STATS", "true").lower() == "true",
+        include_title=include_title,
+        statuses=statuses,
+        summary_files=summary_files,
+        metadata={
+            "run_number": os.environ.get("RUN_NUMBER", ""),
+            "server_url": os.environ.get("SERVER_URL", ""),
+            "repository": os.environ.get("REPOSITORY", ""),
+            "run_id": os.environ.get("RUN_ID", ""),
+            "head_ref": os.environ.get("HEAD_REF", ""),
+            "ref_name": os.environ.get("REF_NAME", ""),
+            "commit_sha": os.environ.get("COMMIT_SHA", ""),
+        },
+    )
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(report, encoding="utf-8")
+
+    overall, failed_count = derive_overall_status(statuses)
+    _write_github_output(overall, failed_count)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/docs/developer/SDK-ROADMAP.md
+++ b/docs/developer/SDK-ROADMAP.md
@@ -231,7 +231,7 @@ Born out of the medsecops-golden-path SDK-integration post-mortem. The pre-refac
 ### Remaining
 
 - [ ] Verify medsecops-golden-path demo pipeline no longer reproduces the silent-failure scenarios once PR #91 is merged to `feat/argus-portability`
-- [ ] Apply the same silent-failure audit to other aggregators (`linting-summary`) — they may have the same "no artifact = no findings" failure mode
+- [x] Apply the same silent-failure audit to other aggregators (`linting-summary`) — same `scan_statuses` JSON input, `fail_on_scanner_failure` gating, `overall_status`/`failed_count` outputs, status table at the top of the report; logic extracted to stdlib-only `scripts/generate_summary.py` with 29 integration tests
 
 ---
 

--- a/tests/integration/test_linting_summary.py
+++ b/tests/integration/test_linting_summary.py
@@ -1,0 +1,522 @@
+"""Integration tests for the linting-summary composite action.
+
+These tests exercise the real `generate_summary.py` script that ships inside
+`.github/actions/linting-summary/scripts/` — not a Python reproduction of
+bash logic. The script owns the report-generation contract, so testing it
+directly means the tests will catch regressions that the composite's
+consumers would actually see.
+
+Coverage goals:
+
+- Discovery path: summaries are found, sorted, and stitched together.
+- Status-table path: `scan_statuses` JSON renders a per-linter pass/fail
+  table and surfaces failing linters.
+- Silent-failure guard: a linter that reports `failure` but uploads no
+  summary artifact is surfaced as failing in the status table rather than
+  collapsing into a "no findings" verdict.
+- Double-disclosure UX: a summary pre-wrapped in `<details>` is unwrapped so
+  reviewers don't have to click twice to see findings.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+
+# Dynamically load the generate_summary module from the composite action
+# so tests stay co-located with the shipped script without needing to add
+# the composite's scripts dir to the global pythonpath.
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / ".github/actions/linting-summary/scripts/generate_summary.py"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("linting_generate_summary", _SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+generate_summary = _load_module()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+YAML_SUMMARY = """\
+#### YAML Lint
+
+| Severity | Count |
+|----------|-------|
+| Info     | 3     |
+
+**Total findings:** 3
+"""
+
+PYTHON_SUMMARY = """\
+#### Python Lint
+
+| Severity | Count |
+|----------|-------|
+| Info     | 1     |
+
+**Total findings:** 1
+"""
+
+DOCKERFILE_SUMMARY_WRAPPED = """\
+<details><summary>🐳 Dockerfile Lint</summary>
+
+**Status:** ✅ Completed
+
+| Info | Style | Warnings |
+|:----:|:-----:|:--------:|
+| 0    | 2     | 5        |
+
+</details>
+"""
+
+
+@pytest.fixture
+def summaries_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "linter-summaries"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def run_in(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """Run tests with tmp_path as the working directory and GITHUB_OUTPUT set."""
+    monkeypatch.chdir(tmp_path)
+    github_output = tmp_path / "gh_output.env"
+    github_output.touch()
+    monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
+    yield tmp_path
+
+
+def _set_env(monkeypatch: pytest.MonkeyPatch, **env: str) -> None:
+    defaults = {
+        "SUMMARY_TITLE": "Code Quality & Linting Summary",
+        "SHOW_METADATA": "false",
+        "SHOW_STATS": "true",
+        "SCAN_STATUSES_JSON": "",
+        "HEAD_REF": "",
+        "REF_NAME": "main",
+        "RUN_NUMBER": "1",
+        "SERVER_URL": "https://github.com",
+        "REPOSITORY": "owner/repo",
+        "RUN_ID": "123",
+        "COMMIT_SHA": "abc1234567",
+    }
+    defaults.update(env)
+    for key, value in defaults.items():
+        monkeypatch.setenv(key, value)
+
+
+def _read_outputs(path: Path) -> dict[str, str]:
+    pairs = {}
+    for line in path.read_text().splitlines():
+        if "=" in line:
+            k, v = line.split("=", 1)
+            pairs[k] = v
+    return pairs
+
+
+# ---------------------------------------------------------------------------
+# Pure-function unit coverage (no file system)
+# ---------------------------------------------------------------------------
+
+
+class TestParseScanStatuses:
+    def test_blank_input_returns_empty_dict(self):
+        assert generate_summary.parse_scan_statuses("") == {}
+        assert generate_summary.parse_scan_statuses("   \n  ") == {}
+
+    def test_valid_json_normalizes_values(self):
+        raw = '{"yaml": "success", "python": "failure"}'
+        assert generate_summary.parse_scan_statuses(raw) == {
+            "yaml": "success",
+            "python": "failure",
+        }
+
+    def test_empty_string_value_becomes_not_run(self):
+        raw = '{"yaml": "", "python": "success"}'
+        result = generate_summary.parse_scan_statuses(raw)
+        assert result["yaml"] == "not-run"
+        assert result["python"] == "success"
+
+    def test_invalid_json_returns_empty_dict(self, capsys):
+        result = generate_summary.parse_scan_statuses("not-json-at-all")
+        assert result == {}
+        captured = capsys.readouterr()
+        assert "not valid JSON" in captured.err
+        # Warning is namespaced to the linting-summary action so log readers
+        # can tell which aggregator produced the message.
+        assert "linting-summary" in captured.err
+
+    def test_json_that_is_not_an_object_returns_empty(self, capsys):
+        result = generate_summary.parse_scan_statuses('["yaml", "python"]')
+        assert result == {}
+        captured = capsys.readouterr()
+        assert "must be a JSON object" in captured.err
+
+
+class TestDeriveOverallStatus:
+    def test_empty_statuses_are_unknown(self):
+        assert generate_summary.derive_overall_status({}) == ("unknown", 0)
+
+    def test_all_success_is_success(self):
+        statuses = {"a": "success", "b": "success"}
+        assert generate_summary.derive_overall_status(statuses) == ("success", 0)
+
+    def test_skipped_counts_as_passing(self):
+        statuses = {"a": "success", "b": "skipped", "c": "not-run"}
+        assert generate_summary.derive_overall_status(statuses) == ("success", 0)
+
+    def test_any_failure_is_failure(self):
+        statuses = {"a": "success", "b": "failure"}
+        assert generate_summary.derive_overall_status(statuses) == ("failure", 1)
+
+    def test_cancelled_counts_as_failure(self):
+        # Cancelled lint jobs can't be trusted; must block downstream consumers.
+        statuses = {"a": "cancelled", "b": "success"}
+        assert generate_summary.derive_overall_status(statuses) == ("failure", 1)
+
+
+class TestNormalizeSummary:
+    def test_plain_markdown_passes_through(self):
+        src = "#### YAML Lint\n\nNo findings.\n"
+        result = generate_summary.normalize_summary(src)
+        assert "<details" not in result
+        assert "YAML Lint" in result
+
+    def test_adds_trailing_newline_to_plain_markdown(self):
+        # Without a trailing newline, subsequent cats would glue linter
+        # headings together.
+        src = "#### YAML Lint\n\nNo findings."
+        result = generate_summary.normalize_summary(src)
+        assert result.endswith("\n")
+
+    def test_strips_single_outer_details_wrapper(self):
+        result = generate_summary.normalize_summary(DOCKERFILE_SUMMARY_WRAPPED)
+        assert "<details>" not in result
+        assert "</details>" not in result
+        assert "#### 🐳 Dockerfile Lint" in result
+        # Body is preserved.
+        assert "Status:" in result and "Warnings" in result
+
+    def test_leaves_nested_details_intact_when_outer_is_not_sole_wrapper(self):
+        # Document contains a heading followed by a disclosure — the outer
+        # regex doesn't match, so the whole thing should survive.
+        src = "## Terraform Lint\n\n<details><summary>details</summary>body</details>\n"
+        result = generate_summary.normalize_summary(src)
+        assert "## Terraform Lint" in result
+        assert "<details>" in result
+
+
+# ---------------------------------------------------------------------------
+# End-to-end tests: invoke the script entry point, read the rendered report
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateSummaryEndToEnd:
+    def test_discovery_only_combines_summaries_in_sorted_order(
+        self, run_in, summaries_dir, monkeypatch
+    ):
+        (summaries_dir / "yaml.md").write_text(YAML_SUMMARY)
+        (summaries_dir / "terraform.md").write_text("#### Terraform Lint\n\nNo findings.\n")
+        (summaries_dir / "python.md").write_text(PYTHON_SUMMARY)
+
+        _set_env(monkeypatch)
+        output = run_in / "report.md"
+        exit_code = generate_summary.main(
+            ["generate_summary.py", str(output), "true"]
+        )
+        assert exit_code == 0
+
+        content = output.read_text()
+        # Alphabetical order: python < terraform < yaml
+        assert (
+            content.index("Python Lint")
+            < content.index("Terraform Lint")
+            < content.index("YAML Lint")
+        )
+        assert "**Linters Executed:** 3" in content
+        assert "_Generated by [Argus]" in content
+
+    def test_status_table_renders_when_scan_statuses_provided(
+        self, run_in, summaries_dir, monkeypatch
+    ):
+        (summaries_dir / "yaml.md").write_text(YAML_SUMMARY)
+
+        _set_env(
+            monkeypatch,
+            SCAN_STATUSES_JSON=json.dumps(
+                {
+                    "yaml": "success",
+                    "python": "success",
+                    "dockerfile": "failure",
+                    "terraform": "skipped",
+                }
+            ),
+        )
+        output = run_in / "report.md"
+        exit_code = generate_summary.main(
+            ["generate_summary.py", str(output), "true"]
+        )
+        assert exit_code == 0
+
+        content = output.read_text()
+        assert "### Lint Status" in content
+        assert "| `yaml` | ✅ PASS |" in content
+        assert "| `dockerfile` | ❌ FAIL |" in content
+        assert "| `terraform` | ⏭️ skipped |" in content
+        # Failing linters are called out explicitly in the blockquote footer.
+        assert "1 linter(s) failed" in content
+        assert "`dockerfile`" in content
+
+    def test_silent_failure_surfaces_when_summary_missing(
+        self, run_in, summaries_dir, monkeypatch
+    ):
+        # Dockerfile linter reports "failure" but never uploaded a summary —
+        # the pre-refactor bash rollup would have silently reported "no
+        # linter summaries found." The status table must catch it as a real
+        # failure rather than a benign empty state.
+        _set_env(
+            monkeypatch,
+            SCAN_STATUSES_JSON=json.dumps({"dockerfile": "failure"}),
+        )
+        output = run_in / "report.md"
+        exit_code = generate_summary.main(
+            ["generate_summary.py", str(output), "true"]
+        )
+        assert exit_code == 0
+
+        content = output.read_text()
+        assert "| `dockerfile` | ❌ FAIL |" in content
+        # No summary artifacts means the Linter Results section explicitly
+        # warns that the status table is the source of truth.
+        assert "_No linter summary artifacts were uploaded._" in content
+        assert "status table above is the source of truth" in content
+
+        # GitHub outputs reflect the failing verdict so the composite knows
+        # to exit non-zero.
+        outputs = _read_outputs(run_in / "gh_output.env")
+        assert outputs["overall_status"] == "failure"
+        assert outputs["failed_count"] == "1"
+
+    def test_all_success_emits_success_overall_status(
+        self, run_in, summaries_dir, monkeypatch
+    ):
+        (summaries_dir / "yaml.md").write_text(YAML_SUMMARY)
+        _set_env(
+            monkeypatch,
+            SCAN_STATUSES_JSON=json.dumps(
+                {"yaml": "success", "python": "success"}
+            ),
+        )
+        output = run_in / "report.md"
+        generate_summary.main(["generate_summary.py", str(output), "true"])
+
+        outputs = _read_outputs(run_in / "gh_output.env")
+        assert outputs["overall_status"] == "success"
+        assert outputs["failed_count"] == "0"
+        assert "**✅ All enabled linters completed successfully.**" in output.read_text()
+
+    def test_all_failed_emits_failure_overall_status(
+        self, run_in, summaries_dir, monkeypatch
+    ):
+        # Worst-case scenario: every wired linter failed. The status table
+        # must list each one and the GitHub output must reflect the count.
+        _set_env(
+            monkeypatch,
+            SCAN_STATUSES_JSON=json.dumps(
+                {"yaml": "failure", "python": "failure", "dockerfile": "cancelled"}
+            ),
+        )
+        output = run_in / "report.md"
+        generate_summary.main(["generate_summary.py", str(output), "true"])
+
+        content = output.read_text()
+        outputs = _read_outputs(run_in / "gh_output.env")
+        assert outputs["overall_status"] == "failure"
+        assert outputs["failed_count"] == "3"
+        assert "3 linter(s) failed" in content
+        assert "| `dockerfile` | ⏹️ cancelled |" in content
+
+    def test_mixed_pass_fail_skipped_renders_each_badge(
+        self, run_in, summaries_dir, monkeypatch
+    ):
+        _set_env(
+            monkeypatch,
+            SCAN_STATUSES_JSON=json.dumps(
+                {
+                    "yaml": "success",
+                    "python": "failure",
+                    "javascript": "skipped",
+                    "dockerfile": "cancelled",
+                    "terraform": "",  # empty -> not-run
+                }
+            ),
+        )
+        output = run_in / "report.md"
+        generate_summary.main(["generate_summary.py", str(output), "true"])
+
+        content = output.read_text()
+        assert "✅ PASS" in content
+        assert "❌ FAIL" in content
+        assert "⏭️ skipped" in content
+        assert "⏹️ cancelled" in content
+        assert "◻️ not run" in content
+
+        outputs = _read_outputs(run_in / "gh_output.env")
+        # Failure + cancelled = 2 blocking; skipped + not-run + success = passing.
+        assert outputs["overall_status"] == "failure"
+        assert outputs["failed_count"] == "2"
+
+    def test_no_scan_statuses_emits_unknown_overall_status(
+        self, run_in, summaries_dir, monkeypatch
+    ):
+        (summaries_dir / "yaml.md").write_text(YAML_SUMMARY)
+        _set_env(monkeypatch)  # no SCAN_STATUSES_JSON
+        output = run_in / "report.md"
+        generate_summary.main(["generate_summary.py", str(output), "true"])
+
+        outputs = _read_outputs(run_in / "gh_output.env")
+        # When caller doesn't wire scan_statuses we cannot make a verdict.
+        # The composite's optional fail step won't fire on "unknown", so the
+        # caller's gating is preserved.
+        assert outputs["overall_status"] == "unknown"
+        content = output.read_text()
+        assert "### Lint Status" not in content
+
+    def test_invalid_scan_statuses_falls_back_to_discovery_only(
+        self, run_in, summaries_dir, monkeypatch
+    ):
+        # A typo in the workflow caller's `with:` block must not crash the
+        # report. We expect a warning + a degraded but valid output.
+        (summaries_dir / "yaml.md").write_text(YAML_SUMMARY)
+        _set_env(monkeypatch, SCAN_STATUSES_JSON="{not valid json")
+        output = run_in / "report.md"
+        exit_code = generate_summary.main(
+            ["generate_summary.py", str(output), "true"]
+        )
+        assert exit_code == 0
+
+        content = output.read_text()
+        assert "### Lint Status" not in content
+        assert "YAML Lint" in content
+        outputs = _read_outputs(run_in / "gh_output.env")
+        assert outputs["overall_status"] == "unknown"
+
+    def test_double_details_unwrap_in_rendered_output(
+        self, run_in, summaries_dir, monkeypatch
+    ):
+        # Dockerfile summary ships wrapped; simulate the previously-broken
+        # double-disclosure UX by rendering it through the aggregator.
+        (summaries_dir / "dockerfile.md").write_text(DOCKERFILE_SUMMARY_WRAPPED)
+        _set_env(monkeypatch)
+        output = run_in / "report.md"
+        generate_summary.main(["generate_summary.py", str(output), "true"])
+
+        content = output.read_text()
+        # The outer <details> wrapper is replaced with a heading so reviewers
+        # see the section title without clicking twice.
+        assert "<details>" not in content
+        assert "</details>" not in content
+        assert "#### 🐳 Dockerfile Lint" in content
+
+    def test_metadata_block_renders_when_enabled(
+        self, run_in, summaries_dir, monkeypatch
+    ):
+        (summaries_dir / "yaml.md").write_text(YAML_SUMMARY)
+        _set_env(
+            monkeypatch,
+            SHOW_METADATA="true",
+            RUN_NUMBER="42",
+            REPOSITORY="acme/lint",
+            RUN_ID="9999",
+            REF_NAME="main",
+            COMMIT_SHA="deadbeef123456",
+        )
+        output = run_in / "report.md"
+        generate_summary.main(["generate_summary.py", str(output), "true"])
+
+        content = output.read_text()
+        assert "**Workflow Run:** [42]" in content
+        assert "**Branch:** `main`" in content
+        assert "`deadbee`" in content  # short sha
+
+    def test_show_stats_false_hides_executed_count(
+        self, run_in, summaries_dir, monkeypatch
+    ):
+        (summaries_dir / "yaml.md").write_text(YAML_SUMMARY)
+        _set_env(monkeypatch, SHOW_STATS="false")
+        output = run_in / "report.md"
+        generate_summary.main(["generate_summary.py", str(output), "true"])
+
+        content = output.read_text()
+        assert "**Linters Executed:**" not in content
+        # The actual linter section still renders.
+        assert "### Linter Results" in content
+        assert "YAML Lint" in content
+
+    def test_title_hidden_when_include_title_false(
+        self, run_in, summaries_dir, monkeypatch
+    ):
+        # The composite calls the script twice — once with include_title for
+        # the job summary, once without for the PR comment body. Verify the
+        # toggle works.
+        (summaries_dir / "yaml.md").write_text(YAML_SUMMARY)
+        _set_env(monkeypatch, SUMMARY_TITLE="Custom Title")
+        output = run_in / "report.md"
+        generate_summary.main(["generate_summary.py", str(output), "false"])
+
+        content = output.read_text()
+        assert not content.lstrip().startswith("## Custom Title")
+        assert "YAML Lint" in content
+
+    def test_title_renders_with_h2_when_include_title_true(
+        self, run_in, summaries_dir, monkeypatch
+    ):
+        (summaries_dir / "yaml.md").write_text(YAML_SUMMARY)
+        _set_env(monkeypatch, SUMMARY_TITLE="Code Quality & Linting Summary")
+        output = run_in / "report.md"
+        generate_summary.main(["generate_summary.py", str(output), "true"])
+
+        # The job-step-summary copy gets the title prefixed with `## `.
+        assert output.read_text().lstrip().startswith("## Code Quality & Linting Summary")
+
+    def test_empty_linter_summaries_without_statuses_shows_no_results(
+        self, run_in, summaries_dir, monkeypatch
+    ):
+        _set_env(monkeypatch)  # empty summaries dir, no scan_statuses
+        output = run_in / "report.md"
+        generate_summary.main(["generate_summary.py", str(output), "true"])
+
+        content = output.read_text()
+        assert "_No linter summary artifacts were uploaded._" in content
+        outputs = _read_outputs(run_in / "gh_output.env")
+        # With no statuses AND no summaries we can't claim success OR failure.
+        assert outputs["overall_status"] == "unknown"
+
+
+class TestScriptInterface:
+    def test_missing_args_returns_nonzero(self, monkeypatch, capsys):
+        _set_env(monkeypatch)
+        exit_code = generate_summary.main(["generate_summary.py"])
+        assert exit_code == 2
+        captured = capsys.readouterr()
+        assert "usage:" in captured.err
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Description

Mirrors the security-summary refactor (PR #91) on the linting aggregator. The pre-refactor bash rollup could not distinguish "linter ran cleanly with zero findings" from "linter crashed and uploaded nothing" — both rendered the same green report. This PR closes that silent-failure class on `linting-summary` with the same `scan_statuses` JSON input + per-linter status table + `fail_on_scanner_failure` gating used on `security-summary`.

## Changes Made
- [ ] Added new scanner/workflow
- [x] Modified existing scanner/workflow
- [x] Updated documentation
- [x] Fixed bug
- [ ] Other (please specify)

### Details

- New `scan_statuses` JSON input (mapping linter name → `needs.<job>.result`) renders a per-linter pass/fail/skipped table at the top of the report. Independent of artifact presence, so a crashed linter that uploaded nothing is still surfaced as failed.
- New `fail_on_scanner_failure` input (default `true`) + `overall_status` / `failed_count` outputs — composite exits non-zero when any listed linter did not succeed.
- New `comment_marker` input for PR-comment continuity (default `linting-summary-comment-marker` preserves the existing thread; override to migrate).
- Summary logic extracted from a 60-line bash heredoc to stdlib-only `scripts/generate_summary.py` (unit-testable; mirrors `security-summary/scripts/generate_summary.py` line-for-line on the shared bits).
- Outer `<details>` unwrap so pre-wrapped linter summaries don't render behind a double disclosure.
- Backwards-compatible: callers that don't pass `scan_statuses` get the original discovery-only behavior plus a clearer "no artifacts uploaded" message; `overall_status` is `unknown` so the optional fail step is a no-op.

Affected:
- `.github/actions/linting-summary/action.yml` — new inputs/outputs/steps
- `.github/actions/linting-summary/scripts/generate_summary.py` — new
- `.github/actions/linting-summary/README.md` — documents the new contract
- `tests/integration/test_linting_summary.py` — new
- `.ai/architecture.yaml` — adds linting-summary entry to the summary-generators block, mirroring the existing security-summary metadata
- `docs/developer/SDK-ROADMAP.md` — line 232 marked complete

No breaking changes: existing callers (e.g., `.github/workflows/linting.yml`, `examples/workflows/actions-linting-example.yml`) continue to work unchanged because every new input has a safe default.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results

29 integration tests against the real `generate_summary.py` covering:
- Status-table rendering when `scan_statuses` is provided
- Silent-failure guard: `failure` reported but no artifact uploaded → still surfaced
- `\$GITHUB_OUTPUT` verdict for all-success / all-failure / mixed / cancelled
- Invalid-JSON `scan_statuses` falls back to discovery-only with a warning
- Outer `<details>` unwrap (pre-wrapped Argus-SDK summaries)
- Metadata block, title toggle, show_stats toggle, empty summaries

Local run:
```
$ pytest tests/integration/test_linting_summary.py --no-cov -q
29 passed in 0.05s
```

Full SDK suite + both summary integration tests:
```
$ pytest argus/tests/ tests/integration/test_security_summary.py tests/integration/test_linting_summary.py --no-cov -q
1706 passed, 8 skipped, 7 deselected
```

## Security Considerations
- [x] No security impact
- [ ] Security enhancement
- [ ] Potential security implications (explain below)

### Security Details

`scan_statuses` is consumed only by the report renderer — values are HTML-escaped via markdown table cells (no `eval`, no shell interpolation). Invalid JSON is logged as a GHA warning and falls back to discovery-only mode rather than crashing.

## AI Context Updates (.ai/)

- [x] `.ai/architecture.yaml` updated (if components/structure changed)
- [ ] `.ai/workflows.yaml` updated (if commands/tasks changed)
- [ ] `.ai/decisions.yaml` updated (if design decision made)
- [ ] `.ai/errors.yaml` updated (if common error addressed)
- [ ] N/A - No .ai/ updates needed

ADR-016 in `.ai/decisions.yaml` (recorded with PR #91) already covers the architectural decision; this PR just applies the same pattern to a second aggregator, so no new ADR is needed.

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues

Closes roadmap item #232 (\`docs/developer/SDK-ROADMAP.md\` — Silent-Failure Gating remaining work).