### PR TITLE
refactor(linters): FileDiscoveryScanner template + shared docker-fallback helper

### DIFF
--- a/.ai/architecture.yaml
+++ b/.ai/architecture.yaml
@@ -489,6 +489,18 @@ docsite:
       - zap
       - container
     linters:
+      # Implementation patterns:
+      #   * lint-dockerfile (HadolintLinter) — subclass of
+      #     argus.core.linter_template.FileDiscoveryScanner
+      #     (workspace walk → batched subprocess → local-or-container
+      #     dispatch → parse). See ADR-020.
+      #   * lint-javascript (EslintLinter), lint-terraform — custom
+      #     scan() flows that consume the shared
+      #     argus.core.linter_template.build_docker_command helper.
+      #   * lint-yaml, lint-python — "tool walks workspace itself"
+      #     shape; tool takes the path and discovers files internally.
+      #   * lint-json — Python json.loads fallback when the jsonlint
+      #     binary is absent.
       - lint-yaml
       - lint-json
       - lint-python

--- a/.ai/decisions.yaml
+++ b/.ai/decisions.yaml
@@ -1150,3 +1150,118 @@ decisions:
     pr_references:
       - "#91 (initial pattern in scanner-container and scanner-zap)"
       - "#126 (migration of remaining 14 SDK-using wrappers + bin/argus removal)"
