### PR TITLE
docs(adr-021): formalize SDK-vs-composite-action boundary, close roadmap #206

### DIFF
--- a/.ai/decisions.yaml
+++ b/.ai/decisions.yaml
@@ -1265,3 +1265,128 @@ decisions:
     pr_references:
       - "#117 (build_args contract for security scanners — the parallel pattern this complements)"
       - "#120 (HadolintLinter pre-batching — the optimization this PR's base captures generically)"
+
+  - id: ADR-021
+    title: "SDK-vs-composite-action boundary: when a scanner stays composite-only"
+    status: accepted
+    date: 2026-05-08
+    context: |
+      Argus's primary contribution shape is the SDK module (an
+      argus.scanners.<name> class implementing the Scanner protocol).
+      Composite actions exist as wrappers that delegate to the SDK
+      so GitHub Actions consumers get a paved path. The default
+      assumption — captured in CONTRIBUTING.md and the SDK-first
+      framing throughout — is that every new scanner gets an SDK
+      module first, and the composite wrapper is a thin convenience
+      layer.
+
+      Two existing scanners deliberately break that pattern:
+      scanner-codeql and scanner-dependency-review have composite
+      actions but no argus.scanners.codeql / argus.scanners.dependency_review
+      modules, and the SDK-ROADMAP.md previously listed both as open
+      items waiting to get SDK ports.
+
+      Auditing those two more carefully showed neither scanner can
+      ever justify the SDK port:
+
+      * **CodeQL.** The CodeQL CLI is licence-restricted (free use
+        only for OSS or GHAS-entitled private repos), the bundle
+        is ~500MB to redistribute across architectures, and the
+        primary value of running it (SARIF upload to the GitHub
+        Security tab) only exists on github.com / GHES. An SDK
+        consumer scanning proprietary code without GHAS is on
+        questionable licence ground, and the maintenance cost of
+        tracking the bundle's release cadence is substantial.
+
+      * **Dependency-review.** The action is a thin client over
+        GitHub's GET /repos/{owner}/{repo}/dependency-graph/compare/
+        {basehead} endpoint. The intelligence is server-side; the
+        compare data only exists for repos with the Dependency
+        Graph enabled (free for public repos, GHAS for private);
+        and the comparison is meaningless outside a pull_request
+        event context. Wrapping it in the SDK would be a
+        GitHub-API client masquerading as a Scanner protocol.
+
+      Both motivated a deliberate "wontfix on SDK, ship as
+      composite-only" decision. We need that recorded so a future
+      contributor doesn't reopen #206 or a sibling issue without
+      seeing the rationale.
+    decision: |
+      A scanner stays composite-action-only (no SDK module) when
+      EITHER condition holds:
+
+      1. **GitHub-API-bound primary signal.** The scanner's main
+         output comes from a GitHub API endpoint (not from running
+         a binary against local files). It needs GITHUB_TOKEN, a
+         specific event payload, or server-side data that doesn't
+         exist off-platform. Examples: dependency-graph diff,
+         secret-scanning-alerts API, code-scanning-alerts API.
+
+      2. **Licence-restricted CLI distribution.** The scanner's CLI
+         can't be redistributed to all consumers under terms argus
+         is willing to accept on their behalf. Either the licence
+         restricts use cases (CodeQL: OSS or GHAS only), or the
+         distribution itself is encumbered (sealed bundle requiring
+         GitHub auth to download).
+
+      Either condition makes the SDK port a net negative —
+      bigger maintenance surface for a feature only some consumers
+      can legally use, with no off-platform value.
+
+      Both existing instances stay composite-only:
+
+      * .github/actions/scanner-codeql/ — keeps its current shape;
+        consumers wanting CodeQL via argus go through the action.
+      * .github/actions/scanner-dependency-review/ — same.
+
+      Neither will gain argus.scanners.codeql.py or
+      argus.scanners.dependency_review.py modules. The two
+      composite actions' README.md files carry the rationale
+      inline so a contributor browsing the action sees it before
+      filing an SDK-port issue.
+
+      CLAUDE.md's "Adding a New Scanner" section was updated with
+      a one-paragraph carve-out pointing at this ADR, so the
+      default ("SDK-first") guidance has the carve-out attached
+      to it instead of having to be discovered separately.
+    alternatives_considered:
+      - name: "Port both scanners to the SDK anyway, with disclaimers"
+        rejected_because: |
+          For CodeQL, the licence restrictions don't go away just
+          because we add a docstring. Consumers running it under
+          argus's uniform interface against proprietary code without
+          GHAS are still on the wrong side of GitHub's terms; we'd
+          be making it easier for them to get into trouble. For
+          dependency-review, the SDK port would be a single API
+          endpoint wrapper that requires GITHUB_TOKEN + base_ref +
+          head_ref to do anything — which is the composite-action
+          shape, just dressed up differently. No off-platform value
+          gained, real maintenance cost added.
+
+      - name: "Drop the composite actions too — let consumers use the upstream actions directly"
+        rejected_because: |
+          The composite wrappers add real value: uniform input
+          surface (fail_on_severity, post_pr_comment, etc.),
+          security-summary integration, the standard SARIF upload
+          + PR-comment + artifact-upload flow. Consumers using
+          actions/dependency-review-action or
+          github/codeql-action directly miss all of that. The
+          wrappers stay; the SDK ports don't happen.
+
+      - name: "Add an 'SDK-eligible' marker on every action.yml"
+        rejected_because: |
+          Over-engineering. Two scanners are composite-only today,
+          and the rule for adding more is a single sentence. A
+          paragraph in CLAUDE.md + this ADR + a callout in each
+          composite action's README is enough scaffolding. If we
+          ever have 5+ composite-only scanners we can revisit.
+    consequences:
+      - "Roadmap item ``#206 (codeql.py + dependency_review.py)`` closed: composite-only by design, never an SDK port."
+      - "Future contributors filing 'add SDK module for <X>' issues hit the boundary rule in CLAUDE.md and the per-action README before opening the issue. Reduces the chance of a partially-implemented SDK port that later gets ripped out."
+      - "Two existing composite actions are explicitly paved cowpaths, not omissions waiting to be filled in."
+      - "The rule is testable from the contributor's side: 'Does my scanner need GITHUB_TOKEN + a specific event for its primary output?' OR 'Is the CLI licence-restricted?' If yes to either, ship as composite-only."
+    related:
+      - ADR-001  # Composite actions as primary architecture (the dual-track shape this disambiguates)
+      - ADR-013  # Python SDK as primary interface (the default this carves out from)
+    pr_references:
+      - "(roadmap closure for #206 — see SDK-ROADMAP.md line 207)"

