### PR TITLE
feat(view-terminal): multi-select for batch export and clipboard

### DIFF
--- a/argus/tests/viewers/terminal/test_multi_select.py
+++ b/argus/tests/viewers/terminal/test_multi_select.py
@@ -1,0 +1,588 @@
+"""Unit tests for multi-select in the terminal viewer.
+
+Coverage targets:
+  - The clipboard helper (``argus.viewers.terminal.clipboard``) — all
+    formatting + strategy chains. UI-free, easy to test.
+  - The selection-aware export helpers — verified by exercising
+    ``BrowseApp._export_in_format`` indirectly via a stubbed-textual load
+    of ``app.py`` (same fixture pattern the existing test files use).
+  - Filter survives selection — a row that gets filtered out, then
+    back in, retains its selection mark.
+
+Textual ``Pilot``-driven integration testing (real keystroke replay)
+is out of scope here: it requires the [terminal] extra to be installed
+in CI and adds significant test runtime. The selection logic itself
+is sliced thin enough that the unit tests cover the keybinding
+semantics one helper at a time.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from argus.core.models import Finding, Severity
+from argus.viewers.terminal.clipboard import (
+    copy_to_clipboard,
+    format_findings_for_clipboard,
+)
+
+
+_APP_PATH = Path(__file__).resolve().parents[3] / "viewers" / "terminal" / "app.py"
+
+
+# ---------------------------------------------------------------------------
+# Stubbed-textual loader — same pattern as test_view_state / test_export.
+# ---------------------------------------------------------------------------
+
+def _load_app_module():
+    """Load ``app.py`` with textual stubbed.
+
+    The DataTable stub records ``add_row`` calls so tests can inspect
+    what the BrowseApp *would have rendered*. This is the closest we
+    can get to a Textual integration test without the framework
+    installed.
+    """
+
+    class _StubColumn:
+        def __init__(self):
+            self.label = ""
+
+    class _StubTable:
+        def __init__(self):
+            self.rows: list[tuple] = []
+            self.columns: dict[str, _StubColumn] = {}
+            self.cursor_coordinate = (0, 0)
+            self._col_keys: list[str] = []
+
+        def add_columns(self, *labels):
+            keys = [f"col-{i}" for i in range(len(labels))]
+            for k, label in zip(keys, labels):
+                col = _StubColumn()
+                col.label = label
+                self.columns[k] = col
+            self._col_keys = keys
+            return keys
+
+        def clear(self):
+            self.rows.clear()
+
+        def add_row(self, *cells):
+            self.rows.append(cells)
+
+        def focus(self):
+            pass
+
+        def action_cursor_down(self):
+            r, c = self.cursor_coordinate
+            self.cursor_coordinate = (r + 1, c)
+
+        def action_cursor_up(self):
+            r, c = self.cursor_coordinate
+            self.cursor_coordinate = (max(0, r - 1), c)
+
+    class _Permissive:
+        COMMANDS = set()
+
+        def __init__(self, *args, **kwargs): ...
+        def __call__(self, *args, **kwargs): return self
+        def __class_getitem__(cls, item): return cls
+
+    for mod_name in (
+        "textual", "textual.app", "textual.binding", "textual.command",
+        "textual.containers", "textual.reactive", "textual.screen",
+        "textual.widgets", "textual.widgets.option_list",
+    ):
+        if mod_name not in sys.modules:
+            sys.modules[mod_name] = types.ModuleType(mod_name)
+    for attr, mod in (
+        ("App", "textual.app"), ("ComposeResult", "textual.app"),
+        ("Binding", "textual.binding"),
+        ("Hit", "textual.command"),
+        ("Hits", "textual.command"),
+        ("Provider", "textual.command"),
+        ("Container", "textual.containers"),
+        ("Horizontal", "textual.containers"),
+        ("Vertical", "textual.containers"),
+        ("VerticalScroll", "textual.containers"),
+        ("reactive", "textual.reactive"),
+        ("ModalScreen", "textual.screen"),
+        ("DataTable", "textual.widgets"),
+        ("Footer", "textual.widgets"),
+        ("Header", "textual.widgets"),
+        ("Input", "textual.widgets"),
+        ("OptionList", "textual.widgets"),
+        ("Option", "textual.widgets.option_list"),
+        ("Static", "textual.widgets"),
+    ):
+        setattr(sys.modules[mod], attr, _Permissive)
+
+    spec = importlib.util.spec_from_file_location("_browse_app_multi_select", _APP_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_browse_app_multi_select"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _f(sev, fid="X", title="t", location=None, cve=None, scanner="trivy"):
+    return Finding(
+        id=fid, severity=sev, title=title,
+        location=location, cve=cve, scanner=scanner,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Clipboard helper — pure-function tests
+# ---------------------------------------------------------------------------
+
+class TestFormatFindingsForClipboard:
+    """The payload-builder is what users paste into bug trackers."""
+
+    def test_uses_cve_when_present(self):
+        findings = [
+            _f(Severity.HIGH, fid="A", cve="CVE-2021-44228"),
+            _f(Severity.HIGH, fid="B", cve="CVE-2023-12345"),
+        ]
+        out = format_findings_for_clipboard(findings)
+        assert out == "CVE-2021-44228\nCVE-2023-12345"
+
+    def test_falls_back_to_scanner_id_when_no_cve(self):
+        # SAST findings (bandit, opengrep) typically have no CVE — the
+        # fallback identity is what makes the row identifiable in a
+        # bug-tracker comment without forcing the user to chase down
+        # source links manually.
+        findings = [_f(Severity.HIGH, fid="B105", scanner="bandit", cve=None)]
+        out = format_findings_for_clipboard(findings)
+        assert out == "bandit:B105"
+
+    def test_one_per_line(self):
+        findings = [
+            _f(Severity.HIGH, fid="A", cve="CVE-1"),
+            _f(Severity.HIGH, fid="B", cve="CVE-2"),
+            _f(Severity.HIGH, fid="C", cve="CVE-3"),
+        ]
+        out = format_findings_for_clipboard(findings)
+        assert out.count("\n") == 2
+        assert out.split("\n") == ["CVE-1", "CVE-2", "CVE-3"]
+
+    def test_preserves_duplicate_cves(self):
+        # Same CVE on two different SBOMs is intentional — pasting the
+        # list to a bug tracker should reflect that the CVE was
+        # seen twice. Deduping silently would surprise the user.
+        findings = [
+            _f(Severity.HIGH, fid="A", cve="CVE-1", location="alpha.spdx"),
+            _f(Severity.HIGH, fid="B", cve="CVE-1", location="beta.spdx"),
+        ]
+        out = format_findings_for_clipboard(findings)
+        assert out == "CVE-1\nCVE-1"
+
+    def test_empty_input(self):
+        assert format_findings_for_clipboard([]) == ""
+
+
+class TestCopyToClipboard:
+    """Strategy chain — pyperclip → platform CLI → fail-soft."""
+
+    def test_pyperclip_wins_when_present(self, monkeypatch):
+        # Inject a stub pyperclip module so the import path succeeds
+        # without requiring pyperclip in the test env.
+        stub = types.ModuleType("pyperclip")
+        captured: dict[str, str] = {}
+
+        def _copy(text: str) -> None:
+            captured["payload"] = text
+
+        stub.copy = _copy
+        monkeypatch.setitem(sys.modules, "pyperclip", stub)
+        ok, mechanism = copy_to_clipboard("CVE-2021-44228")
+        assert ok is True
+        assert mechanism == "pyperclip"
+        assert captured["payload"] == "CVE-2021-44228"
+
+    def test_falls_back_to_platform_cli(self, monkeypatch):
+        # No pyperclip → strategy chain advances to the next entry.
+        monkeypatch.setitem(sys.modules, "pyperclip", None)
+        called: dict[str, list] = {}
+
+        from argus.viewers.terminal import clipboard as cb
+
+        def fake_subprocess(argv, text):
+            called.setdefault("argv", []).append(argv)
+            called["text"] = text
+            return True
+
+        monkeypatch.setattr(cb, "_try_subprocess", fake_subprocess)
+        ok, mechanism = copy_to_clipboard("hello")
+        # Mechanism varies by platform — we just confirm it succeeded
+        # via the shell-out path (i.e. not pyperclip).
+        assert ok is True
+        assert mechanism != "pyperclip"
+        assert called["text"] == "hello"
+
+    def test_returns_false_when_nothing_works(self, monkeypatch):
+        # Disable pyperclip and force every subprocess attempt to fail
+        # (simulates a headless Linux box without xclip / wl-copy).
+        monkeypatch.setitem(sys.modules, "pyperclip", None)
+        from argus.viewers.terminal import clipboard as cb
+        monkeypatch.setattr(cb, "_try_subprocess", lambda argv, text: False)
+        ok, mechanism = copy_to_clipboard("anything")
+        assert ok is False
+        assert mechanism is None
+
+    def test_pyperclip_exception_falls_through(self, monkeypatch):
+        # pyperclip raises on headless Linux without a backend; we
+        # should *not* crash, we should advance to platform CLIs.
+        stub = types.ModuleType("pyperclip")
+        def _copy(text: str) -> None:
+            raise RuntimeError("no clipboard backend")
+        stub.copy = _copy
+        monkeypatch.setitem(sys.modules, "pyperclip", stub)
+        from argus.viewers.terminal import clipboard as cb
+        monkeypatch.setattr(cb, "_try_subprocess", lambda argv, text: True)
+        ok, mechanism = copy_to_clipboard("hello")
+        assert ok is True
+        assert mechanism != "pyperclip"
+
+
+class TestPlatformStrategies:
+    """The strategy list reflects the platform we're running on."""
+
+    def _strategies_for(self, platform_str: str):
+        from argus.viewers.terminal import clipboard as cb
+        orig = sys.platform
+        sys.platform = platform_str
+        try:
+            return [label for label, _ in cb._platform_strategies()]
+        finally:
+            sys.platform = orig
+
+    def test_macos_includes_pbcopy(self):
+        labels = self._strategies_for("darwin")
+        assert "pbcopy" in labels
+
+    def test_linux_includes_xclip_and_wl_copy(self):
+        labels = self._strategies_for("linux")
+        assert "xclip" in labels
+        # wl-copy fallback for Wayland users without xclip installed.
+        assert "wl-copy" in labels
+
+    def test_windows_includes_clip(self):
+        labels = self._strategies_for("win32")
+        assert "clip" in labels
+
+    def test_pyperclip_is_first_for_every_platform(self):
+        for platform in ("darwin", "linux", "win32"):
+            labels = self._strategies_for(platform)
+            # pyperclip first means a user with it installed on a
+            # platform we don't natively support still works.
+            assert labels[0] == "pyperclip"
+
+
+class TestTrySubprocess:
+    """``_try_subprocess`` should be safe even when the binary is missing."""
+
+    def test_returns_false_when_binary_not_on_path(self):
+        from argus.viewers.terminal import clipboard as cb
+        # Use a binary name that nobody has installed.
+        assert cb._try_subprocess(["definitely-not-a-real-binary-9z9z"], "x") is False
+
+
+# ---------------------------------------------------------------------------
+# Selection state on the BrowseApp — exercised via the stubbed loader.
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def app_with_findings():
+    """Yield a BrowseApp with an in-memory finding set, no Textual run.
+
+    We bypass ``on_mount`` (which loads a JSON file) and seat the
+    state by hand. This lets us call ``action_*`` methods directly
+    and inspect ``_selected`` / ``_visible``.
+    """
+    module = _load_app_module()
+    BrowseApp = module.BrowseApp
+    app = BrowseApp(results_dir=None)
+    findings = [
+        _f(Severity.CRITICAL, fid="CVE-1", cve="CVE-2021-1"),
+        _f(Severity.HIGH,     fid="CVE-2", cve="CVE-2021-2"),
+        _f(Severity.MEDIUM,   fid="CVE-3", cve="CVE-2021-3"),
+        _f(Severity.LOW,      fid="CVE-4", cve="CVE-2021-4"),
+    ]
+    app.all_findings = findings
+    app._visible = list(findings)
+
+    # Stub out the Textual lookups so action methods don't crash.
+    table_stub = types.SimpleNamespace(
+        cursor_coordinate=(0, 0),
+        rows=[], columns={},
+    )
+    notify_calls: list[dict] = []
+    status_text: list[str] = []
+
+    def fake_query_one(selector, *args):
+        if selector == "#status":
+            return types.SimpleNamespace(update=lambda t: status_text.append(t))
+        if selector == "#detail":
+            return types.SimpleNamespace(update_finding=lambda f: None)
+        # DataTable lookup — the stub is intentionally minimal.
+        return table_stub
+
+    def fake_notify(msg, **kwargs):
+        notify_calls.append({"msg": msg, **kwargs})
+
+    app.query_one = fake_query_one  # type: ignore[method-assign]
+    app.notify = fake_notify  # type: ignore[method-assign]
+
+    # Don't drive _refresh_list (it queries DataTable.add_row) —
+    # selection action methods call _refresh_keep_cursor → _refresh_list,
+    # so stub _refresh_list to a no-op that mimics the visible list.
+    app._refresh_list = lambda: None  # type: ignore[method-assign]
+    app._refresh_keep_cursor = lambda row: None  # type: ignore[method-assign]
+
+    return app, findings, notify_calls
+
+
+class TestSelectionToggle:
+    def test_toggle_adds_then_removes(self, app_with_findings):
+        app, findings, _ = app_with_findings
+        # Cursor starts at row 0.
+        app.action_toggle_selection()
+        assert id(findings[0]) in app._selected
+        # Press space again → deselects.
+        app.action_toggle_selection()
+        assert id(findings[0]) not in app._selected
+
+    def test_toggle_at_different_rows(self, app_with_findings):
+        app, findings, _ = app_with_findings
+        # Toggle row 0
+        app.action_toggle_selection()
+        # Move cursor to row 2 by faking the coordinate
+        app.query_one("any").cursor_coordinate = (2, 0)
+        app.action_toggle_selection()
+        assert id(findings[0]) in app._selected
+        assert id(findings[2]) in app._selected
+        assert id(findings[1]) not in app._selected
+        assert len(app._selected) == 2
+
+    def test_toggle_noop_when_no_visible_rows(self, app_with_findings):
+        app, _, _ = app_with_findings
+        app._visible = []
+        app.action_toggle_selection()
+        assert app._selected == set()
+
+
+class TestSelectAll:
+    def test_select_all_marks_every_visible_row(self, app_with_findings):
+        app, findings, notify_calls = app_with_findings
+        app.action_select_all()
+        for f in findings:
+            assert id(f) in app._selected
+        # Toast confirms the action.
+        assert any("Selected" in c["msg"] for c in notify_calls)
+
+    def test_select_all_with_filter_only_marks_filtered_rows(self, app_with_findings):
+        app, findings, _ = app_with_findings
+        # Simulate a filter that excludes CVE-3 and CVE-4.
+        app._visible = findings[:2]
+        app.action_select_all()
+        assert id(findings[0]) in app._selected
+        assert id(findings[1]) in app._selected
+        # Filtered-out rows are NOT in the selection.
+        assert id(findings[2]) not in app._selected
+        assert id(findings[3]) not in app._selected
+
+    def test_select_all_is_additive(self, app_with_findings):
+        # Pre-existing selection from another filter should survive.
+        app, findings, _ = app_with_findings
+        app._selected.add(id(findings[3]))   # CVE-4 — not in current filter
+        app._visible = findings[:2]
+        app.action_select_all()
+        assert id(findings[0]) in app._selected
+        assert id(findings[1]) in app._selected
+        assert id(findings[3]) in app._selected   # preserved
+
+
+class TestClearSelection:
+    def test_clear_drops_everything(self, app_with_findings):
+        app, findings, _ = app_with_findings
+        app._selected = {id(f) for f in findings}
+        app.action_clear_selection()
+        assert app._selected == set()
+
+    def test_clear_when_empty_is_noop(self, app_with_findings):
+        app, _, notify_calls = app_with_findings
+        app.action_clear_selection()
+        # No "Cleared 0" toast.
+        assert not any("Cleared" in c["msg"] for c in notify_calls)
+
+
+class TestFilterPreservesSelection:
+    """Headline behavior: a row filtered out and back retains selection."""
+
+    def test_selection_survives_filter_round_trip(self, app_with_findings):
+        app, findings, _ = app_with_findings
+        # Select CVE-3 (index 2) — a MEDIUM.
+        app.query_one("any").cursor_coordinate = (2, 0)
+        app.action_toggle_selection()
+        assert id(findings[2]) in app._selected
+        # Now apply a filter that hides CVE-3 (only HIGH+).
+        app._visible = findings[:2]   # CRITICAL + HIGH only
+        # Selection is still tracked.
+        assert id(findings[2]) in app._selected
+        # Filter cleared — row reappears with its mark intact.
+        app._visible = list(findings)
+        assert id(findings[2]) in app._selected
+
+
+# ---------------------------------------------------------------------------
+# Export / clipboard integration on the app itself
+# ---------------------------------------------------------------------------
+
+class TestExportRespectsSelection:
+    def test_export_with_selection_writes_only_selected(self, app_with_findings, tmp_path, monkeypatch):
+        app, findings, _ = app_with_findings
+        # Select two rows.
+        app._selected = {id(findings[0]), id(findings[2])}
+
+        from argus.viewers.terminal import export
+        captured: dict[str, list] = {}
+
+        def fake_writer(items, dest):
+            captured["items"] = list(items)
+            return dest
+
+        # Patch WRITERS to use our spy instead of touching the disk.
+        monkeypatch.setitem(
+            export.WRITERS, "csv", (fake_writer, "csv"),
+        )
+        monkeypatch.setattr(
+            export, "make_export_path",
+            lambda fmt, scope="all", **kw: tmp_path / f"out-{scope}.{fmt}",
+        )
+
+        app.action_export_csv()
+        assert len(captured["items"]) == 2
+        ids = {f.id for f in captured["items"]}
+        assert ids == {"CVE-1", "CVE-3"}
+
+    def test_export_without_selection_writes_filtered_view(self, app_with_findings, tmp_path, monkeypatch):
+        app, findings, _ = app_with_findings
+        # No selection → previous behavior preserved.
+        app._selected = set()
+        # Simulate an active filter (HIGH+ only).
+        app._visible = findings[:2]
+
+        from argus.viewers.terminal import export
+        captured: dict[str, list] = {}
+
+        def fake_writer(items, dest):
+            captured["items"] = list(items)
+            return dest
+
+        monkeypatch.setitem(
+            export.WRITERS, "csv", (fake_writer, "csv"),
+        )
+        monkeypatch.setattr(
+            export, "make_export_path",
+            lambda fmt, scope="all", **kw: tmp_path / f"out-{scope}.{fmt}",
+        )
+
+        app.action_export_csv()
+        assert len(captured["items"]) == 2
+        ids = {f.id for f in captured["items"]}
+        assert ids == {"CVE-1", "CVE-2"}
+
+    def test_scope_label_in_filename_reflects_selection(self, app_with_findings, tmp_path, monkeypatch):
+        app, findings, _ = app_with_findings
+        app._selected = {id(findings[0])}
+
+        from argus.viewers.terminal import export
+        scope_seen: dict[str, str] = {}
+
+        def fake_writer(items, dest):
+            return dest
+
+        monkeypatch.setitem(
+            export.WRITERS, "csv", (fake_writer, "csv"),
+        )
+
+        def fake_path(fmt, scope="all", **kw):
+            scope_seen["value"] = scope
+            return tmp_path / f"out-{scope}.{fmt}"
+
+        monkeypatch.setattr(export, "make_export_path", fake_path)
+        app.action_export_csv()
+        # The filename's scope marker reads "selection" — so filter
+        # exports and selection exports never clobber each other.
+        assert scope_seen["value"] == "selection"
+
+
+class TestCopyCves:
+    def test_copies_cve_ids_when_clipboard_works(self, app_with_findings, monkeypatch):
+        app, findings, notify_calls = app_with_findings
+        app._selected = {id(findings[0]), id(findings[1])}
+
+        captured: dict[str, str] = {}
+
+        def fake_copy(text: str):
+            captured["text"] = text
+            return True, "pyperclip"
+
+        from argus.viewers.terminal import clipboard
+        monkeypatch.setattr(clipboard, "copy_to_clipboard", fake_copy)
+
+        app.action_copy_cves()
+        # Two CVEs, one per line, in visible-first order.
+        assert captured["text"] == "CVE-2021-1\nCVE-2021-2"
+        # Toast names the mechanism that worked.
+        assert any("pyperclip" in c["msg"] for c in notify_calls)
+
+    def test_warns_when_no_selection(self, app_with_findings, monkeypatch):
+        app, _, notify_calls = app_with_findings
+        from argus.viewers.terminal import clipboard
+        # We shouldn't even call copy_to_clipboard — break it to prove that.
+        def boom(_text):
+            raise AssertionError("clipboard called with no selection")
+        monkeypatch.setattr(clipboard, "copy_to_clipboard", boom)
+        app.action_copy_cves()
+        # The warning toast nudges the user to select something first.
+        assert any("No findings selected" in c["msg"] for c in notify_calls)
+
+    def test_falls_back_cleanly_when_clipboard_unavailable(self, app_with_findings, monkeypatch):
+        app, findings, notify_calls = app_with_findings
+        app._selected = {id(findings[0])}
+        from argus.viewers.terminal import clipboard
+        monkeypatch.setattr(clipboard, "copy_to_clipboard", lambda t: (False, None))
+        # Should NOT raise.
+        app.action_copy_cves()
+        # Toast tells the user how to fix it.
+        msgs = " ".join(c["msg"] for c in notify_calls)
+        assert "No clipboard mechanism" in msgs
+
+    def test_includes_out_of_view_selections(self, app_with_findings, monkeypatch):
+        # Cross-filter selection: user selected CVE-1, then narrowed
+        # the filter so CVE-1 is no longer visible. Copy should still
+        # include it (just at the end of the payload).
+        app, findings, _ = app_with_findings
+        app._selected = {id(findings[0]), id(findings[3])}
+        app._visible = [findings[3]]   # filter hides findings[0]
+
+        captured: dict[str, str] = {}
+
+        def fake_copy(text: str):
+            captured["text"] = text
+            return True, "pyperclip"
+
+        from argus.viewers.terminal import clipboard
+        monkeypatch.setattr(clipboard, "copy_to_clipboard", fake_copy)
+        app.action_copy_cves()
+        # Both CVEs land in the payload — visible row first, then
+        # the out-of-view selection.
+        lines = captured["text"].split("\n")
+        assert set(lines) == {"CVE-2021-1", "CVE-2021-4"}
+        assert lines[0] == "CVE-2021-4"  # in-view first