+
+  - id: ADR-020
+    title: "FileDiscoveryScanner template + shared linter helpers"
+    status: accepted
+    date: 2026-05-07
+    context: |
+      Linters (lint-yaml, lint-json, lint-python, lint-javascript,
+      lint-dockerfile, lint-terraform) duplicated three concerns
+      across their adapters:
+
+      * File discovery — each linter that walks files in Python
+        (HadolintLinter._find_dockerfiles, JsonlintLinter inline
+        rglob) re-implemented the walk.
+      * Container fallback — HadolintLinter._build_docker_command,
+        EslintLinter._build_docker_command, and
+        TerraformLinter._docker_command each built nearly identical
+        ``docker run -v <ws>:/workspace[:ro] <image> <args>`` shapes,
+        differing only in mount mode and workdir.
+      * UTF-8 subprocess — most linters needed
+        ``encoding='utf-8', errors='replace'`` to avoid the cp1252
+        UnicodeDecodeError on Windows runners. Each one carried it
+        inline.
+
+      The original SDK-ROADMAP.md "FileDiscoveryScanner Template"
+      section called for a unified subclass-based abstraction.
+      Reading the actual linters showed two execution shapes:
+      "tool-walks-itself" (yamllint, python_lint, eslint) and
+      "discover-then-batch" (hadolint, jsonlint). A single forced
+      hierarchy didn't fit both.
+    decision: |
+      Ship a hybrid: helper functions for the deduplication that's
+      always useful, and a base class for the cases that genuinely
+      share a flow.
+
+      argus/core/linter_template.py exports:
+
+      * ``discover_files(target, patterns, exclusions=None)`` — walk
+        helper used by FileDiscoveryScanner internally and available
+        to any custom flow (e.g. jsonlint).
+      * ``build_docker_command(image, workspace, container_args,
+        mount_rw=False, ws_mount='/workspace', workdir=None)`` — the
+        single source of truth for the docker-run command shape.
+        EslintLinter and TerraformLinter migrate to it.
+      * ``run_utf8(cmd, *, cwd=None, timeout=None)`` — explicit
+        UTF-8 subprocess wrapper. Replaces inline encoding+errors
+        keyword args.
+      * ``FileDiscoveryScanner`` — base class for the discover-then-
+        batch flow. Subclasses declare ``name``, ``file_glob``,
+        ``binary``, optionally ``container_image``, and override
+        ``_build_local_args`` / ``_build_container_args`` /
+        ``_parse_results``. The base does discovery, dispatch
+        (local-or-container), error handling (execution_failed for
+        bad exit + empty stdout, parse_failed for parser exceptions
+        — same metadata shape the engine's container path emits),
+        and the engine-compatible ScanResult shape.
+
+      Migrations in this PR:
+      * HadolintLinter — full migration to FileDiscoveryScanner
+        (~30 lines saved). Custom _find_dockerfiles and
+        _build_docker_command gone.
+      * EslintLinter — switches its custom docker-fallback builder
+        to build_docker_command (~10 lines saved); keeps its
+        config-detection flow.
+      * TerraformLinter — same. Multi-step fmt/validate/tflint flow
+        stays bespoke (it doesn't fit FileDiscoveryScanner's
+        single-batched-call shape).
+      * yamllint, python_lint, jsonlint — keep their existing flow.
+        yamllint and python_lint use the "tool walks the workspace
+        itself" shape that doesn't benefit from discovery in Python.
+        jsonlint has a Python-stdlib fallback that the
+        FileDiscoveryScanner abstraction doesn't model. The new
+        helpers are available to them if a future change makes the
+        migration valuable.
+    alternatives_considered:
+      - name: "Single FileDiscoveryScanner base, force-fit every linter"
+        rejected_because: |
+          The "tool-walks-itself" linters (yamllint, python_lint,
+          eslint) never discover files in Python — the binary takes
+          a directory. Forcing them through a discovery layer would
+          add overhead without value, and break their config-aware
+          flows (eslint's no-eslint-config detection,
+          yamllint's Windows AppLocker fallback). Multi-step linters
+          like terraform fundamentally don't match a single-batch
+          shape.
+
+      - name: "Helpers only — skip the base class"
+        rejected_because: |
+          HadolintLinter and a future jsonlint migration genuinely
+          share a 5-step flow (discover → dispatch → run → check
+          for execution failure → parse). Open-coding it in each
+          subclass duplicates the metadata-shape contract that the
+          engine, reporters, and --fail-on-scanner-error all key
+          off of. The base class makes that contract enforceable.
+
+      - name: "Co-locate the helpers in scanner_template.py"
+        rejected_because: |
+          scanner_template.py targets security scanners that write
+          findings to an output file (run_subprocess_scan reads
+          back results.json from a tempdir). Linters typically
+          write findings to stdout and don't need a tempdir. The
+          two surfaces diverged enough that a separate module is
+          clearer.
+    consequences:
+      - "New linter contributors have a clear pattern: subclass FileDiscoveryScanner for discover-then-batch, or use the helpers in a custom scan() flow."
+      - "Adding container fallback to a new linter is one helper call (build_docker_command) instead of ~25 lines of duplicated ``docker run`` boilerplate."
+      - "UTF-8 + errors='replace' is the implicit default via run_utf8 — no more per-linter forgetting to add encoding='utf-8'."
+      - "Migrations are independent and additive: yamllint / python_lint / jsonlint can adopt the helpers later if a future change makes it useful, without coupling release cycles to this refactor."
+      - "The FileDiscoveryScanner base imposes its execution_failed / parse_failed metadata shape — keeps reporters' surface uniform across linters and security scanners."
+    related:
+      - ADR-013  # Python SDK as primary interface
+      - ADR-016  # Silent-failure gating (the metadata shape this preserves)
+      - ADR-018  # Canonical scanner output contract (parallel design choice)
+    pr_references:
+      - "#117 (build_args contract for security scanners — the parallel pattern this complements)"
+      - "#120 (HadolintLinter pre-batching — the optimization this PR's base captures generically)"

--- a/argus/core/linter_template.py
+++ b/argus/core/linter_template.py
@@ -1,0 +1,380 @@
+"""Shared helpers for linter implementations.
+
+Consolidates three concerns that were duplicated across the linter
+adapters:
+
+1. **File discovery** — walking the workspace for files matching a glob
+   pattern (originally re-implemented in `HadolintLinter._find_dockerfiles`,
+   `JsonlintLinter`'s inline `rglob`, etc.).
+2. **Docker fallback** — building the `docker run -v ws:/workspace ...`
+   command line when the local binary isn't installed (originally
+   duplicated across `HadolintLinter._build_docker_command`,
+   `EslintLinter._build_docker_command`, `TerraformLinter._docker_command`).
+3. **UTF-8 subprocess** — `subprocess.run(text=True)` falls back to the
+   platform default encoding (cp1252 on Windows), which breaks on
+   non-ASCII output. The shared helper pins `encoding='utf-8'` +
+   `errors='replace'` everywhere.
+
+Two consumption shapes:
+
+* **Helper functions** (`discover_files`, `build_docker_command`,
+  `run_utf8`) — for linters that have a custom `scan()` flow but want
+  to use the shared building blocks. Most existing linters use this
+  pattern.
+
+* **`FileDiscoveryScanner` base class** — for linters whose flow is
+  "walk for files matching a glob, run the tool against the file list
+  in one batched subprocess, parse the output." Subclasses declare
+  `name`, `file_glob`, `container_image` (optional),
+  `_build_local_args`, `_build_container_args`, `_parse_results`. The
+  base does discovery, dispatch (local → container), error handling,
+  and the engine-compatible `ScanResult` shape.
+
+The base is intentionally distinct from `argus.core.scanner_template`'s
+`run_subprocess_scan` (which targets security scanners writing to an
+output file). Linters typically write findings to stdout and don't
+need a tempdir.
+
+Reference: `docs/developer/SDK-ROADMAP.md` "FileDiscoveryScanner
+Template" section + ADR-020 in `.ai/decisions.yaml`.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Callable, Sequence
+
+from argus.core.models import Finding, ScanResult
+
+
+logger = logging.getLogger("argus.scanner")
+
+
+# --------------------------------------------------------------------- #
+# Helper functions                                                      #
+# --------------------------------------------------------------------- #
+
+
+def discover_files(
+    target: Path,
+    patterns: Sequence[str],
+    *,
+    exclusions: set[str] | None = None,
+) -> list[Path]:
+    """Walk *target* recursively for files matching any of *patterns*.
+
+    Returns the union of matches, sorted and deduplicated. When
+    *target* is itself a file, returns ``[target]`` regardless of the
+    pattern (the caller asked us to lint that exact file).
+
+    *exclusions* is a set of *path substrings* — any path containing
+    one is dropped. The default ``None`` performs no filtering. The
+    engine's full exclusion set lives in ``argus.core.exclusions``;
+    callers can build a substring set from it when finer-grained
+    filtering is needed.
+    """
+    if target.is_file():
+        return [target]
+
+    found: set[Path] = set()
+    for pattern in patterns:
+        for p in target.rglob(pattern):
+            if not p.is_file():
+                continue
+            if exclusions and any(ex in str(p) for ex in exclusions):
+                continue
+            found.add(p)
+    return sorted(found)
+
+
+def build_docker_command(
+    image: str,
+    workspace: Path | str,
+    container_args: Sequence[str],
+    *,
+    mount_rw: bool = False,
+    ws_mount: str = "/workspace",
+    workdir: str | None = None,
+) -> list[str]:
+    """Build a ``docker run --rm -v <workspace>:<ws_mount>[:ro] <image>
+    <container_args>`` command line.
+
+    Used as the container-fallback dispatch when the local linter
+    binary isn't installed but a ``container_image`` is declared on
+    the scanner class.
+
+    *workspace* is bind-mounted at *ws_mount* (default
+    ``/workspace``). *mount_rw* controls read-only vs read-write —
+    most linters need only read access, but ``terraform init`` writes
+    to ``.terraform/`` and ``tflint --init`` writes to ``.tflint.d/``,
+    so those need ``mount_rw=True``.
+
+    *workdir* sets the container's working directory via ``-w``. Most
+    linters don't need it; terraform does.
+
+    Returns the full argv list ready to pass to ``subprocess.run``.
+    The caller appends to *container_args* whatever args their linter
+    expects (the binary name, flags, file paths translated to
+    container-side equivalents). This builder doesn't try to do path
+    translation — that's caller-specific.
+    """
+    workspace_abs = str(Path(workspace).resolve())
+    mount_spec = f"{workspace_abs}:{ws_mount}" + ("" if mount_rw else ":ro")
+    cmd = ["docker", "run", "--rm", "-v", mount_spec]
+    if workdir:
+        cmd.extend(["-w", workdir])
+    cmd.append(image)
+    cmd.extend(container_args)
+    return cmd
+
+
+def run_utf8(
+    cmd: Sequence[str],
+    *,
+    cwd: str | Path | None = None,
+    timeout: float | None = None,
+) -> subprocess.CompletedProcess:
+    """``subprocess.run`` with explicit UTF-8 + ``errors='replace'``.
+
+    The platform default encoding (cp1252 on Windows) raises
+    ``UnicodeDecodeError`` on non-ASCII output (CVE descriptions, file
+    paths with unicode segments, scanner banners with arrows). This
+    helper pins UTF-8 so every linter handles non-ASCII identically.
+
+    ``errors='replace'`` is intentional: a security/lint tool showing
+    ``\\ufffd`` is better than crashing on otherwise-usable output.
+    """
+    return subprocess.run(
+        list(cmd),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        cwd=cwd,
+        timeout=timeout,
+    )
+
+
+# --------------------------------------------------------------------- #
+# FileDiscoveryScanner base class                                       #
+# --------------------------------------------------------------------- #
+
+
+class FileDiscoveryScanner:
+    """Base for linters that walk the workspace then batch-invoke a tool.
+
+    Two shapes a subclass declares:
+
+    * Class attributes: ``name``, ``file_glob`` (str or list[str]),
+      and optionally ``container_image``.
+    * Methods: ``_build_local_args(files, config)``,
+      ``_build_container_args(container_files, config)`` (only when a
+      container fallback is wanted), and ``_parse_results(stdout,
+      result)``.
+
+    The base implements ``scan()``: it discovers files matching
+    ``file_glob`` under the target path, builds the local command (or
+    falls back to container if the binary is missing and
+    ``container_image`` is declared), runs it via ``run_utf8``, and
+    hands the output to ``_parse_results`` for finding extraction.
+    Empty output with a non-zero exit code becomes
+    ``execution_failed`` metadata in the same shape the engine's
+    container path emits — reporters render the two paths
+    identically.
+
+    Subclasses still own ``is_available()``, ``install_command()``,
+    and ``tool_version()`` — the base doesn't try to dictate those
+    because the variation across linters (binary check vs. always-
+    available stdlib fallbacks like jsonlint) doesn't fit one shape.
+    """
+
+    # --- class-level configuration the subclass must declare ---
+    name: str = ""
+    file_glob: str | Sequence[str] = ()
+    container_image: str | None = None
+    binary: str = ""  # the local binary name; set so the base can shutil.which it
+
+    # --- subprocess behavior knobs ---
+    accept_returncodes: tuple[int, ...] = (0, 1)
+    """Exit codes treated as success. Most linters: 0 (clean) and 1
+    (findings). Override per-tool when the convention differs (e.g.,
+    yamllint uses ``> 1`` as the failure threshold)."""
+
+    require_stdout_on_failure: bool = True
+    """When the exit code is outside ``accept_returncodes`` AND
+    stdout is empty, treat as a real failure (set
+    ``execution_failed``). Override to ``False`` for tools that emit
+    findings only via stderr."""
+
+    # --- public API ---
+
+    def scan(self, path: str, config: dict | None = None) -> ScanResult:
+        config = config or {}
+        target = Path(path)
+        patterns = (
+            [self.file_glob] if isinstance(self.file_glob, str) else list(self.file_glob)
+        )
+
+        files = discover_files(target, patterns)
+        if not files:
+            return ScanResult(
+                scanner=self.name,
+                metadata={"info": f"No files matching {patterns} found"},
+            )
+
+        cmd, mode = self._dispatch_command(target, files, config)
+        if cmd is None:
+            return ScanResult(
+                scanner=self.name,
+                metadata={
+                    "execution_failed": True,
+                    "execution_failure_reason": (
+                        f"{self.binary or self.name} not installed and Docker "
+                        f"not available. Install the binary or install Docker "
+                        f"to use the container backend."
+                    ),
+                },
+            )
+
+        try:
+            result = run_utf8(cmd)
+        except FileNotFoundError as exc:
+            return ScanResult(
+                scanner=self.name,
+                metadata={
+                    "execution_failed": True,
+                    "execution_failure_reason": (
+                        f"{exc.filename or self.binary or self.name} not found "
+                        f"(race between is_available() and exec)."
+                    ),
+                },
+            )
+
+        stdout = (result.stdout or "").strip()
+        if (
+            result.returncode not in self.accept_returncodes
+            and (self.require_stdout_on_failure and not stdout)
+        ):
+            return ScanResult(
+                scanner=self.name,
+                metadata={
+                    "mode": mode,
+                    "execution_failed": True,
+                    "execution_failure_reason": (
+                        f"{self.name} exited {result.returncode}. "
+                        f"stderr: {(result.stderr or '').strip()[:400]}"
+                    ),
+                },
+            )
+
+        try:
+            findings = self._parse_results(stdout, result)
+        except Exception as exc:
+            return ScanResult(
+                scanner=self.name,
+                metadata={
+                    "mode": mode,
+                    "parse_failed": True,
+                    "parse_failure_reason": (
+                        f"{type(exc).__name__}: {exc}. "
+                        f"output head: {stdout[:200]!r}"
+                    ),
+                },
+            )
+
+        return ScanResult(
+            scanner=self.name,
+            findings=list(findings),
+            metadata={"mode": mode, "file_count": len(files)},
+        )
+
+    # --- subclass extension points ---
+
+    def _build_local_args(
+        self, files: Sequence[Path], config: dict
+    ) -> list[str]:
+        """Build the local-invocation argv (binary + flags + files).
+
+        Subclasses MUST override.
+        """
+        raise NotImplementedError
+
+    def _build_container_args(
+        self,
+        container_files: Sequence[str],
+        config: dict,
+    ) -> list[str]:
+        """Build the in-container argv to pass after ``docker run ... <image>``.
+
+        *container_files* are paths translated to their container-side
+        equivalents under ``/workspace``. Subclasses override this when
+        they want a container fallback. The default raises so a
+        subclass without ``container_image`` doesn't accidentally hit
+        the docker dispatch.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} did not declare a container fallback "
+            f"(no ``container_image`` or no ``_build_container_args`` override)."
+        )
+
+    def _parse_results(
+        self, stdout: str, completed: subprocess.CompletedProcess
+    ) -> list[Finding]:
+        """Convert the linter's stdout into a list of :class:`Finding`.
+
+        Subclasses MUST override. The full ``CompletedProcess`` is
+        passed for cases where stderr or returncode also informs
+        parsing.
+        """
+        raise NotImplementedError
+
+    # --- internals ---
+
+    def _dispatch_command(
+        self,
+        target: Path,
+        files: Sequence[Path],
+        config: dict,
+    ) -> tuple[list[str] | None, str]:
+        """Pick local-binary vs docker dispatch. Returns ``(cmd, mode)``.
+
+        ``mode`` is ``"local"`` or ``"container"`` — surfaced in the
+        returned ``ScanResult.metadata`` so the user can see which
+        path executed.
+        """
+        if self.binary and shutil.which(self.binary):
+            return self._build_local_args(files, config), "local"
+
+        if self.container_image and shutil.which("docker"):
+            target_abs = target.resolve()
+            container_files = [
+                f"/workspace/{f.resolve().relative_to(target_abs).as_posix()}"
+                for f in files
+                # If a discovered file isn't under target_abs (rare —
+                # symlinks pointing outside), skip it: the container
+                # mount only covers the workspace.
+                if _is_under(f.resolve(), target_abs)
+            ]
+            container_args = self._build_container_args(container_files, config)
+            return (
+                build_docker_command(
+                    self.container_image,
+                    target_abs,
+                    container_args,
+                ),
+                "container",
+            )
+
+        return None, "unavailable"
+
+
+def _is_under(path: Path, root: Path) -> bool:
+    """Return True if *path* is under *root* (inclusive)."""
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False

