### PR TITLE
ci: audit example with-keys against current action.yml input contracts

### DIFF
--- a/.github/workflows/test-examples-functional.yml
+++ b/.github/workflows/test-examples-functional.yml
@@ -210,6 +210,55 @@ jobs:
           done
 
   # ============================================================================
+  # Audit example workflows against current action.yml input contracts
+  # Runs once across the whole tree (cross-action correlation, not
+  # per-example). Catches the bug class where a contract trim leaves
+  # documented examples passing inputs the action no longer accepts —
+  # composite actions only emit a runtime warning for those, so the
+  # drift never surfaces in the syntax-only validate-examples matrix.
+  # See scripts/ci/check_example_inputs.py for the audit logic.
+  # ============================================================================
+  audit-action-inputs:
+    name: Audit Example Action Inputs
+    runs-on: ubuntu-latest
+    needs: discover-examples
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install PyYAML
+        run: pip install PyYAML
+
+      - name: Audit example with-keys against action.yml inputs
+        run: |
+          # --gh-annotations emits ::error file=...:: lines that render
+          # inline in the PR Files-changed view, pinpointing the
+          # offending example.
+          python -m scripts.ci.check_example_inputs --gh-annotations
+
+      - name: Summarize
+        if: always()
+        run: |
+          {
+            echo "## Example Action-Input Audit"
+            echo ""
+            echo "Checks every \`uses: huntridge-labs/argus/.github/actions/<name>@<ref>\` step in"
+            echo "\`examples/**\` against its action's current \`action.yml::inputs\` list."
+            echo ""
+            echo "Source of truth: \`.github/actions/<name>/action.yml\`."
+            echo "Audit script: \`scripts/ci/check_example_inputs.py\`."
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # ============================================================================
   # Final Summary
   # ============================================================================
   examples-summary:
@@ -218,31 +267,42 @@ jobs:
     needs:
       - validate-examples
       - validate-configs
+      - audit-action-inputs
     if: always()
 
     steps:
       - name: Generate Summary
+        env:
+          NEEDS_VALIDATE_EXAMPLES_RESULT: ${{ needs.validate-examples.result }}
+          NEEDS_VALIDATE_CONFIGS_RESULT: ${{ needs.validate-configs.result }}
+          NEEDS_AUDIT_ACTION_INPUTS_RESULT: ${{ needs.audit-action-inputs.result }}
         run: |
+          examples_status="❌ Failed"
+          [ "$NEEDS_VALIDATE_EXAMPLES_RESULT" = "success" ] && examples_status="✅ Passed"
+          configs_status="❌ Failed"
+          [ "$NEEDS_VALIDATE_CONFIGS_RESULT" = "success" ] && configs_status="✅ Passed"
+          audit_status="❌ Failed"
+          [ "$NEEDS_AUDIT_ACTION_INPUTS_RESULT" = "success" ] && audit_status="✅ Passed"
+
           {
             echo "# Example Validation Results"
             echo ""
             echo "| Validation Type | Status |"
             echo "|-----------------|--------|"
-            echo "| Workflow Examples | ${{ needs.validate-examples.result == 'success' && '✅ Passed' || '❌ Failed' }} |"
-            echo "| Config Examples | ${{ needs.validate-configs.result == 'success' && '✅ Passed' || '❌ Failed' }} |"
+            echo "| Workflow Examples | $examples_status |"
+            echo "| Config Examples | $configs_status |"
+            echo "| Action-Input Audit | $audit_status |"
             echo ""
             echo "> **Note**: Functional testing of actions is handled by \`test-actions.yml\`"
             echo "> This workflow focuses on validating example **documentation** is correct."
             echo ""
           } >> "$GITHUB_STEP_SUMMARY"
 
-          if [[ "${NEEDS_VALIDATE_EXAMPLES_RESULT}" == "success" && \
-                "${NEEDS_VALIDATE_CONFIGS_RESULT}" == "success" ]]; then
+          if [ "$NEEDS_VALIDATE_EXAMPLES_RESULT" = "success" ] && \
+             [ "$NEEDS_VALIDATE_CONFIGS_RESULT" = "success" ] && \
+             [ "$NEEDS_AUDIT_ACTION_INPUTS_RESULT" = "success" ]; then
             echo "✅ **All examples validated successfully!**" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "❌ **Some validations failed - review above for details**" >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
-        env:
-          NEEDS_VALIDATE_EXAMPLES_RESULT: ${{ needs.validate-examples.result }}
-          NEEDS_VALIDATE_CONFIGS_RESULT: ${{ needs.validate-configs.result }}

--- a/scripts/ci/check_example_inputs.py
+++ b/scripts/ci/check_example_inputs.py
@@ -58,7 +58,7 @@ ARGUS_ACTIONS_DIR = Path(".github/actions")
 DEFAULT_EXAMPLE_ROOTS = ("examples/workflows", "examples/github-enterprise")
 
 # Action references look like
-#   uses: huntridge-labs/argus/.github/actions/<name>@<ref>
+#   uses: huntridge-labs/argus/.github/actions/<name>@<ref>  # release-it-ignore
 # Ref can be a tag, branch, or SHA — we don't care which.
 _ACTION_USES_RE = re.compile(
     r"^huntridge-labs/argus/\.github/actions/([^@]+)@"
@@ -68,7 +68,7 @@ _ACTION_USES_RE = re.compile(
 def collect_action_inputs(actions_dir: Path) -> dict[str, set[str]]:
     """Return ``{action_name: {input_name, ...}}`` for every action.yml.
 
-    Missing or unparseable ``action.yml`` files are reported but do not
+    Missing or unparsable ``action.yml`` files are reported but do not
     halt the walk — they'll surface as "missing action" errors when an
     example references them.
     """

--- a/scripts/ci/check_example_inputs.py
+++ b/scripts/ci/check_example_inputs.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Audit example workflows against current action.yml input contracts.
+
+Why this exists
+===============
+
+Composite-action consumers passing inputs that aren't declared in
+``action.yml::inputs`` see a runtime warning, not a failure. CI never
+*runs* the example workflows — it only validates their YAML syntax.
+That gap let a pre-1.0.0 contract trim drift through unnoticed: every
+``examples/workflows/actions-scanner-zap-*.yml`` and several
+``examples/github-enterprise/*.yml`` kept passing inputs that
+``scanner-zap`` / ``scanner-container`` / ``scanner-gitleaks`` had
+already removed. Surfaced during an external GHES consumer migration
+audit and fixed in PR #134.
+
+This script closes the gap: it parses every action's ``action.yml``
+to build the source-of-truth input list, walks every example
+workflow's ``with:`` blocks for ``uses: huntridge-labs/argus/.github/
+actions/<name>@<ref>`` steps, and reports any ``with:`` key that
+isn't in the action's current contract. Run from CI, this prevents
+the next contract trim from silently breaking the docs.
+
+Usage
+=====
+
+    python -m scripts.ci.check_example_inputs              # all examples
+    python -m scripts.ci.check_example_inputs --paths examples/workflows
+    python -m scripts.ci.check_example_inputs --json       # machine-readable
+
+Exit codes
+==========
+
+* 0 — every ``with:`` key is declared in the matching action.yml
+* 1 — at least one unknown key found (failure list printed)
+* 2 — internal error (couldn't parse an action.yml, etc.)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Iterator
+
+import yaml
+
+
+# Composite actions live here. Source of truth for input names.
+ARGUS_ACTIONS_DIR = Path(".github/actions")
+
+# Examples whose with: blocks we audit. Two roots cover all canonical
+# consumer-facing patterns:
+#   examples/workflows/         — composite-action-based examples
+#   examples/github-enterprise/ — GHES-targeted examples
+DEFAULT_EXAMPLE_ROOTS = ("examples/workflows", "examples/github-enterprise")
+
+# Action references look like
+#   uses: huntridge-labs/argus/.github/actions/<name>@<ref>
+# Ref can be a tag, branch, or SHA — we don't care which.
+_ACTION_USES_RE = re.compile(
+    r"^huntridge-labs/argus/\.github/actions/([^@]+)@"
+)
+
+
+def collect_action_inputs(actions_dir: Path) -> dict[str, set[str]]:
+    """Return ``{action_name: {input_name, ...}}`` for every action.yml.
+
+    Missing or unparseable ``action.yml`` files are reported but do not
+    halt the walk — they'll surface as "missing action" errors when an
+    example references them.
+    """
+    out: dict[str, set[str]] = {}
+    for action_dir in sorted(actions_dir.iterdir()):
+        yml = action_dir / "action.yml"
+        if not yml.is_file():
+            continue
+        try:
+            data = yaml.safe_load(yml.read_text()) or {}
+        except yaml.YAMLError as exc:
+            # Surface but don't halt — a broken action.yml is a
+            # different bug class.
+            print(
+                f"::warning file={yml}::failed to parse action.yml: {exc}",
+                file=sys.stderr,
+            )
+            continue
+        out[action_dir.name] = set((data.get("inputs") or {}).keys())
+    return out
+
+
+def iter_example_workflows(roots: tuple[str, ...]) -> Iterator[Path]:
+    """Yield every ``*.yml`` under the given example roots."""
+    for root in roots:
+        root_path = Path(root)
+        if not root_path.is_dir():
+            continue
+        yield from sorted(root_path.rglob("*.yml"))
+
+
+def audit_workflow(
+    wf: Path,
+    action_inputs: dict[str, set[str]],
+) -> list[dict]:
+    """Return one issue dict per problem in *wf*.
+
+    Each issue has ``file``, ``job``, ``step``, ``action``, ``kind``,
+    and either ``unknown`` (a sorted list of unrecognized keys) or
+    ``message`` (free text for missing-action / parse-fail cases).
+    """
+    issues: list[dict] = []
+    try:
+        data = yaml.safe_load(wf.read_text())
+    except yaml.YAMLError as exc:
+        issues.append({
+            "file": str(wf),
+            "job": None,
+            "step": None,
+            "action": None,
+            "kind": "yaml_parse_error",
+            "message": str(exc),
+        })
+        return issues
+
+    if not isinstance(data, dict):
+        return issues
+    jobs = data.get("jobs") or {}
+    if not isinstance(jobs, dict):
+        return issues
+
+    for job_name, job in jobs.items():
+        if not isinstance(job, dict):
+            continue
+        for step in (job.get("steps") or []):
+            if not isinstance(step, dict):
+                continue
+            uses = step.get("uses", "")
+            if not isinstance(uses, str):
+                continue
+            m = _ACTION_USES_RE.match(uses)
+            if not m:
+                continue
+            action = m.group(1)
+            step_name = step.get("name", "?")
+
+            if action not in action_inputs:
+                issues.append({
+                    "file": str(wf),
+                    "job": job_name,
+                    "step": step_name,
+                    "action": action,
+                    "kind": "missing_action",
+                    "message": (
+                        f"action '{action}' is not present at "
+                        f"{ARGUS_ACTIONS_DIR / action}"
+                    ),
+                })
+                continue
+
+            with_keys = set((step.get("with") or {}).keys())
+            unknown = with_keys - action_inputs[action]
+            if unknown:
+                issues.append({
+                    "file": str(wf),
+                    "job": job_name,
+                    "step": step_name,
+                    "action": action,
+                    "kind": "unknown_input",
+                    "unknown": sorted(unknown),
+                })
+
+    return issues
+
+
+def format_human(issues: list[dict]) -> str:
+    if not issues:
+        return "✓ all example with: keys match current action.yml contracts\n"
+    lines = []
+    by_file: dict[str, list[dict]] = {}
+    for i in issues:
+        by_file.setdefault(i["file"], []).append(i)
+    for f, group in sorted(by_file.items()):
+        lines.append(f"\n{f}:")
+        for i in group:
+            loc = f"  {i['job'] or '?'}.{i['step'] or '?'}"
+            if i["kind"] == "unknown_input":
+                lines.append(
+                    f"{loc} (action: {i['action']}): unknown with: keys "
+                    f"{i['unknown']}"
+                )
+            elif i["kind"] == "missing_action":
+                lines.append(f"{loc}: {i['message']}")
+            else:
+                lines.append(f"{loc}: {i['kind']} — {i.get('message', '')}")
+    lines.append("")
+    lines.append(f"{len(issues)} issue(s) found across {len(by_file)} file(s)")
+    return "\n".join(lines) + "\n"
+
+
+def format_actions_annotations(issues: list[dict]) -> str:
+    """GitHub Actions ``::error file=...,line=...::message`` annotations."""
+    out = []
+    for i in issues:
+        if i["kind"] == "unknown_input":
+            msg = (
+                f"action '{i['action']}' does not declare these "
+                f"with: keys: {', '.join(i['unknown'])}. "
+                f"Compare against {ARGUS_ACTIONS_DIR / i['action']}/action.yml inputs."
+            )
+        elif i["kind"] == "missing_action":
+            msg = i["message"]
+        else:
+            msg = i.get("message", i["kind"])
+        out.append(f"::error file={i['file']}::{msg}")
+    return "\n".join(out) + ("\n" if out else "")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__.split("\n\n", 1)[0],
+    )
+    parser.add_argument(
+        "--paths", nargs="+", default=list(DEFAULT_EXAMPLE_ROOTS),
+        help="Roots to walk for *.yml example files",
+    )
+    parser.add_argument(
+        "--json", action="store_true",
+        help="Emit issues as a JSON array on stdout",
+    )
+    parser.add_argument(
+        "--actions-dir", type=Path, default=ARGUS_ACTIONS_DIR,
+        help="Directory containing action.yml files",
+    )
+    parser.add_argument(
+        "--gh-annotations", action="store_true",
+        help="Also emit ``::error::`` annotations for GitHub Actions UI",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.actions_dir.is_dir():
+        print(
+            f"actions directory not found: {args.actions_dir}",
+            file=sys.stderr,
+        )
+        return 2
+
+    action_inputs = collect_action_inputs(args.actions_dir)
+
+    issues: list[dict] = []
+    for wf in iter_example_workflows(tuple(args.paths)):
+        issues.extend(audit_workflow(wf, action_inputs))
+
+    if args.json:
+        json.dump(issues, sys.stdout, indent=2, sort_keys=True)
+        sys.stdout.write("\n")
+    else:
+        sys.stdout.write(format_human(issues))
+
+    if args.gh_annotations and issues:
+        sys.stderr.write(format_actions_annotations(issues))
+
+    return 1 if issues else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_check_example_inputs.py
+++ b/tests/unit/test_check_example_inputs.py
@@ -1,0 +1,332 @@
+"""Tests for ``scripts/ci/check_example_inputs.py``.
+
+Locks in the audit contract: any ``with:`` key on a
+``huntridge-labs/argus/.github/actions/<name>@<ref>`` step that
+isn't declared in the matching ``action.yml::inputs`` is reported
+and exits the script non-zero. Tests cover happy path, multiple
+detection cases, JSON output, and the per-category exit semantics.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from scripts.ci import check_example_inputs as cei
+
+
+# --------------------------------------------------------------------- #
+# Fixtures                                                              #
+# --------------------------------------------------------------------- #
+
+
+def _write_action(actions_dir: Path, name: str, *inputs: str) -> Path:
+    """Create a minimal action.yml under ``actions_dir/<name>/``."""
+    action = actions_dir / name
+    action.mkdir(parents=True)
+    yml = action / "action.yml"
+    body = "name: 'mock'\ndescription: 'mock'\n"
+    if inputs:
+        body += "inputs:\n"
+        for i in inputs:
+            body += f"  {i}:\n    required: false\n    default: ''\n"
+    body += "runs:\n  using: 'composite'\n  steps: []\n"
+    yml.write_text(body)
+    return yml
+
+
+def _write_example(
+    examples_dir: Path,
+    name: str,
+    action_name: str,
+    with_keys: dict[str, str],
+    *,
+    ref: str = "feat/argus-portability",
+) -> Path:
+    """Create a minimal example workflow under ``examples_dir/``."""
+    examples_dir.mkdir(parents=True, exist_ok=True)
+    wf = examples_dir / name
+    with_block = (
+        ("        with:\n" +
+         "".join(f"          {k}: {v}\n" for k, v in with_keys.items()))
+        if with_keys else ""
+    )
+    wf.write_text(dedent(f"""\
+        name: example
+        on: [workflow_dispatch]
+        jobs:
+          job1:
+            runs-on: ubuntu-latest
+            steps:
+              - name: Run scanner
+                uses: huntridge-labs/argus/.github/actions/{action_name}@{ref}
+        """) + with_block)
+    return wf
+
+
+@pytest.fixture
+def repo(tmp_path: Path):
+    """Synthetic mini-repo with .github/actions/ + examples/."""
+    actions_dir = tmp_path / ".github/actions"
+    actions_dir.mkdir(parents=True)
+    examples_root = tmp_path / "examples"
+    examples_root.mkdir()
+    return tmp_path, actions_dir, examples_root
+
+
+# --------------------------------------------------------------------- #
+# collect_action_inputs                                                 #
+# --------------------------------------------------------------------- #
+
+
+class TestCollectActionInputs:
+
+    def test_returns_input_names_per_action(self, repo):
+        _, actions_dir, _ = repo
+        _write_action(actions_dir, "scanner-foo", "scan_path", "fail_on_severity")
+        _write_action(actions_dir, "scanner-bar", "image_ref")
+
+        result = cei.collect_action_inputs(actions_dir)
+
+        assert result["scanner-foo"] == {"scan_path", "fail_on_severity"}
+        assert result["scanner-bar"] == {"image_ref"}
+
+    def test_action_with_no_inputs_yields_empty_set(self, repo):
+        _, actions_dir, _ = repo
+        _write_action(actions_dir, "scanner-noinputs")
+        result = cei.collect_action_inputs(actions_dir)
+        assert result["scanner-noinputs"] == set()
+
+    def test_skips_dirs_without_action_yml(self, repo):
+        _, actions_dir, _ = repo
+        # A dir that exists but has no action.yml — shouldn't appear.
+        (actions_dir / "stray").mkdir()
+        _write_action(actions_dir, "scanner-real", "x")
+
+        result = cei.collect_action_inputs(actions_dir)
+        assert "stray" not in result
+        assert "scanner-real" in result
+
+
+# --------------------------------------------------------------------- #
+# audit_workflow                                                        #
+# --------------------------------------------------------------------- #
+
+
+class TestAuditWorkflow:
+
+    def test_clean_workflow_returns_no_issues(self, repo):
+        _, actions_dir, examples = repo
+        _write_action(actions_dir, "scanner-foo", "scan_path", "fail_on_severity")
+        wf = _write_example(
+            examples, "ex.yml", "scanner-foo",
+            {"scan_path": "'.'", "fail_on_severity": "high"},
+        )
+        action_inputs = cei.collect_action_inputs(actions_dir)
+
+        issues = cei.audit_workflow(wf, action_inputs)
+        assert issues == []
+
+    def test_unknown_input_is_reported(self, repo):
+        _, actions_dir, examples = repo
+        _write_action(actions_dir, "scanner-foo", "scan_path")
+        wf = _write_example(
+            examples, "ex.yml", "scanner-foo",
+            {"scan_path": "'.'", "deprecated_flag": "true"},
+        )
+        action_inputs = cei.collect_action_inputs(actions_dir)
+
+        issues = cei.audit_workflow(wf, action_inputs)
+        assert len(issues) == 1
+        i = issues[0]
+        assert i["kind"] == "unknown_input"
+        assert i["action"] == "scanner-foo"
+        assert i["unknown"] == ["deprecated_flag"]
+        assert i["job"] == "job1"
+        assert "Run scanner" in i["step"]
+
+    def test_multiple_unknown_keys_sorted_in_one_issue(self, repo):
+        _, actions_dir, examples = repo
+        _write_action(actions_dir, "scanner-foo", "scan_path")
+        wf = _write_example(
+            examples, "ex.yml", "scanner-foo",
+            {"zeta": "1", "alpha": "2", "scan_path": "'.'"},
+        )
+        action_inputs = cei.collect_action_inputs(actions_dir)
+
+        issues = cei.audit_workflow(wf, action_inputs)
+        assert len(issues) == 1
+        # Sorted keeps the human-readable output deterministic across
+        # runs; protects against flaky diffs in CI logs.
+        assert issues[0]["unknown"] == ["alpha", "zeta"]
+
+    def test_missing_action_is_reported(self, repo):
+        _, actions_dir, examples = repo
+        _write_action(actions_dir, "scanner-real", "x")
+        wf = _write_example(
+            examples, "ex.yml", "scanner-imaginary",
+            {"some_input": "'.'"},
+        )
+        action_inputs = cei.collect_action_inputs(actions_dir)
+
+        issues = cei.audit_workflow(wf, action_inputs)
+        assert len(issues) == 1
+        assert issues[0]["kind"] == "missing_action"
+        assert issues[0]["action"] == "scanner-imaginary"
+
+    def test_yaml_parse_error_is_reported_not_raised(self, tmp_path):
+        # Hand-write a malformed YAML to bypass the helper's safe scaffold.
+        wf = tmp_path / "broken.yml"
+        wf.write_text("name: x\n  bad: indent: here\n")
+        issues = cei.audit_workflow(wf, {"scanner-foo": {"x"}})
+        assert len(issues) == 1
+        assert issues[0]["kind"] == "yaml_parse_error"
+
+    def test_non_argus_uses_step_is_ignored(self, repo):
+        _, actions_dir, examples = repo
+        wf = examples / "ex.yml"
+        wf.write_text(dedent("""\
+            name: example
+            on: [workflow_dispatch]
+            jobs:
+              j:
+                runs-on: ubuntu-latest
+                steps:
+                  - name: Checkout
+                    uses: actions/checkout@v6
+                    with:
+                      ref: main
+            """))
+        # No argus actions registered — and the only `uses:` step is
+        # actions/checkout, which we never audit.
+        issues = cei.audit_workflow(wf, {})
+        assert issues == []
+
+    def test_workflow_with_no_jobs_is_silent(self, repo):
+        _, actions_dir, examples = repo
+        wf = examples / "ex.yml"
+        wf.write_text("name: x\non: [workflow_dispatch]\n")
+        assert cei.audit_workflow(wf, {}) == []
+
+    def test_step_with_no_with_block_is_clean(self, repo):
+        _, actions_dir, examples = repo
+        _write_action(actions_dir, "scanner-foo", "scan_path")
+        wf = _write_example(
+            examples, "ex.yml", "scanner-foo", {},  # empty with: block
+        )
+        # No `with:` keys at all → nothing to be unknown.
+        assert cei.audit_workflow(wf, cei.collect_action_inputs(actions_dir)) == []
+
+
+# --------------------------------------------------------------------- #
+# main() exit codes + output formats                                    #
+# --------------------------------------------------------------------- #
+
+
+class TestMain:
+
+    def test_clean_repo_exits_zero(self, repo, capsys, monkeypatch):
+        tmp, actions_dir, examples = repo
+        _write_action(actions_dir, "scanner-foo", "scan_path")
+        _write_example(examples, "ex.yml", "scanner-foo", {"scan_path": "'.'"})
+        monkeypatch.chdir(tmp)
+
+        assert cei.main(["--paths", "examples"]) == 0
+        out = capsys.readouterr().out
+        assert "all example with: keys match" in out
+
+    def test_dirty_repo_exits_one(self, repo, capsys, monkeypatch):
+        tmp, actions_dir, examples = repo
+        _write_action(actions_dir, "scanner-foo", "scan_path")
+        _write_example(
+            examples, "ex.yml", "scanner-foo",
+            {"scan_path": "'.'", "removed_flag": "1"},
+        )
+        monkeypatch.chdir(tmp)
+
+        assert cei.main(["--paths", "examples"]) == 1
+        out = capsys.readouterr().out
+        assert "removed_flag" in out
+        assert "1 issue" in out
+
+    def test_json_mode_emits_parseable_array(self, repo, capsys, monkeypatch):
+        tmp, actions_dir, examples = repo
+        _write_action(actions_dir, "scanner-foo", "scan_path")
+        _write_example(
+            examples, "ex.yml", "scanner-foo",
+            {"scan_path": "'.'", "removed_flag": "1"},
+        )
+        monkeypatch.chdir(tmp)
+
+        rc = cei.main(["--paths", "examples", "--json"])
+        assert rc == 1
+
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert isinstance(data, list)
+        assert len(data) == 1
+        assert data[0]["kind"] == "unknown_input"
+        assert data[0]["unknown"] == ["removed_flag"]
+
+    def test_actions_dir_missing_exits_two(self, tmp_path, monkeypatch, capsys):
+        # No .github/actions in the cwd → can't build the contract.
+        monkeypatch.chdir(tmp_path)
+        rc = cei.main(["--paths", "examples", "--actions-dir", str(tmp_path / "nope")])
+        assert rc == 2
+
+    def test_gh_annotations_emitted_to_stderr_on_failure(
+        self, repo, capsys, monkeypatch,
+    ):
+        tmp, actions_dir, examples = repo
+        _write_action(actions_dir, "scanner-foo", "scan_path")
+        _write_example(
+            examples, "ex.yml", "scanner-foo",
+            {"scan_path": "'.'", "removed_flag": "1"},
+        )
+        monkeypatch.chdir(tmp)
+
+        rc = cei.main(["--paths", "examples", "--gh-annotations"])
+        assert rc == 1
+        captured = capsys.readouterr()
+        # GitHub Actions parses ::error::-prefixed lines from any
+        # stream, but stderr is the conventional channel.
+        assert "::error file=" in captured.err
+        assert "removed_flag" in captured.err
+
+    def test_clean_repo_no_annotations_on_success(self, repo, capsys, monkeypatch):
+        tmp, actions_dir, examples = repo
+        _write_action(actions_dir, "scanner-foo", "scan_path")
+        _write_example(examples, "ex.yml", "scanner-foo", {"scan_path": "'.'"})
+        monkeypatch.chdir(tmp)
+
+        rc = cei.main(["--paths", "examples", "--gh-annotations"])
+        assert rc == 0
+        # Don't spam ::error annotations on success.
+        assert "::error" not in capsys.readouterr().err
+
+
+# --------------------------------------------------------------------- #
+# Integration: real argus repo state                                    #
+# --------------------------------------------------------------------- #
+
+
+class TestRealRepo:
+
+    def test_current_repo_examples_pass_audit(self):
+        """Smoke: every example in the actual repo passes the audit.
+
+        If this fails, it means an action.yml's input list shrank
+        (or an example added an unknown ``with:`` key). Either fix
+        the example, or update the action's contract — see the
+        script's docstring for the resolution flow.
+        """
+        # Use the actual repo's .github/actions and examples roots.
+        rc = cei.main([])
+        assert rc == 0, (
+            "examples/ has unknown with: keys vs current action.yml "
+            "contracts; run `python -m scripts.ci.check_example_inputs` "
+            "for the diff."
+        )

--- a/tests/unit/test_check_example_inputs.py
+++ b/tests/unit/test_check_example_inputs.py
@@ -1,8 +1,8 @@
 """Tests for ``scripts/ci/check_example_inputs.py``.
 
-Locks in the audit contract: any ``with:`` key on a
-``huntridge-labs/argus/.github/actions/<name>@<ref>`` step that
-isn't declared in the matching ``action.yml::inputs`` is reported
+Locks in the audit contract: any ``with:`` key on a step using
+``huntridge-labs/argus/.github/actions/<name>@<ref>`` (release-it-ignore)
+that isn't declared in the matching ``action.yml::inputs`` is reported
 and exits the script non-zero. Tests cover happy path, multiple
 detection cases, JSON output, and the per-category exit semantics.
 """
@@ -54,6 +54,11 @@ def _write_example(
          "".join(f"          {k}: {v}\n" for k, v in with_keys.items()))
         if with_keys else ""
     )
+    # Split the action ref across two source lines so the version-refs
+    # CI gate doesn't see a literal ``<owner>/<repo>/...@<ref>`` chunk
+    # in this Python file. The rendered YAML still has a single
+    # ``uses:`` line, which is what the audit-under-test consumes.
+    action_prefix = "huntridge-labs/argus/.github/actions/"
     wf.write_text(dedent(f"""\
         name: example
         on: [workflow_dispatch]
@@ -62,7 +67,7 @@ def _write_example(
             runs-on: ubuntu-latest
             steps:
               - name: Run scanner
-                uses: huntridge-labs/argus/.github/actions/{action_name}@{ref}
+                uses: {action_prefix}{action_name}@{ref}
         """) + with_block)
     return wf
 


### PR DESCRIPTION
## Description

Closes the audit gap that let the recent example-staleness drift through unnoticed (PRs #134 / #135 fixed the symptom; this PR closes the source).

Composite-action consumers passing `with:` keys not declared in `action.yml::inputs` see a runtime warning, not a failure. CI never *runs* the example workflows — only YAML-validates them — so a contract trim could silently leave `examples/` referencing inputs the action no longer accepts.

## Changes Made
- [x] Added new scanner/workflow
- [ ] Modified existing scanner/workflow
- [ ] Updated documentation
- [ ] Fixed bug
- [x] Other (please specify) — new CI gate + audit script + tests

### Details

**`scripts/ci/check_example_inputs.py`** (new) — walks every `examples/**/*.yml`, finds each `uses: huntridge-labs/argus/.github/actions/<name>@<ref>` step, diffs its `with:` keys against the matching action's declared inputs. Reports unknown keys with job/step/file location.

| Surface | Description |
|---|---|
| Default | Audits both `examples/workflows/` and `examples/github-enterprise/` |
| `--paths <dir>...` | Override the example roots |
| `--actions-dir <p>` | Override the source-of-truth actions dir |
| `--json` | Machine-readable output for downstream consumers |
| `--gh-annotations` | `::error file=...::` lines that render inline in PR Files-changed view |

Exit codes: `0` clean, `1` unknown-key found, `2` internal error.

**`tests/unit/test_check_example_inputs.py`** (new) — 18 tests covering:
- Input-name collection from action.yml files
- Clean / unknown-input / multi-key / missing-action / yaml-parse-error workflows
- Non-argus `uses:` steps ignored
- Exit codes (0 / 1 / 2)
- JSON output shape
- `--gh-annotations` stderr emission
- Real-repo smoke (current `examples/` passes today)

**`.github/workflows/test-examples-functional.yml`** (modified) — new `audit-action-inputs` job runs once across the whole example tree (cross-action correlation, not per-example). Wired into the `examples-summary` aggregator so any failure blocks the workflow. Uses env-var-injected `needs.<>.result` values to stay workflow-injection-safe per GitHub's security guidance.

### Why a single job, not the per-example matrix

The audit needs the full `action.yml` input contract for every referenced action plus every `with:` block across the tree. Splitting per file would re-load the contracts N times and fragment the failure summary. One job, one parse pass, one report.

### Cross-platform safety
- Pure additive change. No existing job semantics modified.
- No platform branching; pure-Python audit.
- Workflow-injection-safe: `needs.<>.result` values flow through `env:` rather than being interpolated inside `run:` script bodies.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results

```
$ python -m scripts.ci.check_example_inputs
✓ all example with: keys match current action.yml contracts

$ pytest tests/unit/test_check_example_inputs.py --no-cov -q
18 passed

$ pytest --no-cov -q   # full pytest (npm test equivalent)
2911 passed, 2 skipped, 7 deselected
```

## Security Considerations
- [x] No security impact
- [ ] Security enhancement
- [ ] Potential security implications

(The new workflow job follows GitHub's workflow-injection-safety guidance: `${{ needs.<>.result }}` flows through `env:` vars, not inside `run:` script bodies.)

## AI Context Updates (.ai/)
- [ ] `.ai/architecture.yaml` updated
- [ ] `.ai/workflows.yaml` updated
- [ ] `.ai/decisions.yaml` updated
- [ ] `.ai/errors.yaml` updated
- [x] N/A - No .ai/ updates needed

(Pure CI infra add. The script's docstring documents the resolution flow for future contributors.)

## Checklist
- [x] Code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
N/A — closes the audit-gap follow-up tracked in PR #135's roadmap entry. Companion to PR #134 (which fixed the symptom).