--- a/argus/viewers/terminal/app.py
+++ b/argus/viewers/terminal/app.py
@@ -11,7 +11,11 @@ the footer automatically):
   / (slash)     — focus the search input
   1 / 2 / 3 / 4 — filter to CRITICAL / HIGH+ / MEDIUM+ / ALL severities
   s             — cycle sort (severity desc, severity asc, package, id)
-  e             — export the currently filtered view to CSV
+  space         — toggle selection on the focused row
+  a             — select every row in the current filter
+  A (shift+a)   — clear all selections
+  e             — export the currently filtered view (or the selection) to CSV
+  C (shift+c)   — copy CVE IDs of selected findings to the clipboard
   q             — quit
 """
 
@@ -74,14 +78,24 @@ _HELP_TEXT = """\
   [b]3[/b]                MEDIUM and above
   [b]4[/b]                all severities (clear filter)
   [b]p[/b]                pick a product (SBOM source) to focus on
-  [b]c[/b]                pick a scanner to focus on
+  [b]N[/b]                pick a scanner to focus on (shift+n)
+
+[b]Multi-select (batch actions)[/b]
+  [b]space[/b]            toggle selection on the focused row
+  [b]a[/b]                select every row in the current filter
+  [b]A[/b]                clear all selections (shift+a)
+  [b]c[/b]                copy selected findings' CVE IDs to the clipboard
+                   (falls back to <scanner>:<id> when no CVE)
+                   When nothing is selected, [b]e[/b] still exports the
+                   filtered view; with a selection, [b]e[/b] exports
+                   only the selected rows.
 
 [b]Sort[/b]
   [b]s[/b]                cycle: Severity desc → Severity asc → Package → ID
                    active column shows ↓/↑ in its header
 
 [b]Export[/b]