--- a/argus/linters/eslint.py
+++ b/argus/linters/eslint.py
@@ -21,6 +21,7 @@ import subprocess
 from pathlib import Path
 
 from argus.containers import get_image
+from argus.core.linter_template import build_docker_command
 from argus.core.models import Finding, ScanResult, Severity
 from argus.core.version import parse_tool_version
 
@@ -187,28 +188,29 @@ class EslintLinter:
     def _build_docker_command(
         self, target: Path, config: dict,
     ) -> list[str] | None:
-        """Build a ``docker run pipelinecomponents/eslint`` command, or None when Docker is unavailable."""
+        """Build a ``docker run pipelinecomponents/eslint`` command, or None when Docker is unavailable.
+
+        The ``pipelinecomponents/eslint`` image ships with eslint on
+        PATH and an ENTRYPOINT that passes its argv straight through,
+        so the in-container args are ``eslint --format json
+        --no-error-on-unmatched-pattern [--config ...] .``. The
+        workspace mount + ``-w /workspace`` come from the shared
+        ``build_docker_command`` helper.
+        """
         if shutil.which("docker") is None:
             return None
 
-        target_abs = str(target.resolve())
-        # ``pipelinecomponents/eslint`` ships with eslint on PATH and an
-        # ENTRYPOINT that lets us pass eslint args directly. Mount the
-        # workspace at /workspace so eslint can read both the source
-        # files and the project's eslint config from the same root.
-        cmd = [
-            "docker", "run", "--rm",
-            "-v", f"{target_abs}:/workspace:ro",
-            "-w", "/workspace",
-            self.container_image,
+        args = [
             "eslint",
             "--format", "json",
             "--no-error-on-unmatched-pattern",
         ]
         if config.get("config_file"):
-            cmd.extend(["--config", f"/workspace/{config['config_file']}"])
-        cmd.append(".")
-        return cmd
+            args.extend(["--config", f"/workspace/{config['config_file']}"])
+        args.append(".")
+        return build_docker_command(
+            self.container_image, target, args, workdir="/workspace",
+        )
 
     def _parse_message(self, msg: dict, file_path: str) -> Finding:
         """Convert a single ESLint message dict into a Finding."""

--- a/argus/linters/hadolint.py
+++ b/argus/linters/hadolint.py
@@ -1,4 +1,12 @@
-"""Dockerfile linter wrapping hadolint."""
+"""Dockerfile linter wrapping hadolint.
+
+Implemented on top of :class:`argus.core.linter_template.FileDiscoveryScanner`:
+the base does workspace discovery (glob ``Dockerfile*``), local→
+container dispatch, UTF-8 subprocess, and the
+``execution_failed`` / ``parse_failed`` metadata shape. Hadolint
+specifics live in three short methods: ``_build_local_args``,
+``_build_container_args``, and ``_parse_results``.
+"""
 
 import json
 import shutil
@@ -6,11 +14,12 @@ import subprocess
 from pathlib import Path
 
 from argus.containers import get_image
-from argus.core.models import Finding, ScanResult, Severity
+from argus.core.linter_template import FileDiscoveryScanner
+from argus.core.models import Finding, Severity
 from argus.core.version import parse_tool_version
 
 
-class HadolintLinter:
+class HadolintLinter(FileDiscoveryScanner):
     """Wraps hadolint to lint Dockerfiles for best-practice violations."""
 
     name = "lint-dockerfile"
@@ -18,172 +27,60 @@ class HadolintLinter:
     category = "linter"
     languages = ["dockerfile"]
     container_image = get_image("hadolint")
+    binary = "hadolint"
+    file_glob = "Dockerfile*"
 
-    def scan(self, path: str, config: dict | None = None) -> ScanResult:
-        """Find Dockerfiles under *path* and lint them all in one hadolint invocation.
-
-        Hadolint accepts multiple file paths on its CLI (``hadolint
-        file1 file2 ...``) and emits a single JSON array spanning every
-        file's findings. Doing one batched call beats spawning
-        ``len(dockerfiles)`` subprocesses by N startup costs and keeps
-        the per-finding ``file`` field intact in the parsed output.
-
-        When the local ``hadolint`` binary isn't installed, falls back
-        to the official ``hadolint/hadolint`` Docker image (declared as
-        ``container_image`` and pulled by argus's standard mechanism).
-        Hadolint is a single Haskell binary with no Python wrapper on
-        PyPI — the container is the cleanest way to run it on a
-        machine that doesn't have the binary, and avoids requiring
-        contributors to install yet another tool just to lint our
-        Dockerfiles.
-        """
-        config = config or {}
-        target = Path(path)
-
-        dockerfiles = self._find_dockerfiles(target)
-        if not dockerfiles:
-            return ScanResult(
-                scanner=self.name,
-                metadata={"info": "No Dockerfiles found"},
-            )
-
-        if self.is_available():
-            cmd = self._build_command(dockerfiles, config)
-        else:
-            cmd = self._build_docker_command(target, dockerfiles, config)
-            if cmd is None:
-                return ScanResult(
-                    scanner=self.name,
-                    metadata={
-                        "execution_failed": True,
-                        "execution_failure_reason": (
-                            "hadolint not installed and Docker not available. "
-                            "Install hadolint from "
-                            "https://github.com/hadolint/hadolint/releases "
-                            "or install Docker to use the container backend."
-                        ),
-                    },
-                )
-
-        result = subprocess.run(cmd, capture_output=True, text=True)
-
-        # hadolint exits 0 when clean, non-zero when findings exist —
-        # both are the happy path. Empty stdout means a real error
-        # (binary missing, parse failure inside hadolint, etc.).
-        if not result.stdout.strip():
-            return ScanResult(
-                scanner=self.name,
-                metadata={
-                    "execution_failed": True,
-                    "execution_failure_reason": (
-                        f"hadolint produced no output (exit={result.returncode}). "
-                        f"stderr: {(result.stderr or '').strip()[:400]}"
-                    ),
-                },
-            )
-
-        try:
-            data = json.loads(result.stdout)
-        except json.JSONDecodeError as exc:
-            return ScanResult(
-                scanner=self.name,
-                metadata={
-                    "execution_failed": True,
-                    "execution_failure_reason": f"Invalid JSON from hadolint: {exc}",
-                },
-            )
-
-        findings = [self._parse_item(item) for item in data]
-        return ScanResult(scanner=self.name, findings=findings)
+    # hadolint: 0 = clean, 1 = findings (happy path); we accept both.
+    accept_returncodes = (0, 1)
 
     def is_available(self) -> bool:
-        """Check if hadolint is installed."""
         return shutil.which("hadolint") is not None
 
     def install_command(self) -> str | None:
-        """Return install instructions for hadolint."""
         return "Install from https://github.com/hadolint/hadolint/releases"
 
     def tool_version(self) -> str | None:
-        """Return the installed hadolint version, or None if not available."""
         if not self.is_available():
             return None
         return parse_tool_version(["hadolint", "--version"], r"Linter (\d+\.\d+\.\d+)")
 
-    def _find_dockerfiles(self, target: Path) -> list[Path]:
-        """Find all Dockerfile-like files under the target path."""
-        if target.is_file():
-            return [target]
-        return sorted(target.rglob("Dockerfile*"))
+    def _build_local_args(
+        self, files: list[Path], config: dict
+    ) -> list[str]:
+        cmd = ["hadolint", "--format", "json"]
+        config_file = config.get("config_file")
+        if config_file:
+            cmd.extend(["--config", config_file])
+        for rule in config.get("ignore_rules", []) or []:
+            cmd.extend(["--ignore", rule])
+        cmd.extend(str(p) for p in files)
+        return cmd
 
-    def _build_docker_command(
-        self, target: Path, dockerfiles: list[Path], config: dict,
-    ) -> list[str] | None:
-        """Build a ``docker run hadolint ...`` command — local fallback for the container.
-
-        Returns ``None`` when Docker isn't available (the caller turns
-        that into a clean ``execution_failed`` row with both install
-        paths in the diagnostic). The mount is read-only; hadolint
-        only reads the Dockerfile contents and writes JSON to stdout.
-        """
-        if shutil.which("docker") is None:
-            return None
-
-        target_abs = target.resolve()
-        # Translate discovered host paths to their container-side
-        # equivalent under /workspace. dockerfiles came back from
-        # ``rglob`` on ``target`` so they're guaranteed to be under it.
-        container_paths = [
-            f"/workspace/{df.resolve().relative_to(target_abs).as_posix()}"
-            for df in dockerfiles
-        ]
-
+    def _build_container_args(
+        self, container_files: list[str], config: dict
+    ) -> list[str]:
         # The hadolint/hadolint image has no ENTRYPOINT — its CMD is
         # ``["/bin/hadolint", "-"]`` so passing args at the end of
         # ``docker run`` replaces CMD entirely. Include the binary
         # name explicitly as the first arg.
-        cmd = [
-            "docker", "run", "--rm",
-            "-v", f"{target_abs}:/workspace:ro",
-            self.container_image,
-            "hadolint",
-            "--format", "json",
-        ]
+        args = ["hadolint", "--format", "json"]
         config_file = config.get("config_file")
         if config_file:
-            cmd.extend(["--config", f"/workspace/{config_file}"])
+            args.extend(["--config", f"/workspace/{config_file}"])
         for rule in config.get("ignore_rules", []) or []:
-            cmd.extend(["--ignore", rule])
-        cmd.extend(container_paths)
-        return cmd
+            args.extend(["--ignore", rule])
+        args.extend(container_files)
+        return args
 
-    def _build_command(
-        self, dockerfiles: list[Path], config: dict
-    ) -> list[str]:
-        """Build a single hadolint command covering every Dockerfile.
-
-        Hadolint takes multiple file arguments and emits one combined
-        JSON array — far cheaper than spawning a process per file.
-        """
-        cmd = ["hadolint", "--format", "json"]
-
-        config_file = config.get("config_file")
-        if config_file:
-            cmd.extend(["--config", config_file])
-
-        for rule in config.get("ignore_rules", []) or []:
-            cmd.extend(["--ignore", rule])
-
-        cmd.extend(str(p) for p in dockerfiles)
-        return cmd
+    def _parse_results(
+        self, stdout: str, completed: subprocess.CompletedProcess
+    ) -> list[Finding]:
+        if not stdout:
+            return []
+        data = json.loads(stdout)
+        return [self._parse_item(item) for item in data]
 
     def _parse_item(self, item: dict) -> Finding:
-        """Convert a single hadolint JSON result into a Finding.
-
-        Hadolint emits the source file as ``item["file"]`` when it ran
-        against multiple paths — we use that directly instead of
-        threading the path in via the caller.
-        """
         rule_code = item.get("code", "UNKNOWN")
         line_num = item.get("line", 0)
         dockerfile = item.get("file", "")

--- a/argus/linters/terraform.py
+++ b/argus/linters/terraform.py
@@ -3,9 +3,9 @@
 import json
 import shutil
 import subprocess
-from pathlib import Path
 
 from argus.containers import get_image
+from argus.core.linter_template import build_docker_command
 from argus.core.models import Finding, ScanResult, Severity
 from argus.core.version import parse_tool_version
 
@@ -69,39 +69,32 @@ class TerraformLinter:
                 ["terraform", *args],
                 capture_output=True, text=True, cwd=path,
             )