--- a/.github/actions/scanner-codeql/README.md
+++ b/.github/actions/scanner-codeql/README.md
@@ -2,6 +2,8 @@
 
 Run GitHub CodeQL SAST analysis for a single language and generate reports.
 
+> **Composite-only by design.** CodeQL has no `argus.scanners.codeql` SDK module and won't get one. The CodeQL CLI's licence terms restrict use to open-source repos and GHAS-entitled private repos, the bundle is ~500MB to redistribute, and SARIF upload to the GitHub Security tab is the primary value of running it — none of which an off-platform SDK consumer can take advantage of. See [`.ai/decisions.yaml` ADR-021](../../../.ai/decisions.yaml) for the SDK-vs-composite-action boundary rule.
+
 ## Overview
 
 This composite action analyzes code for security vulnerabilities using CodeQL. Run it once per language (use a matrix for multiple languages). Results integrate with the security summary aggregator.

--- a/.github/actions/scanner-dependency-review/README.md
+++ b/.github/actions/scanner-dependency-review/README.md
@@ -2,6 +2,8 @@
 
 Scans pull request dependency changes for vulnerabilities and license compliance using [GitHub's dependency-review-action](https://github.com/actions/dependency-review-action).
 
+> **Composite-only by design.** Dependency-review has no `argus.scanners.dependency_review` SDK module and won't get one. The whole feature is a thin client over GitHub's `/repos/{owner}/{repo}/dependency-graph/compare/{basehead}` API — the intelligence is server-side, the data only exists for repos with GitHub's Dependency Graph enabled, and the comparison only makes sense in a `pull_request` event context. There's no off-platform shape worth porting. See [`.ai/decisions.yaml` ADR-021](../../../.ai/decisions.yaml) for the SDK-vs-composite-action boundary rule.
+
 ## Overview
 
 - Compares dependency changes between PR base and head via the GitHub Dependency Graph API

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,6 +319,8 @@ examples/workflows/                   # User-facing workflow examples
 
 ## Adding a New Scanner
 
+> **Some scanners stay composite-only by design.** If your tool's primary signal comes from the GitHub API (e.g. requires `GITHUB_TOKEN` + a `pull_request` event context to do anything useful), or its CLI is licence-restricted such that off-platform consumers can't legally run it, route it through a composite action under `.github/actions/scanner-<name>/` and skip the SDK port. The two existing instances are `scanner-codeql` (licence-encumbered CLI + bundle distribution cost) and `scanner-dependency-review` (thin client over GitHub's dependency-graph compare API). The full boundary rule, the test for future contributors, and the rationale for these two specifically lives in [`.ai/decisions.yaml` ADR-021](.ai/decisions.yaml).
+
 ### SDK Scanner Module (preferred)
 
 Create a single Python file implementing the `Scanner` protocol:

--- a/docs/developer/SDK-ROADMAP.md
+++ b/docs/developer/SDK-ROADMAP.md
@@ -204,7 +204,7 @@ All 16 scanner/linter actions refactored to call `argus scan` internally. Action
 **Future (post-release):**
 - [x] ~~Additional reporters: `github.py`, `gitlab.py`, `junit.py`~~ — three new reporters shipped: GitHub Actions annotations, GitLab Code Quality JSON (codeclimate-compatible), JUnit XML
 - [ ] Reporter plugin registration system (the broader item — still open as a follow-up)
-- [ ] Additional scanners: `codeql.py`, `dependency_review.py` (GitHub-specific)
+- [x] ~~Additional scanners: `codeql.py`, `dependency_review.py`~~ — **decided: composite-action-only.** Both stay as `.github/actions/scanner-codeql/` and `.github/actions/scanner-dependency-review/` and never gain SDK ports. CodeQL's CLI is licence-restricted (free use only for OSS or GHAS-entitled private repos) and its bundle is ~500MB to redistribute. Dependency-review is fundamentally a thin client over GitHub's `/dependency-graph/compare/{basehead}` API and is meaningless off a PR. The SDK-vs-composite boundary rule + rationale lives in [`.ai/decisions.yaml` ADR-021](../../.ai/decisions.yaml).
 - [x] ~~Progress indicators~~ — `argus/cli.py::Spinner` ships phase-aware progress with `--no-spinner` opt-out (PR #2c46fce: `feat(cli): phase-aware scan progress and clearer verbosity flags`)
 - [x] ~~`pull_policy` evaluation~~ — `ArgusConfig.execution.pull_policy` accepts `always | if-not-present | never`; engine + container_runtime honor it
 - [ ] Performance: profiling, pre-warming, lazy pulls (the remaining items from the original bundle)


### PR DESCRIPTION
## Description

Closes roadmap item **#206** ("Additional scanners: `codeql.py`, `dependency_review.py`") with a deliberate **wontfix**. Records the SDK-vs-composite-action boundary rule in four places so a future contributor doesn't reopen the same issue without seeing the rationale.

This PR is pure docs — no code, no scanner registration, no composite-action behavior modified. Both scanners are already composite-only on `feat/argus-portability`; this PR just formalizes the decision.

## Changes Made
- [ ] Added new scanner/workflow
- [ ] Modified existing scanner/workflow
- [x] Updated documentation
- [ ] Fixed bug
- [ ] Other (please specify)

### Why both scanners stay composite-only

| Scanner | Reason |
|---|---|
| **CodeQL** | CLI is licence-restricted (free use only for OSS or GHAS-entitled private repos). Bundle is ~500MB to redistribute across architectures. SARIF upload to the GitHub Security tab — the primary value — only exists on github.com / GHES. SDK consumer scanning proprietary code without GHAS is on questionable licence ground. |
| **Dependency-review** | Thin client over GitHub's `/repos/{owner}/{repo}/dependency-graph/compare/{basehead}` API. Intelligence is server-side. Data only exists for repos with the Dependency Graph enabled (free for public repos, GHAS for private). Comparison meaningless outside a `pull_request` event. No off-platform shape worth porting. |

### What this PR records

- **`docs/developer/SDK-ROADMAP.md`** — open `#206` line replaced with a closed-in-place summary that points at ADR-021.
- **`.github/actions/scanner-codeql/README.md`** — top-of-file callout: *"Composite-only by design. <rationale>."* Same callout on the dependency-review README.
- **`CLAUDE.md` — "Adding a New Scanner" section** — adds a paragraph that attaches the carve-out to the default ("SDK-first") guidance rather than leaving it to be discovered separately. Names both existing instances and points at ADR-021.
- **`.ai/decisions.yaml` ADR-021** (new) — full context, the two-condition test (*"GitHub-API-bound primary signal"* OR *"licence-restricted CLI distribution"*), the alternatives rejected (port-with-disclaimers, drop-the-composite-too, add-a-marker-everywhere), and the consequences.

### The two-condition rule for future contributors

A scanner stays composite-action-only (no SDK module) when **either** holds:

1. **GitHub-API-bound primary signal** — needs `GITHUB_TOKEN` + a specific event payload + server-side data that doesn't exist off-platform.
2. **Licence-restricted CLI distribution** — can't be redistributed under terms argus is willing to accept on consumers' behalf.

Either makes the SDK port a net negative — bigger maintenance surface for a feature only some consumers can legally use, with no off-platform value.

### Cross-platform safety
- Pure docs / ADR addition. No behavior change anywhere in the codebase.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] Tested with different scanner combinations

(Pure docs change, no code paths affected.)

### Validation

```
$ python -c "import yaml; yaml.safe_load(open('.ai/decisions.yaml'))"
$ python -m scripts.ci.check_version_refs
$ # both clean
```

## Security Considerations
- [x] No security impact
- [ ] Security enhancement
- [ ] Potential security implications

## AI Context Updates (.ai/)
- [ ] `.ai/architecture.yaml` updated
- [ ] `.ai/workflows.yaml` updated
- [x] `.ai/decisions.yaml` updated — new ADR-021
- [ ] `.ai/errors.yaml` updated
- [ ] N/A - No .ai/ updates needed

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (if applicable) — `CLAUDE.md`, `docs/developer/SDK-ROADMAP.md`, two action READMEs
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
N/A — closes roadmap item #206 with a documented "won't add SDK port; both stay composite-only by design".