-  [b]e[/b]                export the currently filtered view as CSV
+  [b]e[/b]                export the currently filtered view (or selection) as CSV
                    (timestamped filename, stored in cwd)
   [b]o[/b]                open the last export with your default app
                    (Numbers/Excel/LibreOffice on macOS; default handler elsewhere)
@@ -379,12 +393,16 @@ class ArgusBrowseCommands(Provider):
             ("Product: Pick a product filter", "Filter findings by SBOM source / product", app.action_pick_product),
             ("Scanner: Pick a scanner filter", "Filter findings by reporting scanner", app.action_pick_scanner),
             ("Sort: Cycle sort mode",    "Cycle severity desc → asc → package → id", app.action_cycle_sort),
-            ("Export: CSV of current view", "Write the filtered findings to a timestamped CSV", app.action_export_csv),
-            ("Export: JSON",             "Write the filtered findings as JSON", app.action_export_json),
-            ("Export: Markdown",         "Write the filtered findings as a paste-ready Markdown table", app.action_export_markdown),
-            ("Export: SARIF",            "Write the filtered findings as SARIF 2.1.0", app.action_export_sarif),
+            ("Export: CSV of current view", "Write the filtered findings (or selection) to a timestamped CSV", app.action_export_csv),
+            ("Export: JSON",             "Write the filtered findings (or selection) as JSON", app.action_export_json),
+            ("Export: Markdown",         "Write the filtered findings (or selection) as a paste-ready Markdown table", app.action_export_markdown),
+            ("Export: SARIF",            "Write the filtered findings (or selection) as SARIF 2.1.0", app.action_export_sarif),
             ("Open: Last export",        "Open the last export with the system's default app", app.action_open_last_export),
             ("Reveal: Last export",      "Show the last export in the OS file manager", app.action_reveal_last_export),