-        cmd = self._docker_command(get_image("terraform"), path, args)
+        cmd = build_docker_command(
+            get_image("terraform"), path, args,
+            mount_rw=True, workdir="/workspace",
+        )
         return subprocess.run(cmd, capture_output=True, text=True)
 
     def _run_tflint_subprocess(self, args: list[str], path: str) -> subprocess.CompletedProcess | None:
-        """Run ``tflint <args>``, returning None when neither local nor docker is available."""
+        """Run ``tflint <args>``, returning None when neither local nor docker is available.
+
+        The mount is read-write because ``terraform init`` and
+        ``tflint --init`` write plugin state under ``.terraform/`` and
+        ``.tflint.d/`` respectively. The user's repo is already where
+        terraform would write locally; RW preserves that contract.
+        """
         if shutil.which("tflint"):
             return subprocess.run(
                 ["tflint", *args],
                 capture_output=True, text=True, cwd=path,
             )
         if shutil.which("docker"):
-            cmd = self._docker_command(get_image("tflint"), path, args)
+            cmd = build_docker_command(
+                get_image("tflint"), path, args,
+                mount_rw=True, workdir="/workspace",
+            )
             return subprocess.run(cmd, capture_output=True, text=True)
         return None
-
-    @staticmethod
-    def _docker_command(image: str, workspace: str, args: list[str]) -> list[str]:
-        """Build a ``docker run -v <workspace>:/workspace -w /workspace <image> <args>``.
-
-        The mount is read-write so ``terraform init`` can write
-        ``.terraform/`` plugin state. tflint also writes to a
-        ``.tflint.d/`` subdir on init. The user's repo is already where
-        terraform would write locally; mounting RW preserves that
-        contract.
-        """
-        workspace_abs = str(Path(workspace).resolve())
-        return [
-            "docker", "run", "--rm",
-            "-v", f"{workspace_abs}:/workspace",
-            "-w", "/workspace",
-            image,
-            *args,
-        ]
 
     # ------------------------------------------------------------------
     # Per-tool runners

