### PR TITLE
feat(reporters): add github, gitlab, and junit reporters

### DIFF
--- a/.ai/architecture.yaml
+++ b/.ai/architecture.yaml
@@ -44,7 +44,7 @@ components:
       "viewers/browser/": "`argus view --interface=browser` — FastAPI + Jinja2 web UI, 127.0.0.1 only ([browser] extra)"
       "scanners/": "Scanner modules implementing Scanner protocol (SCANNER_REGISTRY includes linters via auto-merge)"
       "linters/": "Linter modules implementing Scanner protocol (LINTER_REGISTRY auto-merges into SCANNER_REGISTRY)"
-      "reporters/": "Output reporters (terminal, markdown, sarif, json)"
+      "reporters/": "Output reporters (terminal, markdown, sarif, json, github, gitlab, junit)"
       "preflight/": "CI preflight: provider detection, living issue reporting (GitHub/GitLab), network deps, scanner tool-readiness checks (tool_check.py)"
 
   - name: argus-linters
@@ -460,7 +460,7 @@ docsite:
       "viewers/browser/": "`argus view --interface=browser` — FastAPI + Jinja2 web UI, 127.0.0.1 only ([browser] extra)"
       "scanners/": "Scanner modules implementing Scanner protocol (SCANNER_REGISTRY includes linters via auto-merge)"
       "linters/": "Linter modules implementing Scanner protocol (LINTER_REGISTRY auto-merges into SCANNER_REGISTRY)"
-      "reporters/": "Output reporters (terminal, markdown, sarif, json)"
+      "reporters/": "Output reporters (terminal, markdown, sarif, json, github, gitlab, junit)"
       "tests/": "Co-located pytest tests (180 tests, 83%+ coverage)"
     scanners:
       - bandit
@@ -485,6 +485,9 @@ docsite:
       - markdown
       - sarif
       - json
+      - github
+      - gitlab
+      - junit
     dependencies:
       core: "pyyaml, click, jsonschema, rich (terminal output), packaging"
       optional_extras:
@@ -509,7 +512,7 @@ directory_structure:
   "argus/core/": "Core models, protocols, config, and engine"
   "argus/scanners/": "Scanner modules (one per scanner, SCANNER_REGISTRY includes linters)"
   "argus/linters/": "Linter modules (one per linter, LINTER_REGISTRY auto-merges into SCANNER_REGISTRY)"
-  "argus/reporters/": "Output reporters (terminal, markdown, sarif, json)"
+  "argus/reporters/": "Output reporters (terminal, markdown, sarif, json, github, gitlab, junit)"
   "argus/tests/": "SDK test suite"
   ".github/actions/": "Composite actions (GitHub Actions interface)"
   ".github/workflows/": "CI/CD and test workflows"

--- a/argus/cli.py
+++ b/argus/cli.py
@@ -15,7 +15,7 @@ EXIT_FINDINGS = 1
 EXIT_ERROR = 2
 
 SEVERITY_CHOICES = ["critical", "high", "medium", "low", "none"]