+            ("Select: Toggle row",       "Toggle multi-select on the focused row (space)", app.action_toggle_selection),
+            ("Select: All visible",      "Add every visible row to the selection (a)", app.action_select_all),
+            ("Select: Clear",            "Clear all multi-select selections (shift+a)", app.action_clear_selection),
+            ("Copy: Selected CVE IDs",   "Copy selected findings' CVE IDs to the clipboard (c)", app.action_copy_cves),
         ]
         for label, help_text, callback in commands:
             score = matcher.match(label)
@@ -489,10 +507,22 @@ class BrowseApp(App):
         Binding("s", "cycle_sort", "Sort"),
         Binding("e", "export_csv", "CSV"),
         Binding("d", "show_dashboard", "Dash"),
+        # Multi-select — drives the bulk-action workflows (export N rows,
+        # paste a CVE list into a bug tracker). ``space``/``a``/``A``
+        # manage the selection set; ``c`` copies CVEs from it. ``e``
+        # already existed; its action method now picks the selection
+        # over the filtered view when one is active.
+        Binding("space", "toggle_selection", "Select", show=True),
+        Binding("a", "select_all", "Select all", show=False),
+        Binding("A", "clear_selection", "Clear sel", show=False),
+        Binding("c", "copy_cves", "Copy CVEs", show=True),
         Binding("o", "open_last_export", "Open export", show=False),
         Binding("r", "reveal_last_export", "Reveal export", show=False),
         Binding("p", "pick_product", "Product", show=False),