--- a/argus/tests/core/test_linter_template.py
+++ b/argus/tests/core/test_linter_template.py
@@ -1,0 +1,422 @@
+"""Tests for argus.core.linter_template.
+
+Locks in the contract every migrated linter consumes: file discovery,
+docker-fallback command building, UTF-8 subprocess, and the
+FileDiscoveryScanner base's local→container dispatch + error
+handling.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from argus.core.linter_template import (
+    FileDiscoveryScanner,
+    build_docker_command,
+    discover_files,
+    run_utf8,
+)
+from argus.core.models import Finding, Severity
+
+
+# --------------------------------------------------------------------- #
+# discover_files                                                        #
+# --------------------------------------------------------------------- #
+
+
+class TestDiscoverFiles:
+
+    def test_target_is_file_returns_just_that_file(self, tmp_path):
+        f = tmp_path / "Dockerfile"
+        f.write_text("FROM scratch")
+        assert discover_files(f, ["Dockerfile*"]) == [f]
+
+    def test_walks_recursively_for_glob_match(self, tmp_path):
+        (tmp_path / "a").mkdir()
+        (tmp_path / "a" / "Dockerfile").write_text("FROM scratch")
+        (tmp_path / "b").mkdir()
+        (tmp_path / "b" / "Dockerfile.api").write_text("FROM alpine")
+        (tmp_path / "b" / "ignore.txt").write_text("nope")
+
+        result = discover_files(tmp_path, ["Dockerfile*"])
+        names = sorted(p.name for p in result)
+        assert names == ["Dockerfile", "Dockerfile.api"]
+
+    def test_multiple_patterns_unioned(self, tmp_path):
+        (tmp_path / "a.json").write_text("{}")
+        (tmp_path / "b.yml").write_text("k: v")
+        (tmp_path / "c.txt").write_text("nope")
+
+        result = discover_files(tmp_path, ["*.json", "*.yml"])
+        names = sorted(p.name for p in result)
+        assert names == ["a.json", "b.yml"]
+
+    def test_results_are_deduplicated(self, tmp_path):
+        # Same file matched by two patterns shouldn't appear twice.
+        (tmp_path / "Dockerfile").write_text("FROM scratch")
+        result = discover_files(tmp_path, ["Dockerfile", "Dockerfile*"])
+        assert len(result) == 1
+
+    def test_results_sorted(self, tmp_path):
+        (tmp_path / "z.json").write_text("{}")
+        (tmp_path / "a.json").write_text("{}")
+        (tmp_path / "m.json").write_text("{}")
+        result = discover_files(tmp_path, ["*.json"])
+        assert [p.name for p in result] == ["a.json", "m.json", "z.json"]
+
+    def test_directories_are_not_returned(self, tmp_path):
+        # A directory whose name matches the glob shouldn't be returned;
+        # only files.
+        (tmp_path / "Dockerfile").mkdir()
+        (tmp_path / "Dockerfile.api").write_text("FROM scratch")
+        result = discover_files(tmp_path, ["Dockerfile*"])
+        assert [p.name for p in result] == ["Dockerfile.api"]
+
+    def test_exclusions_filter_substring_matches(self, tmp_path):
+        (tmp_path / "good.json").write_text("{}")
+        (tmp_path / "node_modules").mkdir()
+        (tmp_path / "node_modules" / "lib.json").write_text("{}")
+        result = discover_files(
+            tmp_path, ["*.json"], exclusions={"node_modules"},
+        )
+        assert [p.name for p in result] == ["good.json"]
+
+    def test_no_matches_returns_empty_list(self, tmp_path):
+        assert discover_files(tmp_path, ["*.no-match"]) == []
+
+
+# --------------------------------------------------------------------- #
+# build_docker_command                                                  #
+# --------------------------------------------------------------------- #
+
+
+class TestBuildDockerCommand:
+
+    def test_basic_shape(self, tmp_path):
+        cmd = build_docker_command(
+            "myimg:latest", tmp_path, ["--flag", "/workspace/file"],
+        )
+        # docker run --rm -v <abs>:/workspace:ro myimg:latest --flag ...
+        assert cmd[0:3] == ["docker", "run", "--rm"]
+        assert cmd[3] == "-v"
+        assert cmd[4].endswith(":/workspace:ro")
+        assert cmd[5] == "myimg:latest"
+        assert cmd[6:] == ["--flag", "/workspace/file"]
+
+    def test_mount_rw_drops_ro_suffix(self, tmp_path):
+        cmd = build_docker_command(
+            "img", tmp_path, ["x"], mount_rw=True,
+        )
+        v_index = cmd.index("-v")
+        spec = cmd[v_index + 1]
+        assert spec.endswith(":/workspace")
+        assert not spec.endswith(":ro")
+
+    def test_workdir_inserts_dash_w_before_image(self, tmp_path):
+        cmd = build_docker_command(
+            "img", tmp_path, ["x"], workdir="/workspace",
+        )
+        # -w must come BEFORE the image name (image is the docker run
+        # positional after flags).
+        w_index = cmd.index("-w")
+        img_index = cmd.index("img")
+        assert w_index < img_index
+        assert cmd[w_index + 1] == "/workspace"
+
+    def test_custom_ws_mount_path_used(self, tmp_path):
+        cmd = build_docker_command(
+            "img", tmp_path, ["x"], ws_mount="/scan",
+        )
+        assert any(c.endswith(":/scan:ro") for c in cmd)
+
+    def test_workspace_is_resolved_to_absolute(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cmd = build_docker_command("img", Path("."), ["x"])
+        # Spec must be absolute (`/`-rooted on Unix).
+        v_index = cmd.index("-v")
+        spec = cmd[v_index + 1]
+        assert spec.startswith("/")
+
+
+# --------------------------------------------------------------------- #
+# run_utf8                                                              #
+# --------------------------------------------------------------------- #
+
+
+class TestRunUtf8:
+
+    def test_passes_encoding_replace(self):
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured.update(kwargs)
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            run_utf8(["echo", "hi"])
+
+        assert captured["encoding"] == "utf-8"
+        assert captured["errors"] == "replace"
+        assert captured["text"] is True
+        assert captured["capture_output"] is True
+
+    def test_threads_cwd_through(self, tmp_path):
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured.update(kwargs)
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            run_utf8(["echo"], cwd=tmp_path)
+
+        assert captured["cwd"] == tmp_path
+
+    def test_threads_timeout_through(self):
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured.update(kwargs)
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            run_utf8(["echo"], timeout=5)
+
+        assert captured["timeout"] == 5
+
+
+# --------------------------------------------------------------------- #
+# FileDiscoveryScanner — base class behavior                            #
+# --------------------------------------------------------------------- #
+
+
+class _TestableScanner(FileDiscoveryScanner):
+    """Concrete subclass purely for testing the base."""
+
+    name = "lint-test"
+    file_glob = "*.txt"
+    binary = "fake-binary"
+    container_image = "fake/image:latest"
+
+    def _build_local_args(self, files, config):
+        return [self.binary, *[str(f) for f in files]]
+
+    def _build_container_args(self, container_files, config):
+        return [self.binary, *container_files]
+
+    def _parse_results(self, stdout, completed):
+        # One Finding per nonempty line in stdout.
+        return [
+            Finding(
+                id="x", severity=Severity.INFO,
+                title=line, description=line, scanner=self.name,
+            )
+            for line in stdout.splitlines()
+            if line.strip()
+        ]
+
+
+def _completed(stdout="", stderr="", returncode=0):
+    return subprocess.CompletedProcess(
+        args=["fake"], returncode=returncode, stdout=stdout, stderr=stderr,
+    )
+
+
+class TestFileDiscoveryScanner:
+
+    def test_no_matching_files_returns_clean_info_row(self, tmp_path):
+        # Empty workspace — no *.txt anywhere.
+        result = _TestableScanner().scan(str(tmp_path))
+        assert result.findings == []
+        assert "No files matching" in result.metadata.get("info", "")
+        assert result.metadata.get("execution_failed") is not True
+
+    def test_local_dispatch_when_binary_on_path(self, tmp_path):
+        (tmp_path / "a.txt").write_text("x")
+        (tmp_path / "b.txt").write_text("y")
+        captured_cmd = {}
+
+        def fake_run(cmd, **kwargs):
+            captured_cmd["cmd"] = cmd
+            return _completed(stdout="line1\nline2\n")
+
+        with patch("argus.core.linter_template.shutil.which") as mock_which, \
+             patch("argus.core.linter_template.subprocess.run", side_effect=fake_run):
+            mock_which.side_effect = lambda b: f"/usr/bin/{b}" if b == "fake-binary" else None
+            result = _TestableScanner().scan(str(tmp_path))
+
+        # Two findings parsed; metadata says local mode.
+        assert len(result.findings) == 2
+        assert result.metadata["mode"] == "local"
+        assert result.metadata["file_count"] == 2
+        # Local args used the binary directly.
+        assert captured_cmd["cmd"][0] == "fake-binary"
+        assert captured_cmd["cmd"][1].endswith(".txt")
+
+    def test_falls_back_to_container_when_binary_missing(self, tmp_path):
+        (tmp_path / "a.txt").write_text("x")
+        captured_cmd = {}
+
+        def fake_run(cmd, **kwargs):
+            captured_cmd["cmd"] = cmd
+            return _completed(stdout="found something\n")
+
+        def fake_which(b):
+            # Binary missing, docker present.
+            return "/usr/bin/docker" if b == "docker" else None
+
+        with patch("argus.core.linter_template.shutil.which", side_effect=fake_which), \
+             patch("argus.core.linter_template.subprocess.run", side_effect=fake_run):
+            result = _TestableScanner().scan(str(tmp_path))
+
+        assert result.metadata["mode"] == "container"
+        # Command starts with `docker run --rm -v ... fake/image:latest fake-binary ...`
+        assert captured_cmd["cmd"][0] == "docker"
+        assert "fake/image:latest" in captured_cmd["cmd"]
+        assert "fake-binary" in captured_cmd["cmd"]
+        # Container files use /workspace prefix
+        assert any(arg.startswith("/workspace/") for arg in captured_cmd["cmd"])
+
+    def test_unavailable_when_neither_binary_nor_docker(self, tmp_path):
+        (tmp_path / "a.txt").write_text("x")
+
+        with patch("argus.core.linter_template.shutil.which", return_value=None):
+            result = _TestableScanner().scan(str(tmp_path))
+
+        assert result.metadata["execution_failed"] is True
+        reason = result.metadata.get("execution_failure_reason", "")
+        assert "not installed" in reason
+        assert "Docker" in reason
+
+    def test_filenotfound_during_run_emits_execution_failed(self, tmp_path):
+        (tmp_path / "a.txt").write_text("x")
+
+        def fake_which(b):
+            return f"/usr/bin/{b}" if b == "fake-binary" else None
+
+        with patch("argus.core.linter_template.shutil.which", side_effect=fake_which), \
+             patch(
+                 "argus.core.linter_template.subprocess.run",
+                 side_effect=FileNotFoundError(2, "no such file", "fake-binary"),
+             ):
+            result = _TestableScanner().scan(str(tmp_path))
+
+        assert result.metadata["execution_failed"] is True
+        assert "fake-binary" in result.metadata["execution_failure_reason"]
+
+    def test_high_exit_with_no_stdout_marks_execution_failed(self, tmp_path):
+        (tmp_path / "a.txt").write_text("x")
+
+        def fake_which(b):
+            return f"/usr/bin/{b}" if b == "fake-binary" else None
+
+        def fake_run(cmd, **kwargs):
+            return _completed(stdout="", stderr="boom", returncode=42)
+
+        with patch("argus.core.linter_template.shutil.which", side_effect=fake_which), \
+             patch("argus.core.linter_template.subprocess.run", side_effect=fake_run):
+            result = _TestableScanner().scan(str(tmp_path))
+
+        assert result.metadata["execution_failed"] is True
+        assert "exited 42" in result.metadata["execution_failure_reason"]
+        assert "boom" in result.metadata["execution_failure_reason"]
+
+    def test_findings_returncode_does_not_mark_failed(self, tmp_path):
+        # Default accept_returncodes is (0, 1) — exit 1 with output is
+        # the "lint findings present" happy path.
+        (tmp_path / "a.txt").write_text("x")
+
+        def fake_which(b):
+            return f"/usr/bin/{b}" if b == "fake-binary" else None
+
+        def fake_run(cmd, **kwargs):
+            return _completed(stdout="finding-line\n", returncode=1)
+
+        with patch("argus.core.linter_template.shutil.which", side_effect=fake_which), \
+             patch("argus.core.linter_template.subprocess.run", side_effect=fake_run):
+            result = _TestableScanner().scan(str(tmp_path))
+
+        assert len(result.findings) == 1
+        assert result.metadata.get("execution_failed") is not True
+
+    def test_parse_exception_marks_parse_failed(self, tmp_path):
+        # parse_failed is the third state — scanner ran AND produced
+        # output, we just couldn't interpret it.
+        (tmp_path / "a.txt").write_text("x")
+
+        class BoomParser(_TestableScanner):
+            def _parse_results(self, stdout, completed):
+                raise ValueError("malformed")
+
+        def fake_which(b):
+            return f"/usr/bin/{b}" if b == "fake-binary" else None
+
+        def fake_run(cmd, **kwargs):
+            return _completed(stdout="some output")
+
+        with patch("argus.core.linter_template.shutil.which", side_effect=fake_which), \
+             patch("argus.core.linter_template.subprocess.run", side_effect=fake_run):
+            result = BoomParser().scan(str(tmp_path))
+
+        assert result.metadata.get("parse_failed") is True
+        assert "ValueError" in result.metadata.get("parse_failure_reason", "")
+        # Distinct from execution_failed — these are orthogonal signals.
+        assert result.metadata.get("execution_failed") is not True
+
+    def test_target_is_a_single_file(self, tmp_path):
+        f = tmp_path / "single.txt"
+        f.write_text("x")
+
+        def fake_which(b):
+            return f"/usr/bin/{b}" if b == "fake-binary" else None
+
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return _completed(stdout="finding\n")
+
+        with patch("argus.core.linter_template.shutil.which", side_effect=fake_which), \
+             patch("argus.core.linter_template.subprocess.run", side_effect=fake_run):
+            result = _TestableScanner().scan(str(f))
+
+        assert result.metadata["file_count"] == 1
+        assert any("single.txt" in c for c in captured["cmd"])
+
+    def test_subclass_must_implement_local_args_when_local_path_used(
+        self, tmp_path
+    ):
+        class Incomplete(FileDiscoveryScanner):
+            name = "incomplete"
+            file_glob = "*.x"
+            binary = "fake"
+
+        (tmp_path / "a.x").write_text("x")
+        with patch(
+            "argus.core.linter_template.shutil.which",
+            side_effect=lambda b: f"/usr/bin/{b}" if b == "fake" else None,
+        ), pytest.raises(NotImplementedError):
+            Incomplete().scan(str(tmp_path))
+
+    def test_multi_glob_class_attr_supported(self, tmp_path):
+        class MultiGlob(_TestableScanner):
+            file_glob = ["*.json", "*.yml"]
+
+        (tmp_path / "a.json").write_text("{}")
+        (tmp_path / "b.yml").write_text("k: v")
+
+        def fake_which(b):
+            return f"/usr/bin/{b}" if b == "fake-binary" else None
+
+        def fake_run(cmd, **kwargs):
+            return _completed(stdout="line\n")
+
+        with patch("argus.core.linter_template.shutil.which", side_effect=fake_which), \
+             patch("argus.core.linter_template.subprocess.run", side_effect=fake_run):
+            result = MultiGlob().scan(str(tmp_path))
+
+        assert result.metadata["file_count"] == 2

--- a/argus/tests/linters/test_hadolint.py
+++ b/argus/tests/linters/test_hadolint.py
@@ -1,0 +1,261 @@
+"""Tests for argus.linters.hadolint.HadolintLinter.
+
+Locks in the FileDiscoveryScanner-based behavior after the
+linter_template migration: discovery of Dockerfile* files, batched
+single-subprocess invocation (local), docker fallback when the
+binary is missing, JSON output parsing, and the
+``execution_failed`` / ``parse_failed`` metadata shapes.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from argus.core.models import Severity
+from argus.linters.hadolint import HadolintLinter
+
+
+def _completed(stdout="", stderr="", returncode=0):
+    return subprocess.CompletedProcess(
+        args=["hadolint"], returncode=returncode, stdout=stdout, stderr=stderr,
+    )
+
+
+# ---------------------------------------------------------------- #
+# Metadata + protocol surface                                      #
+# ---------------------------------------------------------------- #
+
+
+class TestHadolintLinterMeta:
+
+    def test_name(self):
+        assert HadolintLinter().name == "lint-dockerfile"
+
+    def test_category(self):
+        assert HadolintLinter().category == "linter"
+
+    def test_languages(self):
+        assert "dockerfile" in HadolintLinter().languages
+
+    def test_install_command_returns_string(self):
+        assert isinstance(HadolintLinter().install_command(), str)
+
+    def test_file_glob(self):
+        assert HadolintLinter.file_glob == "Dockerfile*"
+
+    def test_container_image_declared(self):
+        assert HadolintLinter.container_image
+        assert "hadolint" in HadolintLinter.container_image.lower()
+
+    def test_binary_attribute(self):
+        # Required by the FileDiscoveryScanner base for shutil.which.
+        assert HadolintLinter.binary == "hadolint"
+
+    def test_accept_returncodes_includes_findings_path(self):
+        # hadolint exits 1 when findings exist; that's the happy
+        # path, not an execution failure.
+        assert 1 in HadolintLinter.accept_returncodes
+
+
+# ---------------------------------------------------------------- #
+# scan() — discovery + dispatch                                    #
+# ---------------------------------------------------------------- #
+
+
+class TestHadolintScan:
+
+    def test_no_dockerfiles_returns_clean_info_row(self, tmp_path):
+        result = HadolintLinter().scan(str(tmp_path))
+        assert result.findings == []
+        assert "No files matching" in result.metadata.get("info", "")
+
+    def test_local_invocation_when_binary_present(self, tmp_path):
+        (tmp_path / "Dockerfile").write_text("FROM scratch")
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return _completed(stdout=json.dumps([{
+                "code": "DL3001",
+                "line": 1,
+                "column": 1,
+                "level": "warning",
+                "file": "Dockerfile",
+                "message": "Useless cd",
+            }]))
+
+        with patch("argus.core.linter_template.shutil.which") as mw, \
+             patch("argus.core.linter_template.subprocess.run", side_effect=fake_run):
+            mw.side_effect = lambda b: f"/usr/bin/{b}" if b == "hadolint" else None
+            result = HadolintLinter().scan(str(tmp_path))
+
+        # Local mode used.
+        assert result.metadata["mode"] == "local"
+        assert result.metadata["file_count"] == 1
+        # Local args use the binary directly + json format.
+        assert captured["cmd"][0] == "hadolint"
+        assert "--format" in captured["cmd"]
+        assert "json" in captured["cmd"]
+        # Findings parsed.
+        assert len(result.findings) == 1
+        assert result.findings[0].id == "DL3001"
+        assert result.findings[0].severity == Severity.INFO
+        assert result.findings[0].location == "Dockerfile:1"
+
+    def test_container_fallback_when_binary_missing(self, tmp_path):
+        (tmp_path / "Dockerfile").write_text("FROM alpine")
+        captured = {}
+
+        def fake_which(b):
+            return "/usr/bin/docker" if b == "docker" else None
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return _completed(stdout="[]")
+
+        with patch("argus.core.linter_template.shutil.which", side_effect=fake_which), \
+             patch("argus.core.linter_template.subprocess.run", side_effect=fake_run):
+            result = HadolintLinter().scan(str(tmp_path))
+
+        assert result.metadata["mode"] == "container"
+        assert captured["cmd"][0] == "docker"
+        # Container path includes the image and the binary as args.
+        assert HadolintLinter.container_image in captured["cmd"]
+        assert "hadolint" in captured["cmd"]
+        # Container files are translated to /workspace/...
+        assert any(arg.startswith("/workspace/") for arg in captured["cmd"])
+
+    def test_unavailable_when_neither_binary_nor_docker(self, tmp_path):
+        (tmp_path / "Dockerfile").write_text("FROM scratch")
+        with patch("argus.core.linter_template.shutil.which", return_value=None):
+            result = HadolintLinter().scan(str(tmp_path))
+        assert result.metadata["execution_failed"] is True
+        assert "hadolint" in result.metadata["execution_failure_reason"]
+
+    def test_findings_with_exit_1_are_happy_path(self, tmp_path):
+        # Exit 1 from hadolint = findings present. Must not be an
+        # execution failure.
+        (tmp_path / "Dockerfile").write_text("FROM scratch")
+
+        def fake_which(b):
+            return f"/usr/bin/{b}" if b == "hadolint" else None
+
+        def fake_run(cmd, **kwargs):
+            return _completed(
+                stdout=json.dumps([{
+                    "code": "DL3025", "line": 1, "level": "warning",
+                    "file": "Dockerfile", "message": "Use arguments JSON form",
+                }]),
+                returncode=1,
+            )
+
+        with patch("argus.core.linter_template.shutil.which", side_effect=fake_which), \
+             patch("argus.core.linter_template.subprocess.run", side_effect=fake_run):
+            result = HadolintLinter().scan(str(tmp_path))
+
+        assert len(result.findings) == 1
+        assert result.metadata.get("execution_failed") is not True
+
+    def test_malformed_json_marks_parse_failed(self, tmp_path):
+        (tmp_path / "Dockerfile").write_text("FROM alpine")
+
+        def fake_which(b):
+            return f"/usr/bin/{b}" if b == "hadolint" else None
+
+        def fake_run(cmd, **kwargs):
+            return _completed(stdout="not really json")
+
+        with patch("argus.core.linter_template.shutil.which", side_effect=fake_which), \
+             patch("argus.core.linter_template.subprocess.run", side_effect=fake_run):
+            result = HadolintLinter().scan(str(tmp_path))
+
+        assert result.metadata["parse_failed"] is True
+        assert "JSONDecodeError" in result.metadata["parse_failure_reason"]
+
+    def test_multiple_dockerfiles_batched_in_one_call(self, tmp_path):
+        # Roadmap motivation: avoid N subprocess startups for N files.
+        (tmp_path / "Dockerfile").write_text("FROM alpine")
+        (tmp_path / "Dockerfile.api").write_text("FROM alpine")
+        (tmp_path / "sub").mkdir()
+        (tmp_path / "sub" / "Dockerfile").write_text("FROM scratch")
+
+        def fake_which(b):
+            return f"/usr/bin/{b}" if b == "hadolint" else None
+
+        call_count = {"n": 0}
+
+        def fake_run(cmd, **kwargs):
+            call_count["n"] += 1
+            return _completed(stdout="[]")
+
+        with patch("argus.core.linter_template.shutil.which", side_effect=fake_which), \
+             patch("argus.core.linter_template.subprocess.run", side_effect=fake_run):
+            result = HadolintLinter().scan(str(tmp_path))
+
+        assert call_count["n"] == 1, "hadolint must be invoked once for the whole batch"
+        assert result.metadata["file_count"] == 3
+
+    def test_config_file_threaded_into_local_args(self, tmp_path):
+        (tmp_path / "Dockerfile").write_text("FROM scratch")
+        captured = {}
+
+        def fake_which(b):
+            return f"/usr/bin/{b}" if b == "hadolint" else None
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return _completed(stdout="[]")
+
+        with patch("argus.core.linter_template.shutil.which", side_effect=fake_which), \
+             patch("argus.core.linter_template.subprocess.run", side_effect=fake_run):
+            HadolintLinter().scan(str(tmp_path), config={"config_file": ".hadolint.yaml"})
+
+        assert "--config" in captured["cmd"]
+        idx = captured["cmd"].index("--config")
+        assert captured["cmd"][idx + 1] == ".hadolint.yaml"
+
+    def test_ignore_rules_threaded_into_local_args(self, tmp_path):
+        (tmp_path / "Dockerfile").write_text("FROM scratch")
+        captured = {}
+
+        def fake_which(b):
+            return f"/usr/bin/{b}" if b == "hadolint" else None
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return _completed(stdout="[]")
+
+        with patch("argus.core.linter_template.shutil.which", side_effect=fake_which), \
+             patch("argus.core.linter_template.subprocess.run", side_effect=fake_run):
+            HadolintLinter().scan(
+                str(tmp_path), config={"ignore_rules": ["DL3025", "DL3008"]},
+            )
+
+        # Each rule passed as a separate --ignore <rule> pair.
+        cmd = captured["cmd"]
+        assert cmd.count("--ignore") == 2
+        ignored = [cmd[i + 1] for i, c in enumerate(cmd) if c == "--ignore"]
+        assert "DL3025" in ignored
+        assert "DL3008" in ignored
+
+    def test_empty_stdout_with_zero_exit_returns_no_findings(self, tmp_path):
+        # Exit 0 + empty stdout = no findings. Some hadolint versions
+        # emit nothing at all when there's nothing to report.
+        (tmp_path / "Dockerfile").write_text("FROM scratch")
+
+        def fake_which(b):
+            return f"/usr/bin/{b}" if b == "hadolint" else None
+
+        def fake_run(cmd, **kwargs):
+            return _completed(stdout="", returncode=0)
+
+        with patch("argus.core.linter_template.shutil.which", side_effect=fake_which), \
+             patch("argus.core.linter_template.subprocess.run", side_effect=fake_run):
+            result = HadolintLinter().scan(str(tmp_path))
+
+        assert result.findings == []
+        assert result.metadata.get("execution_failed") is not True