-FORMAT_CHOICES = ["terminal", "markdown", "sarif", "json"]
+FORMAT_CHOICES = ["terminal", "markdown", "sarif", "json", "github", "gitlab", "junit"]
 _SPINNER_STYLES = [
     ["⠁", "⠂", "⠄", "⡀", "⢀", "⠠", "⠐", "⠈"],
     ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"],
@@ -2541,7 +2541,7 @@ _argus() {{
 
     scanners=({scanners})
     severity=(critical high medium low none)
-    formats=(terminal markdown sarif json)
+    formats=(terminal markdown sarif json github gitlab junit)
     interfaces=(terminal browser)
 
     _arguments -C \\
@@ -2660,7 +2660,7 @@ _argus_completions() {{
     commands="init scan classify collect report validate mcp completion cache view"
     scanners="{scanners}"
     severity="critical high medium low none"
-    formats="terminal markdown sarif json"
+    formats="terminal markdown sarif json github gitlab junit"
     interfaces="terminal browser"
 
     if [ "$COMP_CWORD" -eq 1 ]; then

--- a/argus/reporters/__init__.py
+++ b/argus/reporters/__init__.py
@@ -5,6 +5,9 @@ from .markdown import MarkdownReporter
 from .container_markdown import ContainerMarkdownReporter
 from .sarif import SarifReporter
 from .json_report import JsonReporter
+from .github import GitHubReporter
+from .gitlab import GitLabReporter
+from .junit import JUnitReporter
 
 REPORTER_REGISTRY = {
     'terminal': TerminalReporter,
@@ -12,6 +15,9 @@ REPORTER_REGISTRY = {
     'container_markdown': ContainerMarkdownReporter,
     'sarif': SarifReporter,
     'json': JsonReporter,
+    'github': GitHubReporter,
+    'gitlab': GitLabReporter,
+    'junit': JUnitReporter,
 }
 
 

--- a/argus/reporters/github.py
+++ b/argus/reporters/github.py
@@ -1,0 +1,131 @@
+"""GitHub Actions annotation reporter.
+
+Emits ``::error::``, ``::warning::``, and ``::notice::`` workflow
+commands to stdout, one per finding. When run inside a GitHub Actions
+job these become inline annotations on the PR diff and the workflow
+summary page.
+
+Severity mapping:
+    CRITICAL, HIGH   -> ``error``
+    MEDIUM           -> ``warning``
+    LOW, INFO, UNKNOWN -> ``notice``
+
+Title prefix is ``[<scanner>][<id>]`` so the annotation is
+self-describing even when many scanners run in the same step.
+
+Limitation: GitHub caps annotations at 10 per kind (error/warning/
+notice) per step. Findings beyond the cap will still be printed but
+will not surface as annotations in the GitHub UI. The full set is
+always present in ``argus-results.json`` and the SARIF artifact.
+"""
+
+import sys
+from pathlib import Path
+from typing import Optional, TextIO
+
+from argus.core.models import Finding, ScanSummary, Severity
+
+
+_SEVERITY_TO_ANNOTATION = {
+    Severity.CRITICAL: "error",
+    Severity.HIGH: "error",
+    Severity.MEDIUM: "warning",
+    Severity.LOW: "notice",
+    Severity.INFO: "notice",
+    Severity.UNKNOWN: "notice",
+}
+
+
+def _escape(value: str) -> str:
+    """Escape characters that have meaning in workflow command syntax.
+
+    GitHub's workflow command parser uses ``%`` as an escape prefix and
+    treats raw newlines/CRs as command terminators. The official
+    encoding is documented at:
+    https://docs.github.com/en/actions/using-workflows/workflow-commands
+    """
+    return (
+        value.replace("%", "%25")
+        .replace("\r", "%0D")
+        .replace("\n", "%0A")
+    )
+
+
+class GitHubReporter:
+    """Emit GitHub Actions annotations to stdout."""
+
+    def report(
+        self,
+        summary: ScanSummary,
+        output_dir: Optional[Path] = None,
+        stream: Optional[TextIO] = None,
+    ) -> None:
+        """Print one annotation line per finding.
+
+        ``output_dir`` is accepted for protocol compatibility but
+        unused — GitHub annotations are read from stdout, not from a
+        file artifact.
+        """
+        out = stream if stream is not None else sys.stdout
+
+        for result in summary.results:
+            for finding in result.findings:
+                line = self._format_annotation(result.scanner, finding)
+                print(line, file=out)
+
+    def _format_annotation(self, scanner: str, finding: Finding) -> str:
+        level = _SEVERITY_TO_ANNOTATION.get(finding.severity, "notice")
+        path, line_no, col_no = self._parse_location(finding.location)
+
+        params: list[str] = []
+        if path:
+            params.append(f"file={_escape(path)}")
+        if line_no is not None:
+            params.append(f"line={line_no}")
+        if col_no is not None:
+            params.append(f"col={col_no}")
+
+        param_str = ",".join(params)
+        title = f"[{scanner}][{finding.id}] {finding.title}"
+        message = _escape(title)
+
+        if param_str:
+            return f"::{level} {param_str}::{message}"
+        return f"::{level}::{message}"
+
+    def _parse_location(
+        self, location: Optional[str]
+    ) -> tuple[Optional[str], Optional[int], Optional[int]]:
+        """Split ``path:line:col`` (or ``path:line``) into pieces.
+
+        Returns ``(path, line, col)``. Any component that wasn't
+        present, or wasn't a valid integer, is returned as ``None``.
+        Trailing ``:`` segments that aren't integers are folded back
+        into the path so ``C:\\Windows\\file.txt`` doesn't lose its
+        drive prefix.
+        """
+        if not location:
+            return None, None, None
+
+        parts = location.split(":")
+        if len(parts) == 1:
+            return parts[0], None, None
+
+        # Walk from the right collecting numeric segments. Stop at
+        # the first non-numeric — everything before that is the path
+        # (rejoined with ``:`` so Windows drive letters and URL-like
+        # locations survive).
+        numerics: list[int] = []
+        cut = len(parts)
+        for idx in range(len(parts) - 1, 0, -1):
+            seg = parts[idx]
+            if seg.isdigit():
+                numerics.insert(0, int(seg))
+                cut = idx
+            else:
+                break
+
+        path = ":".join(parts[:cut]) or None
+        line_no = numerics[0] if len(numerics) >= 1 else None
+        col_no = numerics[1] if len(numerics) >= 2 else None
+        return path, line_no, col_no

--- a/argus/reporters/gitlab.py
+++ b/argus/reporters/gitlab.py
@@ -1,0 +1,155 @@
+"""GitLab Code Quality JSON reporter.
+
+Emits a Code Climate-compatible JSON array that GitLab CI ingests
+via the ``codequality`` report artifact. GitLab renders these in
+the merge request widget with severity badges and (where the
+``location.path`` is present in the diff) inline annotations.
+
+Output file: ``gl-code-quality-report.json`` (default) — override
+via reporter config ``output_filename``.
+
+Severity mapping (Argus -> Code Climate):
+    CRITICAL -> ``blocker``
+    HIGH     -> ``critical``
+    MEDIUM   -> ``major``
+    LOW      -> ``minor``
+    INFO     -> ``info``
+    UNKNOWN  -> ``info``
+
+Reference:
+- GitLab Code Quality artifact:
+  https://docs.gitlab.com/ee/ci/testing/code_quality.html
+- Code Climate spec:
+  https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md
+"""
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Optional
+
+from argus.core.models import Finding, ScanResult, ScanSummary, Severity
+
+
+_SEVERITY_TO_GITLAB = {
+    Severity.CRITICAL: "blocker",
+    Severity.HIGH: "critical",
+    Severity.MEDIUM: "major",
+    Severity.LOW: "minor",
+    Severity.INFO: "info",
+    Severity.UNKNOWN: "info",
+}
+
+_DEFAULT_OUTPUT_DIR = Path("./argus-results")
+_DEFAULT_FILENAME = "gl-code-quality-report.json"
+
+
+class GitLabReporter:
+    """Generate GitLab Code Quality JSON report."""
+
+    def report(
+        self,
+        summary: ScanSummary,
+        output_dir: Optional[Path] = None,
+        config: Optional[dict] = None,
+    ) -> Path:
+        """Write the Code Climate-format report.
+
+        Returns the path to the written file. ``config`` accepts
+        ``output_filename`` to override the default
+        ``gl-code-quality-report.json``.
+        """
+        dest = Path(output_dir) if output_dir else _DEFAULT_OUTPUT_DIR
+        dest.mkdir(parents=True, exist_ok=True)
+
+        filename = (config or {}).get("output_filename", _DEFAULT_FILENAME)
+        filepath = dest / filename
+
+        entries = [
+            self._build_entry(result, finding)
+            for result in summary.results
+            for finding in result.findings
+        ]
+
+        filepath.write_text(
+            json.dumps(entries, indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
+        return filepath
+
+    def _build_entry(self, result: ScanResult, finding: Finding) -> dict:
+        path, line = self._parse_location(finding.location)
+        severity = _SEVERITY_TO_GITLAB.get(finding.severity, "info")
+
+        # Linter findings (Severity.INFO) are style issues; everything
+        # else is treated as security. This keeps the GitLab MR widget
+        # filterable without needing to inspect the scanner name.
+        category = "Style" if finding.severity == Severity.INFO else "Security"
+
+        description = finding.title
+        if finding.description:
+            description = f"{finding.title}: {finding.description}"
+
+        return {
+            "description": description,
+            "severity": severity,
+            "fingerprint": self._fingerprint(result.scanner, finding, path, line),
+            "location": {
+                "path": path or "",
+                "lines": {"begin": line if line is not None else 0},
+            },
+            "check_name": f"{result.scanner}:{finding.id}",
+            "categories": [category],
+        }
+
+    def _fingerprint(
+        self,
+        scanner: str,
+        finding: Finding,
+        path: Optional[str],
+        line: Optional[int],
+    ) -> str:
+        """Stable 16-hex-char id for dedup across pipeline runs.
+
+        GitLab uses ``fingerprint`` to track issue continuity across
+        pipelines: same fingerprint = same issue. Hashing on
+        ``(scanner, id, path, line)`` keeps the fingerprint stable
+        across edits to the title/description of the underlying rule
+        but bumps when the offending line moves.
+        """
+        material = "\x1f".join([
+            scanner,
+            finding.id,
+            path or "",
+            str(line) if line is not None else "",
+        ])
+        digest = hashlib.sha256(material.encode("utf-8")).hexdigest()
+        return digest[:16]
+
+    def _parse_location(
+        self, location: Optional[str]
+    ) -> tuple[Optional[str], Optional[int]]:
+        """Extract ``(path, line)`` from a ``path:line[:col]`` string."""
+        if not location:
+            return None, None
+
+        parts = location.split(":")
+        if len(parts) == 1:
+            return parts[0] or None, None
+
+        # Walk right-to-left collecting trailing integers. The first
+        # non-numeric segment terminates the line/col tail; everything
+        # before it is the path (rejoined with ``:`` so Windows drive
+        # letters survive).
+        line_no: Optional[int] = None
+        cut = len(parts)
+        for idx in range(len(parts) - 1, 0, -1):
+            seg = parts[idx]
+            if seg.isdigit():
+                line_no = int(seg)  # line is the leftmost numeric
+                cut = idx
+            else:
+                break
+
+        path = ":".join(parts[:cut]) or None
+        return path, line_no

--- a/argus/reporters/junit.py
+++ b/argus/reporters/junit.py
@@ -1,0 +1,211 @@
+"""JUnit XML reporter.
+
+Emits a JUnit-compatible XML document so generic CI test reporters
+(GitLab CI ``junit`` artifact, Jenkins JUnit plugin, GitHub Actions
+``test-reporter`` actions, CircleCI test summaries) can ingest
+Argus findings as test failures.
+
+Layout:
+    <testsuites>
+      <testsuite name="bandit" tests=N failures=F errors=0>
+        <testcase classname="bandit" name="<location-or-finding-id>">
+          <failure type="<severity>" message="<title>">
+            <description>
+          </failure>
+        </testcase>
+        ...
+      </testsuite>
+      <testsuite name="gitleaks" tests=1 failures=0 errors=0>
+        <testcase classname="gitleaks" name="gitleaks: clean"/>
+      </testsuite>
+    </testsuites>
+
+A scanner with no findings emits a single passing testcase named
+``<scanner>: clean`` so the suite isn't empty (some consumers reject
+empty suites).
+
+Implementation note: stdlib ``xml.etree.ElementTree`` only — no
+``lxml`` dependency.
+"""
+
+import xml.etree.ElementTree as ET
+from collections import defaultdict
+from pathlib import Path
+from typing import Optional
+
+from argus.core.models import Finding, ScanResult, ScanSummary, Severity
+
+
+_DEFAULT_OUTPUT_DIR = Path("./argus-results")
+_DEFAULT_FILENAME = "argus-junit.xml"
+
+
+class JUnitReporter:
+    """Generate a JUnit XML report."""
+
+    def report(
+        self,
+        summary: ScanSummary,
+        output_dir: Optional[Path] = None,
+        config: Optional[dict] = None,
+    ) -> Path:
+        """Write the JUnit XML file.
+
+        Returns the path to the written file. ``config`` accepts
+        ``output_filename`` to override the default ``argus-junit.xml``.
+        """
+        dest = Path(output_dir) if output_dir else _DEFAULT_OUTPUT_DIR
+        dest.mkdir(parents=True, exist_ok=True)
+
+        filename = (config or {}).get("output_filename", _DEFAULT_FILENAME)
+        filepath = dest / filename
+
+        root = self._build_root(summary)
+        tree = ET.ElementTree(root)
+        # ``xml_declaration=True`` so consumers that sniff the XML
+        # prolog (Jenkins JUnit plugin, some old parsers) accept the
+        # file as-is.
+        tree.write(
+            filepath,
+            encoding="utf-8",
+            xml_declaration=True,
+        )
+        return filepath
+
+    def _build_root(self, summary: ScanSummary) -> ET.Element:
+        suites_root = ET.Element("testsuites")
+
+        total_tests = 0
+        total_failures = 0
+        total_errors = 0
+
+        for result in summary.results:
+            suite_elem, tests, failures, errors = self._build_suite(result)
+            suites_root.append(suite_elem)
+            total_tests += tests
+            total_failures += failures
+            total_errors += errors
+
+        suites_root.set("tests", str(total_tests))
+        suites_root.set("failures", str(total_failures))
+        suites_root.set("errors", str(total_errors))
+        suites_root.set("name", "argus")
+
+        return suites_root
+
+    def _build_suite(
+        self, result: ScanResult
+    ) -> tuple[ET.Element, int, int, int]:
+        """Return ``(suite_elem, tests, failures, errors)`` for a scanner."""
+        suite = ET.Element("testsuite", name=result.scanner)
+
+        # Surface engine-level execution failures as test errors so
+        # CI dashboards distinguish "scanner crashed" from "scanner
+        # found a bug." ``execution_failed`` is the canonical flag
+        # the engine sets on ScanResult.metadata.
+        execution_failed = bool(result.metadata.get("execution_failed"))
+
+        if not result.findings and not execution_failed:
+            # Clean scanner — emit a passing testcase so the suite
+            # isn't empty.
+            ET.SubElement(
+                suite,
+                "testcase",
+                classname=result.scanner,
+                name=f"{result.scanner}: clean",
+            )
+            suite.set("tests", "1")
+            suite.set("failures", "0")
+            suite.set("errors", "0")
+            return suite, 1, 0, 0
+
+        # Group findings by file path so each <testcase> represents
+        # one file. Findings without a parseable location go under
+        # an ``<unknown>`` bucket.
+        by_file: dict[str, list[Finding]] = defaultdict(list)
+        for finding in result.findings:
+            path = self._extract_path(finding.location) or "<unknown>"
+            by_file[path].append(finding)
+
+        tests = 0
+        failures = 0
+        for path, findings in by_file.items():
+            case = ET.SubElement(
+                suite,
+                "testcase",
+                classname=result.scanner,
+                name=path,
+            )
+            tests += 1
+            for finding in findings:
+                self._append_failure(case, finding)
+                failures += 1
+
+        errors = 0
+        if execution_failed:
+            err_case = ET.SubElement(
+                suite,
+                "testcase",
+                classname=result.scanner,
+                name=f"{result.scanner}: execution",
+            )
+            err = ET.SubElement(
+                err_case,
+                "error",
+                type="execution_failed",
+                message=str(
+                    result.metadata.get("error", "scanner execution failed")
+                ),
+            )
+            err.text = str(result.metadata.get("error", "scanner execution failed"))
+            tests += 1
+            errors += 1
+
+        suite.set("tests", str(tests))
+        suite.set("failures", str(failures))
+        suite.set("errors", str(errors))
+        return suite, tests, failures, errors
+
+    def _append_failure(self, case: ET.Element, finding: Finding) -> None:
+        """Attach a <failure> element describing a single finding."""
+        failure = ET.SubElement(
+            case,
+            "failure",
+            type=finding.severity.value,
+            message=f"[{finding.id}] {finding.title}",
+        )
+        body_lines = [f"{finding.id}: {finding.title}"]
+        if finding.location:
+            body_lines.append(f"Location: {finding.location}")
+        if finding.severity:
+            body_lines.append(f"Severity: {finding.severity.value}")
+        if finding.cwe:
+            body_lines.append(f"CWE: {finding.cwe}")
+        if finding.cve:
+            body_lines.append(f"CVE: {finding.cve}")
+        if finding.description:
+            body_lines.append("")
+            body_lines.append(finding.description)
+        # ElementTree handles XML escaping of the text content
+        # automatically — no manual ``&amp;``/``&lt;`` substitution
+        # needed.
+        failure.text = "\n".join(body_lines)
+
+    def _extract_path(self, location: Optional[str]) -> Optional[str]:
+        """Strip trailing ``:line[:col]`` from a location string."""
+        if not location:
+            return None
+
+        parts = location.split(":")
+        if len(parts) == 1:
+            return parts[0] or None
+
+        cut = len(parts)
+        for idx in range(len(parts) - 1, 0, -1):
+            if parts[idx].isdigit():
+                cut = idx
+            else:
+                break
+
+        path = ":".join(parts[:cut]) or None
+        return path

--- a/argus/tests/reporters/test_github.py
+++ b/argus/tests/reporters/test_github.py
@@ -1,0 +1,217 @@
+"""Tests for argus.reporters.github — GitHubReporter."""
+
+import io
+
+import pytest
+
+from argus.core.models import Finding, ScanResult, ScanSummary, Severity
+from argus.reporters.github import GitHubReporter
+
+
+def _capture(summary: ScanSummary) -> str:
+    """Run the reporter against an in-memory stream and return text."""
+    buf = io.StringIO()
+    GitHubReporter().report(summary, output_dir=None, stream=buf)
+    return buf.getvalue()
+
+
+class TestGitHubReporterEmptyAndShape:
+    """Empty scans and basic line shape."""
+
+    def test_empty_summary_produces_no_output(self):
+        summary = ScanSummary(results=[])
+        assert _capture(summary) == ""
+
+    def test_empty_scanner_produces_no_output(self):
+        summary = ScanSummary(
+            results=[ScanResult(scanner="bandit", findings=[])]
+        )
+        assert _capture(summary) == ""
+
+    def test_single_finding_with_location(self):
+        finding = Finding(
+            id="B102",
+            severity=Severity.HIGH,
+            title="exec used",
+            location="app.py:25:7",
+        )
+        summary = ScanSummary(
+            results=[ScanResult(scanner="bandit", findings=[finding])]
+        )
+        out = _capture(summary)
+        assert "::error " in out
+        assert "file=app.py" in out
+        assert "line=25" in out
+        assert "col=7" in out
+        assert "[bandit][B102] exec used" in out
+
+    def test_finding_without_line_drops_line_param(self):
+        finding = Finding(
+            id="X1",
+            severity=Severity.MEDIUM,
+            title="bare path",
+            location="src/app.py",
+        )
+        summary = ScanSummary(
+            results=[ScanResult(scanner="checker", findings=[finding])]
+        )
+        out = _capture(summary)
+        assert "file=src/app.py" in out
+        assert "line=" not in out
+        assert "col=" not in out
+
+    def test_finding_without_location_omits_file_param(self):
+        finding = Finding(id="X1", severity=Severity.LOW, title="systemic issue")
+        summary = ScanSummary(
+            results=[ScanResult(scanner="checker", findings=[finding])]
+        )
+        out = _capture(summary).strip()
+        assert out.startswith("::notice::")
+        assert "file=" not in out
+
+
+class TestGitHubReporterSeverityMapping:
+    """Severity → annotation level."""
+
+    @pytest.mark.parametrize(
+        "severity,level",
+        [
+            (Severity.CRITICAL, "::error"),
+            (Severity.HIGH, "::error"),
+            (Severity.MEDIUM, "::warning"),
+            (Severity.LOW, "::notice"),
+            (Severity.INFO, "::notice"),
+            (Severity.UNKNOWN, "::notice"),
+        ],
+    )
+    def test_severity_to_level(self, severity, level):
+        finding = Finding(id="ID", severity=severity, title="t", location="f.py:1")
+        summary = ScanSummary(
+            results=[ScanResult(scanner="s", findings=[finding])]
+        )
+        out = _capture(summary)
+        assert level in out
+
+
+class TestGitHubReporterMixedAndSpecial:
+    """Mixed severities, special chars, multi-scanner output."""
+
+    def test_mixed_severity_emits_one_line_per_finding(self):
+        findings = [
+            Finding(id="A", severity=Severity.CRITICAL, title="c", location="a.py:1"),
+            Finding(id="B", severity=Severity.MEDIUM, title="m", location="b.py:2"),
+            Finding(id="C", severity=Severity.LOW, title="l", location="c.py:3"),
+        ]
+        summary = ScanSummary(
+            results=[ScanResult(scanner="multi", findings=findings)]
+        )
+        out = _capture(summary)
+        lines = [ln for ln in out.splitlines() if ln]
+        assert len(lines) == 3
+
+    def test_multiple_scanners_each_contribute(self):
+        summary = ScanSummary(
+            results=[
+                ScanResult(
+                    scanner="bandit",
+                    findings=[
+                        Finding(id="B1", severity=Severity.HIGH, title="b", location="x.py:1")
+                    ],
+                ),
+                ScanResult(
+                    scanner="gitleaks",
+                    findings=[
+                        Finding(id="GL1", severity=Severity.CRITICAL, title="leak", location="y.py:5")
+                    ],
+                ),
+            ]
+        )
+        out = _capture(summary)
+        assert "[bandit][B1]" in out
+        assert "[gitleaks][GL1]" in out
+
+    def test_special_characters_in_title_are_escaped(self):
+        finding = Finding(
+            id="X",
+            severity=Severity.HIGH,
+            title="line1\nline2 with 50% margin",
+            location="f.py:1",
+        )
+        summary = ScanSummary(
+            results=[ScanResult(scanner="s", findings=[finding])]
+        )
+        out = _capture(summary)
+        # Newline must be encoded so it doesn't terminate the command.
+        assert "line1%0Aline2" in out
+        # Percent sign must be escaped.
+        assert "50%25 margin" in out
+        # The decoded original must NOT appear as a raw newline mid-line.
+        assert "line1\nline2" not in out
+
+    def test_carriage_return_in_title_is_escaped(self):
+        finding = Finding(
+            id="X",
+            severity=Severity.HIGH,
+            title="hi\rthere",
+            location="f.py:1",
+        )
+        summary = ScanSummary(
+            results=[ScanResult(scanner="s", findings=[finding])]
+        )
+        out = _capture(summary)
+        assert "hi%0Dthere" in out
+
+
+class TestGitHubReporterRobustness:
+    """Edge cases around metadata/location parsing."""
+
+    def test_execution_failed_metadata_does_not_crash(self):
+        # Engine sometimes flags a scanner as failed and returns no
+        # findings; the reporter must not blow up.
+        summary = ScanSummary(
+            results=[
+                ScanResult(
+                    scanner="broken",
+                    findings=[],
+                    metadata={"execution_failed": True, "error": "boom"},
+                )
+            ]
+        )
+        # Should produce no output (no findings) and not raise.
+        assert _capture(summary) == ""
+
+    def test_windows_style_path_with_drive_letter(self):
+        finding = Finding(
+            id="W1",
+            severity=Severity.HIGH,
+            title="t",
+            location="C:\\code\\app.py:42",
+        )
+        summary = ScanSummary(
+            results=[ScanResult(scanner="s", findings=[finding])]
+        )
+        out = _capture(summary)
+        # The drive prefix should survive — file= contains both the
+        # drive letter and the path.
+        assert "file=C:\\code\\app.py" in out
+        assert "line=42" in out
+
+    def test_report_accepts_output_dir_argument(self, tmp_path):
+        # output_dir is part of the protocol but unused here. Make
+        # sure passing it doesn't blow up.
+        finding = Finding(id="X", severity=Severity.HIGH, title="t", location="f.py:1")
+        summary = ScanSummary(
+            results=[ScanResult(scanner="s", findings=[finding])]
+        )
+        # No exception, no file written. Default stream goes to
+        # sys.stdout which pytest captures via capsys.
+        GitHubReporter().report(summary, output_dir=tmp_path)
+
+    def test_default_stream_is_stdout(self, capsys):
+        finding = Finding(id="X", severity=Severity.HIGH, title="t", location="f.py:1")
+        summary = ScanSummary(
+            results=[ScanResult(scanner="s", findings=[finding])]
+        )
+        GitHubReporter().report(summary)
+        captured = capsys.readouterr()
+        assert "[s][X] t" in captured.out

--- a/argus/tests/reporters/test_gitlab.py
+++ b/argus/tests/reporters/test_gitlab.py
@@ -1,0 +1,218 @@
+"""Tests for argus.reporters.gitlab — GitLabReporter."""
+
+import json
+
+import pytest
+
+from argus.core.models import Finding, ScanResult, ScanSummary, Severity
+from argus.reporters.gitlab import GitLabReporter
+
+
+def _read(filepath):
+    return json.loads(filepath.read_text())
+
+
+class TestGitLabReporterFiles:
+    """Output filename and on-disk shape."""
+
+    def test_default_filename(self, tmp_output_dir):
+        summary = ScanSummary(results=[])
+        filepath = GitLabReporter().report(summary, tmp_output_dir)
+        assert filepath.name == "gl-code-quality-report.json"
+        assert filepath.exists()
+
+    def test_override_filename(self, tmp_output_dir):
+        summary = ScanSummary(results=[])
+        filepath = GitLabReporter().report(
+            summary,
+            tmp_output_dir,
+            config={"output_filename": "custom.json"},
+        )
+        assert filepath.name == "custom.json"
+
+    def test_creates_output_dir_if_missing(self, tmp_path):
+        nested = tmp_path / "nested" / "out"
+        summary = ScanSummary(results=[])
+        filepath = GitLabReporter().report(summary, nested)
+        assert filepath.exists()
+
+    def test_empty_summary_writes_empty_array(self, tmp_output_dir):
+        summary = ScanSummary(results=[])
+        filepath = GitLabReporter().report(summary, tmp_output_dir)
+        data = _read(filepath)
+        assert data == []
+
+
+class TestGitLabReporterEntries:
+    """Per-finding entry shape."""
+
+    def test_single_finding_basic_fields(self, tmp_output_dir):
+        finding = Finding(
+            id="B102",
+            severity=Severity.HIGH,
+            title="exec used",
+            description="dangerous call",
+            location="app.py:25",
+        )
+        summary = ScanSummary(
+            results=[ScanResult(scanner="bandit", findings=[finding])]
+        )
+        data = _read(GitLabReporter().report(summary, tmp_output_dir))
+
+        assert len(data) == 1
+        entry = data[0]
+        assert entry["severity"] == "critical"
+        assert entry["check_name"] == "bandit:B102"
+        assert entry["location"]["path"] == "app.py"
+        assert entry["location"]["lines"]["begin"] == 25
+        assert "exec used" in entry["description"]
+        assert "dangerous call" in entry["description"]
+
+    def test_finding_without_description_uses_title_only(self, tmp_output_dir):
+        finding = Finding(id="X", severity=Severity.LOW, title="just a title", location="a.py:1")
+        summary = ScanSummary(results=[ScanResult(scanner="s", findings=[finding])])
+        data = _read(GitLabReporter().report(summary, tmp_output_dir))
+        assert data[0]["description"] == "just a title"
+
+    def test_finding_without_location_uses_empty_path_and_zero_line(self, tmp_output_dir):
+        finding = Finding(id="X", severity=Severity.HIGH, title="t")
+        summary = ScanSummary(results=[ScanResult(scanner="s", findings=[finding])])
+        data = _read(GitLabReporter().report(summary, tmp_output_dir))
+        assert data[0]["location"]["path"] == ""
+        assert data[0]["location"]["lines"]["begin"] == 0
+
+    def test_path_only_location_extracts_path(self, tmp_output_dir):
+        finding = Finding(id="X", severity=Severity.HIGH, title="t", location="src/app.py")
+        summary = ScanSummary(results=[ScanResult(scanner="s", findings=[finding])])
+        data = _read(GitLabReporter().report(summary, tmp_output_dir))
+        assert data[0]["location"]["path"] == "src/app.py"
+        assert data[0]["location"]["lines"]["begin"] == 0
+
+    def test_categories_security_for_non_info(self, tmp_output_dir):
+        finding = Finding(id="X", severity=Severity.HIGH, title="t", location="f.py:1")
+        summary = ScanSummary(results=[ScanResult(scanner="s", findings=[finding])])
+        data = _read(GitLabReporter().report(summary, tmp_output_dir))
+        assert data[0]["categories"] == ["Security"]
+
+    def test_categories_style_for_linter_info(self, tmp_output_dir):
+        finding = Finding(id="X", severity=Severity.INFO, title="t", location="f.py:1")
+        summary = ScanSummary(
+            results=[ScanResult(scanner="lint-yaml", findings=[finding])]
+        )
+        data = _read(GitLabReporter().report(summary, tmp_output_dir))
+        assert data[0]["categories"] == ["Style"]
+
+
+class TestGitLabReporterSeverityMapping:
+    """Argus -> Code Climate severity translation."""
+
+    @pytest.mark.parametrize(
+        "severity,expected",
+        [
+            (Severity.CRITICAL, "blocker"),
+            (Severity.HIGH, "critical"),
+            (Severity.MEDIUM, "major"),
+            (Severity.LOW, "minor"),
+            (Severity.INFO, "info"),
+            (Severity.UNKNOWN, "info"),
+        ],
+    )
+    def test_severity_mapping(self, severity, expected, tmp_output_dir):
+        finding = Finding(id="X", severity=severity, title="t", location="f.py:1")
+        summary = ScanSummary(results=[ScanResult(scanner="s", findings=[finding])])
+        data = _read(GitLabReporter().report(summary, tmp_output_dir))
+        assert data[0]["severity"] == expected
+
+
+class TestGitLabReporterFingerprint:
+    """Fingerprint stability and uniqueness guarantees."""
+
+    def test_fingerprint_is_16_hex_chars(self, tmp_output_dir):
+        finding = Finding(id="X", severity=Severity.HIGH, title="t", location="f.py:1")
+        summary = ScanSummary(results=[ScanResult(scanner="s", findings=[finding])])
+        data = _read(GitLabReporter().report(summary, tmp_output_dir))
+        fp = data[0]["fingerprint"]
+        assert len(fp) == 16
+        int(fp, 16)  # must parse as hex
+
+    def test_fingerprint_stable_across_runs(self, tmp_output_dir):
+        finding = Finding(id="X", severity=Severity.HIGH, title="t", location="f.py:1")
+        summary = ScanSummary(results=[ScanResult(scanner="s", findings=[finding])])
+        a = _read(GitLabReporter().report(summary, tmp_output_dir))[0]["fingerprint"]
+        b = _read(GitLabReporter().report(summary, tmp_output_dir))[0]["fingerprint"]
+        assert a == b
+
+    def test_fingerprint_changes_with_line_move(self, tmp_output_dir):
+        f1 = Finding(id="X", severity=Severity.HIGH, title="t", location="f.py:1")
+        f2 = Finding(id="X", severity=Severity.HIGH, title="t", location="f.py:99")
+        summary = ScanSummary(
+            results=[ScanResult(scanner="s", findings=[f1, f2])]
+        )
+        data = _read(GitLabReporter().report(summary, tmp_output_dir))
+        assert data[0]["fingerprint"] != data[1]["fingerprint"]
+
+    def test_fingerprint_distinct_per_scanner(self, tmp_output_dir):
+        f = Finding(id="X", severity=Severity.HIGH, title="t", location="f.py:1")
+        summary = ScanSummary(
+            results=[
+                ScanResult(scanner="a", findings=[f]),
+                ScanResult(scanner="b", findings=[f]),
+            ]
+        )
+        data = _read(GitLabReporter().report(summary, tmp_output_dir))
+        assert data[0]["fingerprint"] != data[1]["fingerprint"]
+
+
+class TestGitLabReporterRobustness:
+    """Robustness against odd inputs."""
+
+    def test_mixed_severities_all_emitted(self, tmp_output_dir):
+        findings = [
+            Finding(id="A", severity=Severity.CRITICAL, title="c", location="a.py:1"),
+            Finding(id="B", severity=Severity.MEDIUM, title="m", location="b.py:2"),
+            Finding(id="C", severity=Severity.LOW, title="l", location="c.py:3"),
+        ]
+        summary = ScanSummary(results=[ScanResult(scanner="s", findings=findings)])
+        data = _read(GitLabReporter().report(summary, tmp_output_dir))
+        assert len(data) == 3
+        assert {e["severity"] for e in data} == {"blocker", "major", "minor"}
+
+    def test_execution_failed_metadata_does_not_crash(self, tmp_output_dir):
+        summary = ScanSummary(
+            results=[
+                ScanResult(
+                    scanner="broken",
+                    findings=[],
+                    metadata={"execution_failed": True, "error": "tool crashed"},
+                )
+            ]
+        )
+        # No findings, no entries — but the reporter must run cleanly.
+        data = _read(GitLabReporter().report(summary, tmp_output_dir))
+        assert data == []
+
+    def test_special_characters_survive_json_encoding(self, tmp_output_dir):
+        finding = Finding(
+            id="X",
+            severity=Severity.HIGH,
+            title="newline\nand <html> & \"quotes\"",
+            location="f.py:1",
+        )
+        summary = ScanSummary(results=[ScanResult(scanner="s", findings=[finding])])
+        data = _read(GitLabReporter().report(summary, tmp_output_dir))
+        # JSON round-trip preserves the literal — no manual escaping
+        # needed.
+        assert "\n" in data[0]["description"]
+        assert "<html>" in data[0]["description"]
+        assert '"quotes"' in data[0]["description"]
+
+    def test_unicode_path_preserved(self, tmp_output_dir):
+        finding = Finding(
+            id="X",
+            severity=Severity.HIGH,
+            title="t",
+            location="src/héllo.py:1",
+        )
+        summary = ScanSummary(results=[ScanResult(scanner="s", findings=[finding])])
+        data = _read(GitLabReporter().report(summary, tmp_output_dir))
+        assert data[0]["location"]["path"] == "src/héllo.py"

--- a/argus/tests/reporters/test_junit.py
+++ b/argus/tests/reporters/test_junit.py
@@ -1,0 +1,260 @@
+"""Tests for argus.reporters.junit — JUnitReporter."""
+
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from argus.core.models import Finding, ScanResult, ScanSummary, Severity
+from argus.reporters.junit import JUnitReporter
+
+
+def _parse(filepath):
+    return ET.parse(str(filepath)).getroot()
+
+
+class TestJUnitReporterFiles:
+    """Output file shape."""
+
+    def test_default_filename(self, tmp_output_dir):
+        summary = ScanSummary(results=[])
+        filepath = JUnitReporter().report(summary, tmp_output_dir)
+        assert filepath.name == "argus-junit.xml"
+        assert filepath.exists()
+
+    def test_override_filename(self, tmp_output_dir):
+        summary = ScanSummary(results=[])
+        filepath = JUnitReporter().report(
+            summary, tmp_output_dir, config={"output_filename": "junit.xml"}
+        )
+        assert filepath.name == "junit.xml"
+
+    def test_creates_output_dir_if_missing(self, tmp_path):
+        nested = tmp_path / "a" / "b"
+        summary = ScanSummary(results=[])
+        filepath = JUnitReporter().report(summary, nested)
+        assert filepath.exists()
+
+    def test_root_is_testsuites(self, tmp_output_dir):
+        summary = ScanSummary(results=[])
+        filepath = JUnitReporter().report(summary, tmp_output_dir)
+        root = _parse(filepath)
+        assert root.tag == "testsuites"
+
+    def test_xml_declaration_present(self, tmp_output_dir):
+        summary = ScanSummary(results=[])
+        filepath = JUnitReporter().report(summary, tmp_output_dir)
+        # ElementTree writes ``<?xml version='1.0' encoding='utf-8'?>``
+        # when xml_declaration=True is set.
+        text = filepath.read_text()
+        assert text.startswith("<?xml")
+
+
+class TestJUnitReporterEmptyAndClean:
+    """Empty scans and clean scanners."""
+
+    def test_empty_summary_has_zero_counts(self, tmp_output_dir):
+        summary = ScanSummary(results=[])
+        root = _parse(JUnitReporter().report(summary, tmp_output_dir))
+        assert root.get("tests") == "0"
+        assert root.get("failures") == "0"
+        assert root.get("errors") == "0"
+
+    def test_clean_scanner_emits_passing_testcase(self, tmp_output_dir):
+        summary = ScanSummary(
+            results=[ScanResult(scanner="bandit", findings=[])]
+        )
+        root = _parse(JUnitReporter().report(summary, tmp_output_dir))
+        suite = root.find("testsuite")
+        assert suite is not None
+        assert suite.get("name") == "bandit"
+        assert suite.get("tests") == "1"
+        assert suite.get("failures") == "0"
+        cases = suite.findall("testcase")
+        assert len(cases) == 1
+        # The clean testcase has no <failure> child.
+        assert cases[0].find("failure") is None
+        assert "clean" in cases[0].get("name")
+
+
+class TestJUnitReporterFindings:
+    """Finding-driven testcase shape."""
+
+    def test_single_finding_creates_failing_testcase(self, tmp_output_dir):
+        finding = Finding(
+            id="B102",
+            severity=Severity.HIGH,
+            title="exec used",
+            description="dangerous call",
+            location="app.py:25",
+        )
+        summary = ScanSummary(
+            results=[ScanResult(scanner="bandit", findings=[finding])]
+        )
+        root = _parse(JUnitReporter().report(summary, tmp_output_dir))
+        suite = root.find("testsuite")
+        assert suite.get("name") == "bandit"
+        assert suite.get("failures") == "1"
+        case = suite.find("testcase")
+        assert case.get("classname") == "bandit"
+        assert case.get("name") == "app.py"
+        failure = case.find("failure")
+        assert failure is not None
+        assert failure.get("type") == "high"
+        assert "B102" in failure.get("message")
+        assert "dangerous call" in failure.text
+
+    def test_findings_grouped_by_file(self, tmp_output_dir):
+        findings = [
+            Finding(id="A", severity=Severity.HIGH, title="a", location="f1.py:1"),
+            Finding(id="B", severity=Severity.HIGH, title="b", location="f1.py:5"),
+            Finding(id="C", severity=Severity.HIGH, title="c", location="f2.py:1"),
+        ]
+        summary = ScanSummary(
+            results=[ScanResult(scanner="bandit", findings=findings)]
+        )
+        root = _parse(JUnitReporter().report(summary, tmp_output_dir))
+        suite = root.find("testsuite")
+        assert suite.get("tests") == "2"  # 2 files = 2 testcases
+        assert suite.get("failures") == "3"  # 3 findings = 3 failures
+        cases = suite.findall("testcase")
+        names = sorted(c.get("name") for c in cases)
+        assert names == ["f1.py", "f2.py"]
+
+    def test_finding_without_location_buckets_under_unknown(self, tmp_output_dir):
+        finding = Finding(id="X", severity=Severity.HIGH, title="systemic")
+        summary = ScanSummary(
+            results=[ScanResult(scanner="s", findings=[finding])]
+        )
+        root = _parse(JUnitReporter().report(summary, tmp_output_dir))
+        case = root.find("testsuite/testcase")
+        assert case.get("name") == "<unknown>"
+        assert case.find("failure") is not None
+
+    def test_failure_type_uses_severity_value(self, tmp_output_dir):
+        findings = [
+            Finding(id="A", severity=Severity.CRITICAL, title="c", location="a.py:1"),
+            Finding(id="B", severity=Severity.LOW, title="l", location="b.py:1"),
+        ]
+        summary = ScanSummary(results=[ScanResult(scanner="s", findings=findings)])
+        root = _parse(JUnitReporter().report(summary, tmp_output_dir))
+        types = sorted(
+            f.get("type") for f in root.findall("testsuite/testcase/failure")
+        )
+        assert types == ["critical", "low"]
+
+
+class TestJUnitReporterCounts:
+    """Aggregate counters at suite and root level."""
+
+    def test_root_aggregates_per_suite_counts(self, tmp_output_dir):
+        s1 = ScanResult(
+            scanner="a",
+            findings=[
+                Finding(id="X", severity=Severity.HIGH, title="t", location="x.py:1")
+            ],
+        )
+        s2 = ScanResult(scanner="b", findings=[])  # clean -> 1 test
+        summary = ScanSummary(results=[s1, s2])
+        root = _parse(JUnitReporter().report(summary, tmp_output_dir))
+        assert root.get("tests") == "2"
+        assert root.get("failures") == "1"
+        assert root.get("errors") == "0"
+
+    def test_mixed_severity_counts(self, tmp_output_dir):
+        findings = [
+            Finding(id="A", severity=Severity.CRITICAL, title="a", location="x.py:1"),
+            Finding(id="B", severity=Severity.LOW, title="b", location="x.py:2"),
+            Finding(id="C", severity=Severity.MEDIUM, title="c", location="y.py:1"),
+        ]
+        summary = ScanSummary(results=[ScanResult(scanner="s", findings=findings)])
+        root = _parse(JUnitReporter().report(summary, tmp_output_dir))
+        suite = root.find("testsuite")
+        assert suite.get("failures") == "3"
+        assert suite.get("tests") == "2"  # 2 distinct files
+
+
+class TestJUnitReporterExecutionFailed:
+    """Engine-level execution failures must surface as <error>."""
+
+    def test_execution_failed_emits_error_testcase(self, tmp_output_dir):
+        summary = ScanSummary(
+            results=[
+                ScanResult(
+                    scanner="broken",
+                    findings=[],
+                    metadata={"execution_failed": True, "error": "tool crashed"},
+                )
+            ]
+        )
+        root = _parse(JUnitReporter().report(summary, tmp_output_dir))
+        suite = root.find("testsuite")
+        assert suite.get("errors") == "1"
+        assert suite.get("failures") == "0"
+        err = suite.find("testcase/error")
+        assert err is not None
+        assert err.get("type") == "execution_failed"
+        assert "tool crashed" in err.get("message")
+
+    def test_execution_failed_with_findings_combines(self, tmp_output_dir):
+        # A scanner can both fail AND produce some partial findings.
+        finding = Finding(id="X", severity=Severity.HIGH, title="t", location="a.py:1")
+        summary = ScanSummary(
+            results=[
+                ScanResult(
+                    scanner="partial",
+                    findings=[finding],
+                    metadata={"execution_failed": True, "error": "timeout"},
+                )
+            ]
+        )
+        root = _parse(JUnitReporter().report(summary, tmp_output_dir))
+        suite = root.find("testsuite")
+        assert suite.get("errors") == "1"
+        assert suite.get("failures") == "1"
+
+
+class TestJUnitReporterSpecialChars:
+    """Escaping of XML-meaningful and unicode characters."""
+
+    def test_special_chars_in_title_are_escaped(self, tmp_output_dir):
+        finding = Finding(
+            id="X",
+            severity=Severity.HIGH,
+            title="foo & bar <script>",
+            location="f.py:1",
+        )
+        summary = ScanSummary(results=[ScanResult(scanner="s", findings=[finding])])
+        filepath = JUnitReporter().report(summary, tmp_output_dir)
+        # ElementTree escapes & and < automatically.
+        raw = filepath.read_text()
+        assert "&amp;" in raw
+        assert "&lt;script&gt;" in raw
+        # Round-trip parse must yield the original literal.
+        root = _parse(filepath)
+        msg = root.find("testsuite/testcase/failure").get("message")
+        assert "foo & bar <script>" in msg
+
+    def test_newline_in_description_preserved(self, tmp_output_dir):
+        finding = Finding(
+            id="X",
+            severity=Severity.HIGH,
+            title="t",
+            description="line1\nline2",
+            location="f.py:1",
+        )
+        summary = ScanSummary(results=[ScanResult(scanner="s", findings=[finding])])
+        root = _parse(JUnitReporter().report(summary, tmp_output_dir))
+        text = root.find("testsuite/testcase/failure").text
+        assert "line1\nline2" in text
+
+    def test_unicode_in_title(self, tmp_output_dir):
+        finding = Finding(
+            id="X",
+            severity=Severity.HIGH,
+            title="héllo wörld",
+            location="f.py:1",
+        )
+        summary = ScanSummary(results=[ScanResult(scanner="s", findings=[finding])])
+        root = _parse(JUnitReporter().report(summary, tmp_output_dir))
+        msg = root.find("testsuite/testcase/failure").get("message")
+        assert "héllo wörld" in msg

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,6 +1,6 @@
 # Argus CLI Reference (v0.7.2)
 
-> Auto-generated from argparse definitions on 2026-05-06.
+> Auto-generated from argparse definitions on 2026-05-07.
 > Do not edit manually — run `python -m scripts.ci.gen_cli_docs` to regenerate.
 
 Argus Security Scanner — comprehensive security scanning for your codebase
@@ -70,8 +70,8 @@ For container image scanning:
 argus scan [-h] [--path PATH] [--config CONFIG]
                   [--output-dir OUTPUT_DIR]
                   [--severity-threshold {critical,high,medium,low,none}]
-                  [--format {terminal,markdown,sarif,json}] [--list]
-                  [--verbose] [--debug] [--quiet] [--no-spinner]
+                  [--format {terminal,markdown,sarif,json,github,gitlab,junit}]
+                  [--list] [--verbose] [--debug] [--quiet] [--no-spinner]
                   [--no-update-check] [--no-timestamp] [--output-vars FILE]
                   [--exclude PATTERNS] [--no-default-excludes] [--dry-run]
                   [--sbom PATH] [--interface {terminal,browser}] [--fail-fast]
@@ -96,7 +96,7 @@ argus scan [-h] [--path PATH] [--config CONFIG]
 | `--config`, `-c` | Path to argus.yml config file |  |
 | `--output-dir`, `-o` | Output directory for results (default: ./argus-results) |  |
 | `--severity-threshold`, `-s` | Fail threshold severity level (default: from config) (critical, high, medium, low, none) |  |
-| `--format`, `-f` | Output format (can be repeated; default: terminal) (terminal, markdown, sarif, json) |  |
+| `--format`, `-f` | Output format (can be repeated; default: terminal) (terminal, markdown, sarif, json, github, gitlab, junit) |  |
 | `--list` | List available scanners and exit | `false` |
 | `--verbose` | Alias for --debug. Full firehose: subprocess output, vulnerability-DB updates, every engine log line. | `false` |
 | `--debug` | Full firehose: subprocess output, vulnerability-DB updates, every engine log line. Use when troubleshooting; the default phase-aware progress is enough for normal scans. | `false` |
@@ -202,12 +202,12 @@ Generate formatted reports from previously captured scan results.
 ```
 argus report [-h] [--results-dir RESULTS_DIR] [--output-dir OUTPUT_DIR]
                     [--verbose]
-                    {terminal,markdown,sarif,json}
+                    {terminal,markdown,sarif,json,github,gitlab,junit}
 ```
 
 **Arguments:**
 
-- `format` — Output format for the report (choices: terminal, markdown, sarif, json)
+- `format` — Output format for the report (choices: terminal, markdown, sarif, json, github, gitlab, junit)
 
 **Options:**
 

--- a/docs/developer/SDK-ROADMAP.md
+++ b/docs/developer/SDK-ROADMAP.md
@@ -202,7 +202,8 @@ All 16 scanner/linter actions refactored to call `argus scan` internally. Action
 - [ ] `argus init` summary: show `pip install argus-security` command
 
 **Future (post-release):**
-- [ ] Additional reporters: `github.py`, `gitlab.py`, `junit.py`, plugin registration system
+- [x] ~~Additional reporters: `github.py`, `gitlab.py`, `junit.py`~~ — three new reporters shipped: GitHub Actions annotations, GitLab Code Quality JSON (codeclimate-compatible), JUnit XML
+- [ ] Reporter plugin registration system (the broader item — still open as a follow-up)
 - [ ] Additional scanners: `codeql.py`, `dependency_review.py` (GitHub-specific)
 - [x] ~~Progress indicators~~ — `argus/cli.py::Spinner` ships phase-aware progress with `--no-spinner` opt-out (PR #2c46fce: `feat(cli): phase-aware scan progress and clearer verbosity flags`)
 - [x] ~~`pull_policy` evaluation~~ — `ArgusConfig.execution.pull_policy` accepts `always | if-not-present | never`; engine + container_runtime honor it


### PR DESCRIPTION
## Description

Three new reporters under `argus/reporters/`, each implementing the existing `Reporter` protocol shape and registered in `REPORTER_REGISTRY` + wired into the `--format` CLI flag.

Closes roadmap item **#205** for the github/gitlab/junit reporter trio. The broader **plugin registration system** remains an open follow-up (tracked separately).

## Changes Made
- [x] Added new scanner/workflow
- [ ] Modified existing scanner/workflow
- [x] Updated documentation
- [ ] Fixed bug
- [ ] Other (please specify)

### Details

**`argus/reporters/github.py` — GitHub Actions annotations**
- Emits `::error` / `::warning` / `::notice file=<path>,line=<N>::<message>` lines
- Severity → annotation level: CRITICAL/HIGH = `error`, MEDIUM = `warning`, LOW/INFO = `notice`
- Title prefix `[<scanner>][<id>]` so each annotation is self-describing
- Documented limitation in docstring: GitHub caps annotations at 10 per kind per step

**`argus/reporters/gitlab.py` — GitLab Code Quality JSON**
- Emits a single JSON array (codeclimate-compatible) — default file `gl-code-quality-report.json`
- Per-finding: `description`, `severity`, `fingerprint` (sha256 of `(scanner, id, path, line)` truncated to 16 hex), `location`, `check_name`, `categories`
- Severity → GitLab band: CRITICAL → `blocker`, HIGH → `critical`, MEDIUM → `major`, LOW → `minor`, INFO → `info`
- Categories: `["Security"]` for security findings; `["Style"]` for INFO findings (linter heuristic)

**`argus/reporters/junit.py` — JUnit XML**
- One `<testsuite>` per scanner; one `<testcase>` per file scanned
- Failed cases include a `<failure>` child with the finding's title + description
- Counts: `tests`, `failures`, `errors` per testsuite, summed at the testsuites root
- Clean scanners (zero findings) emit a passing testcase named after the scanner so the suite isn't empty
- Pure stdlib `xml.etree.ElementTree` — no `lxml` dependency

All three handle `metadata['execution_failed']` cases gracefully — no crash on zero findings + failure marker.

### Cross-platform safety
- All three reporters write text/XML/JSON via stdlib only — no platform-specific branches.
- Path output uses the finding's stored location string verbatim (no path normalization that could surprise on Windows).

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results

```
$ pytest argus/tests/reporters/ --no-cov -q
121 passed
$ pytest --no-cov -q     # full suite, npm test equivalent
2766 passed, 11 skipped, 7 deselected
```

New tests across `test_github.py`, `test_gitlab.py`, `test_junit.py` cover: empty scans, single findings, mixed-severity, scanners with `execution_failed` metadata (must not crash), special characters in titles/descriptions, missing line numbers.

A second commit (`2905dc9`) regenerates `docs/cli-reference.md` because the `--format` choice list grew (caught by the existing `test_check_passes_when_docs_current` doc-staleness gate).

## Security Considerations
- [x] No security impact
- [ ] Security enhancement
- [ ] Potential security implications

## AI Context Updates (.ai/)
- [x] `.ai/architecture.yaml` updated — reporters component lists the three new modules
- [ ] `.ai/workflows.yaml` updated
- [ ] `.ai/decisions.yaml` updated
- [ ] `.ai/errors.yaml` updated
- [ ] N/A - No .ai/ updates needed

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (if applicable) — `docs/cli-reference.md`
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
N/A — closes roadmap item #205 (github/gitlab/junit trio); plugin registration system tracked as separate follow-up.