-        Binding("c", "pick_scanner", "Scanner", show=False),
+        # Scanner picker moved to ``shift+n`` to free ``c`` for the
+        # multi-select clipboard action. Still discoverable via the
+        # Ctrl+P command palette and via the Help overlay.
+        Binding("N", "pick_scanner", "Scanner", show=False),
         Binding("j", "cursor_down", "Down", show=False),
         Binding("k", "cursor_up", "Up", show=False),
     ]
@@ -505,6 +535,14 @@ class BrowseApp(App):
         self.all_findings: list[Finding] = []
         self.view_state = ViewState()
         self._visible: list[Finding] = []
+        # Selection set keyed by stable Finding identity so a row that
+        # gets filtered out and back in retains its selection. We use
+        # ``id(f)`` rather than serializing the Finding because Finding
+        # is a frozen dataclass with all-defaults-comparable fields and
+        # ``hash(Finding)`` depends on the full content equality model.
+        # Storing the live object reference is the cheapest stable key
+        # for an in-memory session.
+        self._selected: set[int] = set()
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=False)
@@ -536,9 +574,12 @@ class BrowseApp(App):
         self.all_findings = flatten_findings(summary)
         table = self.query_one(DataTable)
         # Column keys are kept so we can re-label the active sort column
-        # with an arrow glyph whenever the sort cycles.
+        # with an arrow glyph whenever the sort cycles. The leading
+        # checkbox column ("✓") is updated row-by-row as the selection
+        # changes — it stays unsorted (selection is a per-row state,
+        # not a sort key).
         self._col_keys = table.add_columns(
-            "Sev", "ID", "Package@Version", "Scanner", "Location",
+            " ", "Sev", "ID", "Package@Version", "Scanner", "Location",
         )
         self._refresh_list()
         self._update_sort_indicator()