--- a/docs/developer/SDK-ROADMAP.md
+++ b/docs/developer/SDK-ROADMAP.md
@@ -628,7 +628,26 @@ All engine, scanner, and testing issues from the migration have been resolved.
 
 ---
 
-## FileDiscoveryScanner Template
+## FileDiscoveryScanner Template ✅ shipped
+
+Initial implementation: `argus/core/linter_template.py` exports
+`FileDiscoveryScanner` (workspace walk → batched subprocess →
+local-or-container dispatch → parse) plus three building-block
+helpers (`discover_files`, `build_docker_command`, `run_utf8`).
+`HadolintLinter` is migrated to subclass it (~30 lines saved
+versus the old custom `_find_dockerfiles` + duplicated
+`_build_docker_command` flow). `EslintLinter` and
+`TerraformLinter` switched their custom docker-fallback builders
+to the shared `build_docker_command` helper. Three linters
+remaining (`yamllint`, `python_lint`, `jsonlint`) keep their
+"tool walks the workspace itself" or "Python-stdlib fallback" flow
+since neither fits the FileDiscoveryScanner shape — `discover_files`
++ `run_utf8` are available if a future change ever needs them.
+Rationale + alternatives: ADR-020 in `.ai/decisions.yaml`.
+
+Original analysis below kept for context.
+
+---
 
 Linters (`lint-yaml`, `lint-json`, `lint-python`, `lint-javascript`, `lint-dockerfile`, `lint-terraform`) and a few security scanners share a shape that doesn't fit the standard `build_args(ScanPaths) → list[str]` contract introduced in PR #117: they need to **discover files of a specific shape under a workspace, then run their tool against those file paths** (not against the workspace as a whole). Today each one rolls its own `_find_*` walk + per-file subprocess loop in its `scan()` method, which has three problems:
 