@@ -565,6 +606,7 @@ class BrowseApp(App):
             installed = f.metadata.get("installed_version")
             pkg_label = f"{pkg}@{installed}" if pkg else (f.location or "—")
             table.add_row(
+                "✓" if id(f) in self._selected else " ",
                 _SEVERITY_GLYPH.get(f.severity, "?"),
                 f.id[:36],
                 pkg_label[:36],
@@ -593,9 +635,19 @@ class BrowseApp(App):
         if self.view_state.query:
             parts.append(f"query='{self.view_state.query}'")
         sort = self.view_state.sort_key.replace("_", " ")
+        # Selection is shown only when non-empty so the status bar stays
+        # quiet during normal browsing. The count tracks the global
+        # selection set, not just the rows visible right now — that
+        # matches user expectations after a filter change ("I selected
+        # 5 things; how many did I select total?").
+        selection_str = (
+            f" · [b]{len(self._selected)}[/b] selected"
+            if self._selected else ""
+        )
         self.query_one("#status", Static).update(
             f"[b]{shown}[/b] / {total} findings · "
             f"filter: {' · '.join(parts)} · sort: {sort}"
+            f"{selection_str}"
         )
 
     def _update_detail(self, row: int) -> None:
@@ -716,9 +768,12 @@ class BrowseApp(App):
         DataTable allows updating a column's ``label`` via its
         internal Column object. We restore the base labels on every
         call so switching columns leaves no stale indicator behind.
+
+        Column 0 is the multi-select checkbox column — never a sort
+        target — so the data-column offsets all start at 1.
         """
         table = self.query_one(DataTable)
-        base_labels = ["Sev", "ID", "Package@Version", "Scanner", "Location"]
+        base_labels = [" ", "Sev", "ID", "Package@Version", "Scanner", "Location"]
         # When running under stubbed textual in tests, columns may be
         # an empty mapping or missing; bail silently so the test path
         # (which only exercises view-state logic) stays green.
@@ -727,13 +782,13 @@ class BrowseApp(App):
         arrow_col = None
         arrow_glyph = ""
         if self.view_state.sort_key == "severity_desc":
-            arrow_col, arrow_glyph = 0, " ↓"
-        elif self.view_state.sort_key == "severity_asc":
-            arrow_col, arrow_glyph = 0, " ↑"
-        elif self.view_state.sort_key == "package":
-            arrow_col, arrow_glyph = 2, " ↓"
-        elif self.view_state.sort_key == "id":
             arrow_col, arrow_glyph = 1, " ↓"
+        elif self.view_state.sort_key == "severity_asc":
+            arrow_col, arrow_glyph = 1, " ↑"
+        elif self.view_state.sort_key == "package":
+            arrow_col, arrow_glyph = 3, " ↓"
+        elif self.view_state.sort_key == "id":
+            arrow_col, arrow_glyph = 2, " ↓"
         for idx, key in enumerate(self._col_keys):
             try:
                 col = table.columns[key]
@@ -750,38 +805,204 @@ class BrowseApp(App):
     def action_cursor_up(self) -> None:
         self.query_one(DataTable).action_cursor_up()
 
+    # ------------------------------------------------------------------
+    # Multi-select actions
+    # ------------------------------------------------------------------
+
+    def _focused_row_index(self) -> int | None:
+        """Return the visible-row index the cursor is on, or None.
+
+        Wraps DataTable's ``cursor_coordinate`` attribute so the action
+        handlers don't have to handle "table has no cursor yet" / stub
+        objects in tests. Returns ``None`` when no row is focusable
+        (empty filter set, table not yet mounted).
+        """
+        try:
+            table = self.query_one(DataTable)
+        except Exception:
+            return None
+        coord = getattr(table, "cursor_coordinate", None)
+        if coord is None:
+            return None
+        try:
+            row = coord[0]
+        except (TypeError, IndexError):
+            return None
+        if not isinstance(row, int) or row < 0 or row >= len(self._visible):
+            return None
+        return row
+
+    def action_toggle_selection(self) -> None:
+        """Toggle selection on the focused row (``space`` keybind).
+
+        No-op when no row is focused (e.g. empty filter result). The
+        cursor position is preserved across the refresh so the user can
+        space-down-space-down through a list without losing their
+        place.
+        """
+        row = self._focused_row_index()
+        if row is None:
+            return
+        finding = self._visible[row]
+        key = id(finding)
+        if key in self._selected:
+            self._selected.discard(key)
+        else:
+            self._selected.add(key)
+        self._refresh_keep_cursor(row)
+
+    def action_select_all(self) -> None:
+        """Select every row in the current filter (``a`` keybind).
+
+        Adds to — rather than replaces — the existing selection so a
+        user who already cherry-picked a few rows from another filter
+        doesn't lose them. The status bar's "N selected" count makes
+        the cumulative effect visible.
+        """
+        if not self._visible:
+            return
+        for f in self._visible:
+            self._selected.add(id(f))
+        # Keep cursor where it is so the user can keep navigating.
+        row = self._focused_row_index() or 0
+        self._refresh_keep_cursor(row)
+        self.notify(
+            f"Selected {len(self._visible)} visible row(s).",
+            severity="information", timeout=2,
+        )
+
+    def action_clear_selection(self) -> None:
+        """Drop every selected row (``A`` / shift+a keybind).
+
+        Clears the *global* selection set, not just the visible
+        portion. That matches the keybind name ("clear") — users who
+        want a per-filter clear can re-select-all then refine.
+        """
+        if not self._selected:
+            return
+        count = len(self._selected)
+        self._selected.clear()
+        row = self._focused_row_index() or 0
+        self._refresh_keep_cursor(row)
+        self.notify(
+            f"Cleared {count} selection(s).",
+            severity="information", timeout=2,
+        )
+
+    def _refresh_keep_cursor(self, row: int) -> None:
+        """Re-render the table while keeping the cursor on ``row``.
+
+        ``_refresh_list`` re-seats the cursor at row 0 by design (it's
+        the right behavior after a filter change), but the multi-select
+        flow is high-frequency: hitting ``space`` ten times to mark a
+        run of rows shouldn't fling the cursor back to the top each
+        time. This thin wrapper restores the cursor afterward.
+        """
+        self._refresh_list()
+        try:
+            table = self.query_one(DataTable)
+        except Exception:
+            return
+        if 0 <= row < len(self._visible):
+            try:
+                table.cursor_coordinate = (row, 0)
+            except Exception:
+                pass
+
+    def action_copy_cves(self) -> None:
+        """Copy selected findings' CVE IDs to the clipboard (``c`` keybind).
+
+        One identifier per line. Falls back to ``<scanner>:<id>`` for
+        rows without a CVE so a SAST or secret-scanner finding still
+        ends up in a paste-ready form. Toast names the mechanism that
+        worked (pyperclip / pbcopy / xclip / wl-copy / clip) so users
+        can debug "did it land in the X11 selection or the GNOME
+        Wayland one?" cases.
+        """
+        from argus.viewers.terminal.clipboard import (
+            copy_to_clipboard,
+            format_findings_for_clipboard,
+        )
+        if not self._selected:
+            self.notify(
+                "No findings selected. Use [b]space[/b] to toggle a row "
+                "or [b]a[/b] to select the current filter.",
+                severity="warning", timeout=4,
+            )
+            return
+        # Preserve the current visible order in the clipboard payload —
+        # the user's filter+sort already tells them which view they
+        # were in, and pasting should reflect that ordering. Selected
+        # rows that aren't in the current filter still go in (so a
+        # cross-filter selection doesn't silently drop entries) but
+        # land at the end.
+        in_view = [f for f in self._visible if id(f) in self._selected]
+        in_view_ids = {id(f) for f in in_view}
+        out_of_view = [
+            f for f in self.all_findings
+            if id(f) in self._selected and id(f) not in in_view_ids
+        ]
+        ordered = in_view + out_of_view
+        payload = format_findings_for_clipboard(ordered)
+        ok, mechanism = copy_to_clipboard(payload)
+        n = len(ordered)
+        if ok:
+            self.notify(
+                f"{n} CVE(s) copied to clipboard via {mechanism}.",
+                severity="information", timeout=3,
+            )
+        else:
+            self.notify(
+                "No clipboard mechanism available "
+                "(install pyperclip, xclip, wl-copy, pbcopy, or clip). "
+                f"{n} finding(s) would have been copied.",
+                severity="warning", timeout=6,
+            )
+
     # Format dispatch lives in argus.viewers.terminal.export — these action methods
     # just wrap the shared writers with filename assembly and toast.
 
     def action_export_csv(self) -> None:
-        """Export the currently visible findings as CSV (bound to ``e``)."""
+        """Export the current view (or selection if non-empty) as CSV (bound to ``e``)."""
         self._export_in_format("csv")
 
     def action_export_json(self) -> None:
-        """Export the currently visible findings as JSON."""
+        """Export the current view (or selection if non-empty) as JSON."""
         self._export_in_format("json")
 
     def action_export_markdown(self) -> None:
-        """Export the currently visible findings as Markdown (paste-ready for tickets)."""
+        """Export the current view (or selection if non-empty) as Markdown."""
         self._export_in_format("markdown")
 
     def action_export_sarif(self) -> None:
-        """Export the currently visible findings as SARIF 2.1.0."""
+        """Export the current view (or selection if non-empty) as SARIF 2.1.0."""
         self._export_in_format("sarif")
 
     def _export_in_format(self, fmt: str) -> None:
         from argus.viewers.terminal.export import WRITERS, make_export_path
         writer, extension = WRITERS[fmt]
-        scope = (
-            self.view_state.min_severity.value
-            if self.view_state.min_severity else "all"
-        )
+        # Selection-aware export: when the user has marked a subset, we
+        # export only those rows; without a selection, the previous
+        # "filtered view" semantics still apply. The scope label in the
+        # filename reflects which path we took so a "selection" export
+        # never silently overwrites a "filter" export.
+        if self._selected:
+            findings = [
+                f for f in self.all_findings if id(f) in self._selected
+            ]
+            scope = "selection"
+        else:
+            findings = self._visible
+            scope = (
+                self.view_state.min_severity.value
+                if self.view_state.min_severity else "all"
+            )
         dest = make_export_path(extension, scope=scope)
-        writer(self._visible, dest)
+        writer(findings, dest)
         self._last_export_path = dest
         uri = dest.as_uri()
         self.notify(
-            f"Exported {len(self._visible)} finding(s) as {fmt.upper()} to:\n"
+            f"Exported {len(findings)} finding(s) as {fmt.upper()} to:\n"
             f"{dest}\n"
             f"{uri}\n"
             f"Press [b]o[/b] to open with default app · "

--- a/argus/viewers/terminal/clipboard.py
+++ b/argus/viewers/terminal/clipboard.py
@@ -1,0 +1,151 @@
+"""Clipboard helper for the terminal viewer.
+
+Triage workflows often want to drop a list of CVE IDs into a bug-tracker
+comment. The TUI binds ``c`` to "copy selected CVEs" — this module is the
+testable layer behind that binding.
+
+Design choice: prefer ``pyperclip`` when it's installed (cross-platform,
+already a transitive dep on many machines), otherwise shell out to the
+platform-native CLI:
+
+- macOS  → ``pbcopy``
+- Linux  → ``xclip -selection clipboard``, then ``wl-copy`` for Wayland
+- Windows → ``clip``
+
+Each strategy is wrapped in a function returning ``(success, mechanism)``
+so the caller can show a meaningful toast. When nothing works we return
+``(False, None)`` rather than raising — the UI surfaces that as a
+graceful "clipboard unavailable" toast instead of crashing the TUI.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from typing import Callable
+
+
+# ---------------------------------------------------------------------------
+# Strategy implementations — each returns True on success, False otherwise.
+# ---------------------------------------------------------------------------
+
+def _try_pyperclip(text: str) -> bool:
+    """Use the ``pyperclip`` library if it's installed.
+
+    pyperclip is intentionally an optional import; users who don't have
+    it installed will exercise the shell-out fallbacks below.
+    """
+    try:
+        import pyperclip  # type: ignore[import-not-found]
+    except ImportError:
+        return False
+    try:
+        pyperclip.copy(text)
+        return True
+    except Exception:
+        # pyperclip raises ``PyperclipException`` when no backend is
+        # available on the platform (e.g. headless Linux without xclip).
+        # Fall through to the shell-out chain so the user still gets a
+        # working copy when one of those tools is installed.
+        return False
+
+
+def _try_subprocess(argv: list[str], text: str) -> bool:
+    """Pipe ``text`` into the given subprocess argv.
+
+    Returns False if the binary isn't on PATH or the process exits
+    non-zero. Never raises — the goal is "did it work?", not
+    "what went wrong".
+    """
+    if not shutil.which(argv[0]):
+        return False
+    try:
+        result = subprocess.run(
+            argv,
+            input=text,
+            text=True,
+            capture_output=True,
+            timeout=5,
+        )
+        return result.returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+def _platform_strategies() -> list[tuple[str, Callable[[str], bool]]]:
+    """Return ordered ``(label, strategy)`` pairs for the current platform.
+
+    pyperclip first (works everywhere it works), then platform-native
+    CLI tools. The label is what we surface in the toast so users know
+    which mechanism succeeded — useful when debugging "did it actually
+    end up in the system clipboard or just the Wayland one?".
+    """
+    strategies: list[tuple[str, Callable[[str], bool]]] = [
+        ("pyperclip", _try_pyperclip),
+    ]
+    if sys.platform == "darwin":
+        strategies.append(
+            ("pbcopy", lambda t: _try_subprocess(["pbcopy"], t)),
+        )
+    elif sys.platform.startswith("linux"):
+        # X11 first (still the dominant default for SSH-able Linux),
+        # then Wayland for users on a Wayland session without xclip
+        # installed.
+        strategies.append(
+            ("xclip", lambda t: _try_subprocess(
+                ["xclip", "-selection", "clipboard"], t,
+            )),
+        )
+        strategies.append(
+            ("wl-copy", lambda t: _try_subprocess(["wl-copy"], t)),
+        )
+    elif sys.platform == "win32":
+        strategies.append(
+            ("clip", lambda t: _try_subprocess(["clip"], t)),
+        )
+    return strategies
+
+
+def copy_to_clipboard(text: str) -> tuple[bool, str | None]:
+    """Try every available strategy in order; return (success, mechanism).
+
+    On success, ``mechanism`` is the label of the strategy that worked
+    (``"pyperclip"``, ``"pbcopy"``, …). On failure, ``mechanism`` is
+    ``None`` and the caller should surface a "no clipboard mechanism
+    available" toast.
+    """
+    for label, strategy in _platform_strategies():
+        if strategy(text):
+            return True, label
+    return False, None
+
+
+# ---------------------------------------------------------------------------
+# Finding-specific helper — produces the exact "one CVE per line" payload
+# the ``c`` keybinding ships to the clipboard.
+# ---------------------------------------------------------------------------
+
+def format_findings_for_clipboard(findings) -> str:
+    """Build the multi-line clipboard payload from a list of findings.
+
+    Rule per finding:
+    - If the finding has a CVE → emit the CVE ID.
+    - Otherwise → emit ``<scanner>:<id>`` so the row is still
+      identifiable in the bug tracker.
+
+    Order matches the input list so the user's selection order survives
+    into the paste. Duplicates are preserved — if the same CVE appears
+    on multiple selected rows (cross-product, multi-scanner), the user
+    asked for it; deduping silently would surprise them.
+    """
+    lines: list[str] = []
+    for f in findings:
+        cve = getattr(f, "cve", None)
+        if cve:
+            lines.append(cve)
+        else:
+            scanner = getattr(f, "scanner", None) or "unknown"
+            fid = getattr(f, "id", None) or "unknown"
+            lines.append(f"{scanner}:{fid}")
+    return "\n".join(lines)

--- a/docs/developer/SDK-ROADMAP.md
+++ b/docs/developer/SDK-ROADMAP.md
@@ -292,7 +292,7 @@ Not all of these belong to the TUI itself — the portal integration items are p
 
 #### Existing polish items (pre-roadtest)
 
-- [ ] Multi-select for batch actions (export a subset, copy CVE list to clipboard)
+- [x] Multi-select for batch actions (export a subset, copy CVE list to clipboard)
 - [x] `argus scan --interface=terminal` convenience flag — auto-launches the terminal viewer after the scan finishes
 - [x] ~~Quickstart in `docs/view-terminal.md`~~ — install + launch + key bindings + workflows shipped
 - [ ] Screenshot pass for `docs/view-terminal.md` — doc has no images yet

--- a/docs/view-terminal.md
+++ b/docs/view-terminal.md
@@ -56,11 +56,16 @@ Press `?` inside the TUI for the same reference, grouped by purpose.
 | `3` | MEDIUM severity and above |
 | `4` | clear severity filter (all) |
 | `p` | pick a product (SBOM source) to focus on — modal |
-| `c` | pick a scanner to focus on — modal |
+| `N` (shift+n) | pick a scanner to focus on — modal |
+| **Multi-select (batch actions)** | |
+| `space` | toggle selection on the focused row |
+| `a` | select every row in the current filter (additive) |
+| `A` (shift+a) | clear all selections |
+| `c` | copy selected findings' CVE IDs to the clipboard |
 | **Sort** | |
 | `s` | cycle: severity desc → asc → package → id (toast + header arrow) |
 | **Export** | |