### PR DESCRIPTION
## Description

Consolidates three concerns duplicated across the linter adapters into `argus/core/linter_template.py`: file discovery, docker fallback, and UTF-8 subprocess. Hadolint migrates fully to the new `FileDiscoveryScanner` base; eslint and terraform switch their custom docker-command builders to the shared helper. Closes the **"FileDiscoveryScanner Template"** roadmap section.

## Changes Made
- [ ] Added new scanner/workflow
- [x] Modified existing scanner/workflow
- [x] Updated documentation
- [ ] Fixed bug
- [x] Other (please specify) — refactor + new shared helper module + ADR

### Details

**`argus/core/linter_template.py` (new)** exports four pieces:

| Surface | Purpose |
|---|---|
| `discover_files(target, patterns, exclusions=None)` | Workspace walk helper used by `FileDiscoveryScanner` internally and available to any custom flow |
| `build_docker_command(image, workspace, args, mount_rw, ws_mount, workdir)` | Single source of truth for the `docker run -v <ws>:/workspace ...` shape |
| `run_utf8(cmd, cwd=None, timeout=None)` | Explicit UTF-8 subprocess wrapper (replaces inline `encoding='utf-8'`+`errors='replace'`) |
| `FileDiscoveryScanner` (base class) | discover → dispatch → run → parse, with engine-compatible `ScanResult` shape and `execution_failed` / `parse_failed` metadata identical to the engine's container path |

**Migrations in this PR:**

- **`HadolintLinter`** — full migration to `FileDiscoveryScanner`. Custom `_find_dockerfiles` and `_build_docker_command` gone. ~80 line drop in the module. 18 new dedicated regression tests.
- **`EslintLinter`** — keeps its no-eslint-config detection and config-aware flow, routes the docker-fallback through `build_docker_command`. ~10 lines saved.
- **`TerraformLinter`** — same; the multi-step `fmt` / `validate` / `tflint` flow stays bespoke (doesn't fit `FileDiscoveryScanner`'s single-batched-call shape). `_docker_command` static method removed in favor of the helper.
- **`yamllint`, `python_lint`, `jsonlint`** — unchanged. They use either "tool walks the workspace itself" (no Python-side discovery) or a Python-stdlib fallback (`json.loads`) that the new abstraction doesn't model. Helpers are available to them if a future change makes the migration valuable.

### Why hybrid (helpers + opt-in base) instead of one base for all six

The 6 linters split into three execution shapes: tool-walks-itself (yamllint, python_lint, eslint), discover-then-batch (hadolint, jsonlint), and multi-step special case (terraform). A forced single hierarchy would either lose configuration nuance (eslint's no-config detection, yamllint's Windows AppLocker fallback) or fight terraform's multi-call shape. Helpers + an opt-in base captures the duplication that's actually duplication without forcing the abstraction.

Full rationale + alternatives in **ADR-020** in `.ai/decisions.yaml`.

### Cross-platform safety

- Pure refactor; no behavior change in any subsequent engine, reporter, or downstream step.
- `HadolintLinter` behavior preserved end-to-end — verified by 18 new dedicated tests (`test_hadolint.py`) plus the 27 base-class tests in `test_linter_template.py`.
- No platform branching introduced. Windows / Linux / macOS hit identical code paths.
- The `build_docker_command` helper uses `Path.resolve()` for the workspace, matching the previous inline behavior.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results

```
$ .venv/bin/python -m pytest argus/tests/ --no-cov -q
1789 passed, 8 skipped, 7 deselected

$ .venv/bin/python -m pytest --no-cov -q   # full pytest (npm test equivalent)
2872 passed, 10 skipped, 7 deselected
```

**45 new tests:**
- `argus/tests/core/test_linter_template.py` (27): `discover_files` (8 cases — file/dir/multi-pattern/dedup/sort/dirs-skipped/exclusions/empty), `build_docker_command` (5 — basic shape, mount_rw, workdir position, custom mount, abs path), `run_utf8` (3 — encoding kwargs, cwd thread, timeout thread), `FileDiscoveryScanner` (11 — empty workspace, local dispatch, container fallback, neither-available, FileNotFoundError mid-run, high exit + empty stdout, findings-on-exit-1, parse exception, single-file target, missing override, multi-glob)
- `argus/tests/linters/test_hadolint.py` (18): metadata + protocol surface (8 — name/category/languages/install/file_glob/container_image/binary/accept_returncodes), scan() flow (10 — no-dockerfiles/local/container/unavailable/findings-exit-1/malformed-JSON/multi-file batched/config-file/ignore-rules/empty-stdout)

## Security Considerations
- [x] No security impact
- [ ] Security enhancement
- [ ] Potential security implications

## AI Context Updates (.ai/)
- [x] `.ai/architecture.yaml` updated — linters section annotated with per-linter implementation pattern
- [ ] `.ai/workflows.yaml` updated
- [x] `.ai/decisions.yaml` updated — new ADR-020
- [ ] `.ai/errors.yaml` updated
- [ ] N/A - No .ai/ updates needed

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (if applicable) — `docs/developer/SDK-ROADMAP.md` FileDiscoveryScanner section marked shipped
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
N/A — closes the FileDiscoveryScanner Template roadmap section. Follow-up migrations of yamllint / python_lint / jsonlint remain available as incremental cleanup.