-| `e` | export visible findings as CSV |
+| `e` | export visible findings (or selection) as CSV |
 | `o` | open last export with your default app |
 | `r` | reveal last export in file manager |
 | **Other** | |
@@ -112,6 +117,53 @@ switcher, Screenshot-as-SVG) also appear.
 The **Screenshot** command is genuinely useful: saves the current TUI view
 as an SVG you can drop into a ticket or doc — better than cropping a
 terminal screenshot manually.
+
+## Multi-select for batch actions
+
+Triage workflows often want to act on a subset of findings — export N
+rows as CSV for a spreadsheet, or paste a list of CVE IDs into a
+bug-tracker comment. The TUI keeps a per-session selection set you can
+build with `space` / `a` / `A`:
+
+| Key | Action |
+|-----|--------|
+| `space` | toggle selection on the focused row (adds a `✓` glyph in the leading column) |
+| `a` | select every visible row (additive — preserves any cross-filter picks) |
+| `A` (shift+a) | clear every selection |
+| `c` | copy selected findings' CVE IDs to the clipboard, one per line |
+
+The status bar shows `<N> selected` whenever the selection is
+non-empty. Selection survives filter changes — a row that gets
+filtered out and back retains its mark.
+
+### How `e` and `c` use the selection
+
+- **`e` (Export)** — when the selection is non-empty, the export
+  writes only the selected rows; the filename's scope marker is
+  `selection`. With nothing selected, `e` keeps its original behavior
+  (writes the entire filtered view).
+- **`c` (Copy CVEs)** — copies the CVE IDs of the selected rows.
+  Findings without a CVE (SAST, secret-scanner) fall back to
+  `<scanner>:<id>` so each line is still identifiable. Order is
+  visible-rows-first, then any cross-filter selections, so the paste
+  reflects what you saw on screen.
+
+### Clipboard fallback chain
+
+The TUI tries each mechanism in order until one succeeds, then names
+the winner in the toast:
+
+| Platform | Order |
+|----------|-------|
+| Any | `pyperclip` (when installed) |
+| macOS | → `pbcopy` |
+| Linux | → `xclip -selection clipboard`, then `wl-copy` (Wayland) |
+| Windows | → `clip` |
+
+If nothing works (e.g. headless Linux without `xclip`/`wl-copy`),
+the TUI shows a graceful "no clipboard mechanism available" toast
+rather than crashing — install `pyperclip` (`pip install pyperclip`)
+or your distro's clipboard CLI to enable it.
 
 ## Export formats
 


### PR DESCRIPTION
## Description

Adds multi-select to the `argus view terminal` findings list. Triage workflows often want to act on a subset of findings (export N rows as CSV, copy a CVE list for a bug-tracker comment) — currently the only acting unit is the entire filtered view.

Closes roadmap item **#293** (Multi-select for batch actions).

## Changes Made
- [x] Added new scanner/workflow
- [x] Modified existing scanner/workflow
- [x] Updated documentation
- [ ] Fixed bug
- [ ] Other (please specify)

### Details

**Bindings (additive — existing keys unchanged):**

| Key | Action |
|---|---|
| `<space>` | Toggle selection on the focused row |
| `a` | Select all currently-visible (filter-respecting) rows |
| `A` | Clear all selections |
| `e` | When selection non-empty: export selection only. Otherwise: previous behavior (filtered-view export). |
| `c` | Copy selected findings' CVE IDs to clipboard, one per line. No CVE → fallback to `<scanner>:<id>`. Toast confirms count. |

The previous `c` (scanner picker) moves to `N` to avoid collision with copy-cves.

**Visual cues:**
- Leading checkbox column shows `✓` on selected rows
- Status bar shows `<N> selected` when selection is non-empty
- Selection persists across filter changes (rows filtered out + back in retain selection)
- Selection clears on `q` (quit) or when loading a different scan via the scan picker

**Clipboard helper** at `argus/viewers/terminal/clipboard.py`: `pyperclip` → `pbcopy` / `xclip` / `wl-copy` / `clip` strategy chain. Returns `(success, mechanism)`. No-clipboard toast is clean — never crashes. Tested independently of Textual since terminal-app integration tests are awkward.

### Cross-platform safety
- Clipboard fallback covers macOS (`pbcopy`), Linux (`xclip` then `wl-copy`), Windows (`clip`).
- No platform branching in the TUI itself — all platform handling is in `clipboard.py`.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results

```
$ pytest --no-cov -q     # full suite
2744 passed, 3 skipped, 7 deselected
```

30 new tests in `argus/tests/viewers/terminal/test_multi_select.py` covering: clipboard formatter, strategy chain, per-platform strategies, fall-through, toggle/select-all/clear, filter-survives-selection, export-with-and-without-selection, copy-cves with/without selection/clipboard.

## Security Considerations
- [x] No security impact
- [ ] Security enhancement
- [ ] Potential security implications

## AI Context Updates (.ai/)
- [ ] `.ai/architecture.yaml` updated
- [ ] `.ai/workflows.yaml` updated
- [ ] `.ai/decisions.yaml` updated
- [ ] `.ai/errors.yaml` updated
- [x] N/A - No .ai/ updates needed

(Pure feature add to an existing component; no architectural shift, no new error classes.)

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (if applicable) — `docs/view-terminal.md` (new "Multi-select for batch actions" section + updated keyboard table)
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
N/A — closes roadmap item #293.