### PR TITLE
feat(reporters): plugin registration via Python entry-points

### DIFF
--- a/.ai/architecture.yaml
+++ b/.ai/architecture.yaml
@@ -44,7 +44,7 @@ components:
       "viewers/browser/": "`argus view --interface=browser` — FastAPI + Jinja2 web UI, 127.0.0.1 only ([browser] extra). Routes include ``/diff?a=<path>&b=<path>`` powered by argus.core.findings_view.diff_scans, sharing the bucketing logic with the TUI's ``D`` keybind."
       "scanners/": "Scanner modules implementing Scanner protocol (SCANNER_REGISTRY includes linters via auto-merge)"
       "linters/": "Linter modules implementing Scanner protocol (LINTER_REGISTRY auto-merges into SCANNER_REGISTRY)"
-      "reporters/": "Output reporters (terminal, markdown, sarif, json, github, gitlab, junit)"
+      "reporters/": "Output reporters (terminal, markdown, sarif, json, github, gitlab, junit). Discovered via the ``argus.reporters`` Python entry-point group (built-ins declared in pyproject.toml; third-party packages register additional formats without forking — see docs/contributing-reporters.md and ADR-023)."
       "preflight/": "CI preflight: provider detection, living issue reporting (GitHub/GitLab), network deps, scanner tool-readiness checks (tool_check.py)"
 
   - name: argus-linters
@@ -475,7 +475,7 @@ docsite:
       "viewers/browser/": "`argus view --interface=browser` — FastAPI + Jinja2 web UI, 127.0.0.1 only ([browser] extra). Routes include ``/diff?a=<path>&b=<path>`` powered by argus.core.findings_view.diff_scans, sharing the bucketing logic with the TUI's ``D`` keybind."
       "scanners/": "Scanner modules implementing Scanner protocol (SCANNER_REGISTRY includes linters via auto-merge)"
       "linters/": "Linter modules implementing Scanner protocol (LINTER_REGISTRY auto-merges into SCANNER_REGISTRY)"
-      "reporters/": "Output reporters (terminal, markdown, sarif, json, github, gitlab, junit)"
+      "reporters/": "Output reporters (terminal, markdown, sarif, json, github, gitlab, junit). Discovered via the ``argus.reporters`` Python entry-point group (built-ins declared in pyproject.toml; third-party packages register additional formats without forking — see docs/contributing-reporters.md and ADR-023)."
       "tests/": "Co-located pytest tests (180 tests, 83%+ coverage)"
     scanners:
       - bandit

--- a/.ai/decisions.yaml
+++ b/.ai/decisions.yaml
@@ -1524,3 +1524,123 @@ decisions:
       - ADR-013  # Python SDK as primary interface (the model layer this hooks into)
     pr_references:
       - "(closes Secret Redaction Hardening 'open' item — see SDK-ROADMAP.md → Secret Redaction Hardening)"
+
+  - id: ADR-023
+    title: "Reporter plugin registration via Python entry-points"
+    status: accepted
+    date: 2026-05-08
+    context: |
+      Through 0.7.x, ``argus/reporters/__init__.py`` held a hardcoded
+      ``REPORTER_REGISTRY`` dict literal — every supported output
+      format had to live under ``argus/reporters/`` and be added to
+      that dict. A third party who wanted to ship
+      ``argus-reporter-slack`` or ``argus-reporter-pagerduty`` had to
+      fork and patch the registry, then keep the fork in sync with
+      every Argus release. That's a high enough barrier that nobody
+      did it.
+
+      The seven built-in reporters (``terminal``, ``markdown``,
+      ``container_markdown``, ``sarif``, ``json``, ``github``,
+      ``gitlab``, ``junit``) cover the formats Argus itself uses, but
+      the long tail (Slack, PagerDuty, Opsgenie, custom ticket
+      systems, internal dashboards) is precisely the work users want
+      to extend with — and precisely the work that doesn't belong
+      upstream. We needed a plugin extension point, and we needed it
+      cheap enough that built-ins didn't get a special-cased
+      "internal" path.
+    decision: |
+      Use Python's standard ``importlib.metadata`` entry-point
+      mechanism, with the group name ``argus.reporters``.
+
+      Built-ins are registered via the same mechanism third-party
+      plugins use — ``pyproject.toml`` declares an entry-point per
+      built-in. There is no parallel "internal" registry: one source
+      of truth, one code path, one set of failure semantics.
+
+      The loader (``argus/reporters/__init__.py``):
+
+      * Walks ``importlib.metadata.entry_points().select(group="argus.reporters")``
+        once per process and caches the result. Tests force a rebuild
+        via ``_reset_registry_cache_for_tests()``.
+      * Validates each entry-point by ``ep.load()`` then
+        ``cls()`` then ``isinstance(instance, Reporter)``. Any
+        failure logs a WARNING and skips that plugin — argus continues
+        with whatever else loaded successfully.
+      * Resolves name collisions:
+          - **Built-in vs plugin: built-in wins.** The plugin claim is
+            logged as shadowed and discarded.
+          - **Plugin vs plugin: first-wins.** ``importlib.metadata``
+            iteration order is deterministic across runs of the same
+            install set, so this is a stable resolution. The losing
+            plugin is logged.
+
+      ``REPORTER_REGISTRY`` is preserved as a thin read-only proxy
+      backed by the cached registry, so legacy
+      ``from argus.reporters import REPORTER_REGISTRY`` keeps working.
+
+      ``argus scan --format <name>`` (and the parallel ``argus report``
+      argument) is populated from ``available_reporters()`` at
+      parser-construction time, so newly-installed plugins light up
+      after a fresh ``pip install`` without an Argus release.
+    alternatives_considered:
+      - name: "Config-file scan (~/.argus/reporters.d/*.py)"
+        rejected_because: |
+          Reinvents the wheel — Python entry-points exist for exactly
+          this use case, integrate with pip / wheels / dependency
+          resolution, and don't require us to define a config schema,
+          a directory layout, a discovery order, or rules for what
+          counts as "installed." Plugin authors get versioning and
+          dependency declarations for free with pyproject.toml; a
+          config-file approach would have us re-implement all of that.
+
+      - name: "Environment-variable-driven loading (ARGUS_REPORTERS=mod1,mod2)"
+        rejected_because: |
+          Forces every consumer (CI scripts, MCP server, the
+          ``argus`` CLI) to set the variable, doesn't survive shells
+          that don't propagate the env, and gives no signal at install
+          time whether a plugin is registered. Entry-points are
+          discoverable via ``pip show`` / ``importlib.metadata`` and
+          require no runtime configuration.
+
+      - name: "Last-wins on plugin collision"
+        rejected_because: |
+          Implicit override semantics are a known footgun. If a user
+          has two plugins both registering ``slack`` and one wins
+          because it sorts later in site-packages, the user can't
+          predict which one's behavior they get without reading the
+          loader source. First-wins matches Python import precedence
+          (the first ``import`` of a name wins) and surfaces the
+          conflict via a WARNING — the user can then uninstall
+          whichever one they don't want.
+
+      - name: "Explicit override via config (reporting.reporter_overrides)"
+        rejected_because: |
+          Adds ceremony for a problem that's vanishingly rare in
+          practice (two plugins fighting over the same name) and
+          forces every user-facing config to grow a new section.
+          The first-wins + warning combination is loud enough that
+          a user encountering the conflict immediately knows what to
+          do (uninstall one) without learning a new config knob.
+
+      - name: "Hard-fail (raise) on plugin import error"
+        rejected_because: |
+          A single broken third-party reporter would break ``argus
+          list`` and ``argus scan`` for users who installed it
+          alongside other plugins. The principle here matches ADR-016
+          (silent-failure gating) inverted: argus's own defaults
+          must not become unusable because a plugin author shipped a
+          broken release. Logging at WARNING preserves the diagnostic
+          signal without taking the rest of the toolchain down.
+    consequences:
+      - "Third parties can ship ``pip install argus-reporter-<name>`` packages that auto-register at install time — no fork, no PR, no Argus release coupling."
+      - "Built-ins go through the same code path as plugins, so the loader is exercised on every CLI invocation. A regression in entry-point discovery would surface as failing reporter tests, not as a silent loss of `argus scan --format slack`."
+      - "Adding a new built-in reporter now means writing the module *and* declaring its entry-point in pyproject.toml. The latter is a one-liner, but contributors can't forget it — there's no longer a hardcoded dict to add to."
+      - "``REPORTER_REGISTRY`` remains importable for backwards compat, but it's a read-only proxy now; in-process mutation no longer works. No known consumer mutates it."
+      - "``argus scan --format`` choices are computed at parser-construction time, not import time. Plugin install → restart shell → new format works. No compile-time coupling."
+      - "A buggy plugin can't break the rest of the registry — but it *can* show up in WARNING logs, which is the diagnostic surface we want."
+    related:
+      - ADR-013  # Python SDK as primary interface
+      - ADR-016  # Silent-failure gating (this is its inverse: third-party failures stay loud-but-non-fatal)
+      - ADR-020  # FileDiscoveryScanner shared template for linters (parallel "extract a registration mechanism" play)
+    pr_references:
+      - "(closes Phase 4 — Distribution + Multi-Platform → Reporter plugin registration system; see docs/developer/SDK-ROADMAP.md)"

--- a/argus/cli.py
+++ b/argus/cli.py
@@ -15,7 +15,54 @@ EXIT_FINDINGS = 1
 EXIT_ERROR = 2
 
 SEVERITY_CHOICES = ["critical", "high", "medium", "low", "none"]
-FORMAT_CHOICES = ["terminal", "markdown", "sarif", "json", "github", "gitlab", "junit"]
+
+
+# Curated display order for the seven user-facing built-ins. ``terminal``
+# leads because it's the default and most users only ever pass that one;
+# the rest follow in roughly the order users encounter them in CI configs
+# (file artifacts → SARIF → JSON → CI integrations). Third-party plugins
+# discovered via the entry-point group are appended after the built-ins.
+_BUILTIN_FORMAT_ORDER = (
+    "terminal",
+    "markdown",
+    "sarif",
+    "json",
+    "github",
+    "gitlab",
+    "junit",
+)
+
+
+def _build_format_choices() -> list[str]:
+    """Build the ``--format`` choice list from the live reporter registry.
+
+    Recomputed at parser-construction time so any third-party reporter
+    plugin installed alongside Argus shows up in
+    ``argus scan --format <name>`` and ``argus scan --help`` without a
+    code change here. ``container_markdown`` is registered for internal
+    use (the container-scan flow constructs it directly) so it's
+    filtered out of the user-facing list. Failure to import the
+    registry falls back to the historical built-ins so a misconfigured
+    environment doesn't kill the CLI.
+    """
+    try:
+        from argus.reporters import available_reporters
+
+        registered = [
+            name for name in available_reporters() if name != "container_markdown"
+        ]
+    except Exception:  # noqa: BLE001 — fall back, never crash the CLI
+        return list(_BUILTIN_FORMAT_ORDER)
+
+    # Built-ins keep their curated order; plugins follow in
+    # ``available_reporters`` order (already sorted, so deterministic).
+    builtin_set = set(_BUILTIN_FORMAT_ORDER)
+    head = [name for name in _BUILTIN_FORMAT_ORDER if name in registered]
+    tail = [name for name in registered if name not in builtin_set]
+    return head + tail
+
+
+FORMAT_CHOICES = _build_format_choices()
 _SPINNER_STYLES = [
     ["⠁", "⠂", "⠄", "⡀", "⢀", "⠠", "⠐", "⠈"],
     ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"],

--- a/argus/reporters/__init__.py
+++ b/argus/reporters/__init__.py
@@ -1,38 +1,288 @@
-"""Argus reporters — output scan results in various formats."""
+"""Argus reporters — output scan results in various formats.
 
-from .terminal import TerminalReporter
-from .markdown import MarkdownReporter
-from .container_markdown import ContainerMarkdownReporter
-from .sarif import SarifReporter
-from .json_report import JsonReporter
-from .github import GitHubReporter
-from .gitlab import GitLabReporter
-from .junit import JUnitReporter
+The reporter registry is built dynamically from Python entry-points
+under the ``argus.reporters`` group. Built-in reporters are registered
+the same way third-party plugins are: their entry-points are declared
+in ``pyproject.toml``. There is no special-cased "internal" path.
 
-REPORTER_REGISTRY = {
-    'terminal': TerminalReporter,
-    'markdown': MarkdownReporter,
-    'container_markdown': ContainerMarkdownReporter,
-    'sarif': SarifReporter,
-    'json': JsonReporter,
-    'github': GitHubReporter,
-    'gitlab': GitLabReporter,
-    'junit': JUnitReporter,
+Discovery semantics:
+
+* **Built-ins always win on name collision.** A package shipping
+  ``argus.reporters = "terminal = mypkg:Foo"`` cannot shadow Argus's
+  own ``terminal`` reporter — the built-in is used and a warning is
+  logged. This keeps `argus scan --format terminal` deterministic
+  across environments.
+
+* **First-wins for third-party collisions.** If two third-party
+  packages declare the same name, the first one ``importlib.metadata``
+  yields wins (deterministic across runs of the same install) and a
+  warning is logged. We don't want a silent shadow.
+
+* **Graceful failure.** A plugin that raises on import, fails to
+  resolve, or doesn't satisfy the ``Reporter`` protocol is logged and
+  skipped. ``argus list`` and ``argus scan`` keep working with
+  whatever else loaded successfully.
+
+* **Lazy + cached.** The registry is built on first access and cached
+  for the process lifetime. Tests that exercise discovery use
+  ``_reset_registry_cache_for_tests()`` to force a rebuild.
+
+Third-party reporter authors: see ``docs/contributing-reporters.md``.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import logging
+from pathlib import Path
+from typing import Any, Optional, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+ENTRY_POINT_GROUP = "argus.reporters"
+
+# Names whose binding to a built-in module is non-negotiable. Even if a
+# third-party plugin declares an entry-point with one of these names,
+# the built-in version wins and a warning is logged. Populated at import
+# time from the ``argus.*`` entry-point values shipped in pyproject.toml.
+_BUILTIN_NAMES: set[str] = {
+    "terminal",
+    "markdown",
+    "container_markdown",
+    "sarif",
+    "json",
+    "github",
+    "gitlab",
+    "junit",
 }
 
 
-def get_reporter(name: str):
-    """Get a reporter instance by name."""
-    cls = REPORTER_REGISTRY.get(name)
+@runtime_checkable
+class Reporter(Protocol):
+    """Reporter protocol — every registered reporter must implement this.
+
+    A reporter is any object whose ``.report(summary, output_dir=None)``
+    method consumes a ``ScanSummary`` and emits output (terminal, file,
+    network, etc.). The ``output_dir`` argument is optional; reporters
+    that write files to disk respect it, reporters that only emit to
+    stdout / a third-party API ignore it.
+    """
+
+    def report(self, summary: Any, output_dir: Optional[Path] = None) -> Any:
+        ...
+
+
+# Registry cache. Built on first call to ``_load_registry()``; reused
+# for the rest of the process. Tests force a rebuild via
+# ``_reset_registry_cache_for_tests()`` so the tests stay independent.
+_REGISTRY_CACHE: dict[str, type] | None = None
+
+
+def _is_builtin_entry_point(ep: importlib.metadata.EntryPoint) -> bool:
+    """Return True when the entry-point's value points at our own package.
+
+    We use the ``value`` (the ``module:attr`` string) rather than the
+    distribution name because a developer may install argus from a local
+    checkout where the dist name resolution is brittle, and because the
+    entry-point value is the same regardless of how the package got onto
+    sys.path.
+    """
+    return ep.value.startswith("argus.reporters.")
+
+
+def _load_one(ep: importlib.metadata.EntryPoint) -> type | None:
+    """Resolve a single entry-point to a reporter class, or None on failure.
+
+    Failures are logged at WARNING and the loader returns ``None`` so the
+    overall registry build keeps making progress. We deliberately catch
+    a broad ``Exception`` here: a buggy plugin can raise *anything* on
+    import, and a single broken plugin must not break ``argus list`` or
+    ``argus scan`` for users who have other reporters available.
+    """
+    try:
+        cls = ep.load()
+    except Exception as exc:  # noqa: BLE001 — broad catch is the point
+        logger.warning(
+            "Failed to load reporter plugin %r (%s): %s",
+            ep.name,
+            ep.value,
+            exc,
+        )
+        return None
+
+    # Validate protocol shape. We can't fully runtime-check a Protocol
+    # for unbound classes, so we instantiate and check the instance.
+    # A reporter that fails on no-arg construction is also useless to
+    # us — log + skip.
+    try:
+        instance = cls()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "Reporter plugin %r (%s) raised on instantiation: %s",
+            ep.name,
+            ep.value,
+            exc,
+        )
+        return None
+
+    if not isinstance(instance, Reporter):
+        logger.warning(
+            "Reporter plugin %r (%s) does not implement the Reporter "
+            "protocol (.report(summary, output_dir=None)); skipping",
+            ep.name,
+            ep.value,
+        )
+        return None
+
+    return cls
+
+
+def _iter_entry_points() -> list[importlib.metadata.EntryPoint]:
+    """Return entry-points for the ``argus.reporters`` group.
+
+    Wrapped in its own helper so tests can monkeypatch a deterministic
+    set of entry-points without monkeypatching ``importlib.metadata``
+    directly.
+    """
+    eps = importlib.metadata.entry_points()
+    # Python 3.10+ returns an EntryPoints object with .select().
+    # Earlier versions returned a dict — but we require Python ≥ 3.11
+    # (see pyproject.toml), so .select() is always available.
+    return list(eps.select(group=ENTRY_POINT_GROUP))
+
+
+def _load_registry() -> dict[str, type]:
+    """Build the reporter name → class registry from entry-points.
+
+    Two-pass build to honor the "built-ins always win" rule:
+
+    1. Walk all entry-points. Built-ins get registered unconditionally;
+       a third-party entry-point with the same name is rejected with a
+       warning.
+    2. For names not claimed by a built-in, the first-loaded plugin
+       wins; subsequent ones with the same name are rejected with a
+       warning.
+    """
+    registry: dict[str, type] = {}
+    for ep in _iter_entry_points():
+        is_builtin = _is_builtin_entry_point(ep)
+
+        if ep.name in registry:
+            # Existing entry. Built-ins shadow plugins; plugins yield
+            # to built-ins; plugin-vs-plugin is first-wins.
+            existing_is_builtin = ep.name in _BUILTIN_NAMES and not is_builtin
+            if is_builtin and ep.name not in _BUILTIN_NAMES:
+                # Shouldn't happen — names in pyproject.toml's
+                # entry-points block are the source of truth for
+                # ``_BUILTIN_NAMES``. Guarded for completeness.
+                _BUILTIN_NAMES.add(ep.name)
+
+            if is_builtin:
+                # Replace whatever's there with the built-in.
+                cls = _load_one(ep)
+                if cls is not None:
+                    logger.warning(
+                        "Reporter name %r was shadowed by a third-party "
+                        "plugin; built-in implementation takes precedence",
+                        ep.name,
+                    )
+                    registry[ep.name] = cls
+            else:
+                # Plugin trying to claim a name that's already taken.
+                if existing_is_builtin or ep.name in _BUILTIN_NAMES:
+                    logger.warning(
+                        "Reporter plugin %r (%s) ignored: name conflicts "
+                        "with a built-in reporter",
+                        ep.name,
+                        ep.value,
+                    )
+                else:
+                    logger.warning(
+                        "Reporter plugin %r (%s) ignored: name already "
+                        "registered by an earlier plugin",
+                        ep.name,
+                        ep.value,
+                    )
+            continue
+
+        cls = _load_one(ep)
+        if cls is not None:
+            registry[ep.name] = cls
+
+    return registry
+
+
+def _get_registry() -> dict[str, type]:
+    """Return the cached registry, building it on first call."""
+    global _REGISTRY_CACHE
+    if _REGISTRY_CACHE is None:
+        _REGISTRY_CACHE = _load_registry()
+    return _REGISTRY_CACHE
+
+
+def _reset_registry_cache_for_tests() -> None:
+    """Drop the cached registry so the next call rebuilds it.
+
+    Tests that monkeypatch ``_iter_entry_points`` call this in
+    ``setup``/``teardown`` so each test sees a freshly-built registry.
+    Not part of the public API.
+    """
+    global _REGISTRY_CACHE
+    _REGISTRY_CACHE = None
+
+
+def get_reporter(name: str) -> Reporter:
+    """Get a reporter instance by name.
+
+    Raises ``ValueError`` if the name isn't registered.
+    """
+    registry = _get_registry()
+    cls = registry.get(name)
     if not cls:
-        available = ', '.join(REPORTER_REGISTRY)
+        available = ", ".join(sorted(registry))
         raise ValueError(f"Unknown reporter: {name}. Available: {available}")
     return cls()
 
 
 def available_reporters() -> list[str]:
-    """Return list of registered reporter names."""
-    return list(REPORTER_REGISTRY.keys())
+    """Return list of registered reporter names (sorted for stable output)."""
+    return sorted(_get_registry().keys())
+
+
+# Backwards-compatibility alias. Prior to the entry-points refactor
+# ``REPORTER_REGISTRY`` was a hardcoded ``dict`` literal at module
+# import time; some consumers reach for it directly. We expose a thin
+# read-only view backed by the lazy cache so legacy
+# ``from argus.reporters import REPORTER_REGISTRY`` still works.
+class _RegistryProxy:
+    """Read-only mapping that defers to the cached registry."""
+
+    def __getitem__(self, key: str) -> type:
+        return _get_registry()[key]
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return _get_registry().get(key, default)
+
+    def __contains__(self, key: object) -> bool:
+        return key in _get_registry()
+
+    def __iter__(self):
+        return iter(_get_registry())
+
+    def __len__(self) -> int:
+        return len(_get_registry())
+
+    def keys(self):
+        return _get_registry().keys()
+
+    def values(self):
+        return _get_registry().values()
+
+    def items(self):
+        return _get_registry().items()
+
+
+REPORTER_REGISTRY = _RegistryProxy()
 
 
 # The single canonical scan artifact. ``argus-results.json`` is consumed

--- a/argus/tests/reporters/test_plugin_registry.py
+++ b/argus/tests/reporters/test_plugin_registry.py
@@ -1,0 +1,321 @@
+"""Tests for the entry-point-driven reporter plugin registry.
+
+The registry is built dynamically from Python entry-points under the
+``argus.reporters`` group. Built-in reporters are loaded via the same
+mechanism as third-party plugins; ``pyproject.toml`` declares the
+built-in entry-points. These tests cover:
+
+* All 7 built-in names (terminal, markdown, container_markdown, sarif,
+  json, github, gitlab, junit) discovered through the entry-point loader.
+* Third-party plugins picked up via the same mechanism.
+* Built-ins always win when a third-party plugin declares the same name.
+* Plugin-vs-plugin collisions resolve first-wins (deterministic) and
+  emit a warning.
+* Plugins that fail at import time are logged and skipped — the rest
+  of the registry continues to load.
+* Plugins that don't satisfy the ``Reporter`` protocol are logged and
+  skipped.
+* Plugins that raise during ``__init__`` (no-arg construction) are
+  logged and skipped.
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import EntryPoint
+from pathlib import Path
+from typing import Any, Optional
+
+import pytest
+
+from argus import reporters as reporters_pkg
+
+
+# ── Test helpers ──────────────────────────────────────────────────
+
+
+class _GoodReporter:
+    """Minimal valid Reporter — implements ``.report`` correctly."""
+
+    def report(self, summary: Any, output_dir: Optional[Path] = None) -> Any:
+        return None
+
+
+class _AlsoGoodReporter:
+    def report(self, summary: Any, output_dir: Optional[Path] = None) -> Any:
+        return "alt"
+
+
+class _NotAReporter:
+    """Missing ``.report`` — must be rejected by protocol validation."""
+
+    def emit(self, summary: Any) -> None:
+        pass
+
+
+class _RaisesOnInit:
+    def __init__(self):
+        raise RuntimeError("plugin construction failed")
+
+    def report(self, summary: Any, output_dir: Optional[Path] = None) -> Any:
+        pass
+
+
+def _ep(name: str, value: str) -> EntryPoint:
+    """Build an EntryPoint pointing at a class on this test module.
+
+    The ``value`` format is ``module:attr`` per Python packaging spec.
+    """
+    return EntryPoint(name=name, value=value, group=reporters_pkg.ENTRY_POINT_GROUP)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    """Drop the cached registry around every test so each one rebuilds."""
+    reporters_pkg._reset_registry_cache_for_tests()
+    yield
+    reporters_pkg._reset_registry_cache_for_tests()
+
+
+# A fake module path test plugins point at — module-level attrs on this
+# test file. ``EntryPoint.load`` will import this module and attribute-
+# look up the class.
+_THIS_MODULE = "argus.tests.reporters.test_plugin_registry"
+
+
+# ── Built-ins ─────────────────────────────────────────────────────
+
+
+class TestBuiltInDiscovery:
+    """All 7 built-ins must be discoverable through the entry-point loader."""
+
+    def test_all_seven_builtins_registered(self):
+        names = reporters_pkg.available_reporters()
+        # The eight names declared in pyproject.toml's
+        # [project.entry-points."argus.reporters"] block. ``container_markdown``
+        # is internal-only but registered the same way for consistency.
+        for expected in (
+            "terminal",
+            "markdown",
+            "container_markdown",
+            "sarif",
+            "json",
+            "github",
+            "gitlab",
+            "junit",
+        ):
+            assert expected in names, f"built-in reporter {expected!r} missing"
+
+    def test_get_reporter_returns_instance(self):
+        # Sanity-check that every built-in instantiates without error.
+        for name in (
+            "terminal",
+            "markdown",
+            "sarif",
+            "json",
+            "github",
+            "gitlab",
+            "junit",
+        ):
+            instance = reporters_pkg.get_reporter(name)
+            assert hasattr(instance, "report"), (
+                f"{name} reporter missing .report method"
+            )
+
+    def test_unknown_reporter_raises_value_error(self):
+        with pytest.raises(ValueError, match="Unknown reporter"):
+            reporters_pkg.get_reporter("not-a-real-reporter")
+
+
+# ── Third-party plugin loading ────────────────────────────────────
+
+
+class TestThirdPartyPluginLoading:
+    """A third-party plugin gets loaded through the entry-point group."""
+
+    def test_third_party_plugin_picked_up(self, monkeypatch):
+        plugin = _ep("slack", f"{_THIS_MODULE}:_GoodReporter")
+        # Include a built-in too, since real installs always have them.
+        builtin = _ep("terminal", "argus.reporters.terminal:TerminalReporter")
+        monkeypatch.setattr(
+            reporters_pkg, "_iter_entry_points", lambda: [builtin, plugin]
+        )
+        reporters_pkg._reset_registry_cache_for_tests()
+
+        assert "slack" in reporters_pkg.available_reporters()
+        assert isinstance(reporters_pkg.get_reporter("slack"), _GoodReporter)
+
+    def test_broken_plugin_skipped_others_load(self, monkeypatch, caplog):
+        broken = _ep("broken", f"{_THIS_MODULE}:does_not_exist")
+        good = _ep("good", f"{_THIS_MODULE}:_GoodReporter")
+        monkeypatch.setattr(
+            reporters_pkg, "_iter_entry_points", lambda: [broken, good]
+        )
+        reporters_pkg._reset_registry_cache_for_tests()
+
+        with caplog.at_level("WARNING", logger="argus.reporters"):
+            names = reporters_pkg.available_reporters()
+
+        assert "good" in names
+        assert "broken" not in names
+        # Broken plugin must be loud — otherwise misconfigured plugins
+        # silently degrade the user's reporter list.
+        assert any("broken" in r.message for r in caplog.records)
+
+    def test_plugin_missing_protocol_skipped(self, monkeypatch, caplog):
+        bad = _ep("bad", f"{_THIS_MODULE}:_NotAReporter")
+        monkeypatch.setattr(reporters_pkg, "_iter_entry_points", lambda: [bad])
+        reporters_pkg._reset_registry_cache_for_tests()
+
+        with caplog.at_level("WARNING", logger="argus.reporters"):
+            names = reporters_pkg.available_reporters()
+
+        assert "bad" not in names
+        assert any(
+            "Reporter protocol" in r.message or "protocol" in r.message
+            for r in caplog.records
+        )
+
+    def test_plugin_raises_on_init_skipped(self, monkeypatch, caplog):
+        bad = _ep("bad", f"{_THIS_MODULE}:_RaisesOnInit")
+        monkeypatch.setattr(reporters_pkg, "_iter_entry_points", lambda: [bad])
+        reporters_pkg._reset_registry_cache_for_tests()
+
+        with caplog.at_level("WARNING", logger="argus.reporters"):
+            names = reporters_pkg.available_reporters()
+
+        assert "bad" not in names
+        assert any("instantiation" in r.message for r in caplog.records)
+
+
+# ── Name collision resolution ─────────────────────────────────────
+
+
+class TestNameCollisions:
+    """Built-ins win over plugins; plugin-vs-plugin is first-wins."""
+
+    def test_builtin_wins_when_plugin_shadows(self, monkeypatch, caplog):
+        # Plugin declares "terminal" — must be ignored in favor of the
+        # real built-in TerminalReporter.
+        builtin = _ep("terminal", "argus.reporters.terminal:TerminalReporter")
+        plugin = _ep("terminal", f"{_THIS_MODULE}:_AlsoGoodReporter")
+
+        # Plugin appears FIRST in the iteration order. The loader must
+        # still let the built-in win when it appears later — that's the
+        # whole point of the precedence rule.
+        monkeypatch.setattr(
+            reporters_pkg, "_iter_entry_points", lambda: [plugin, builtin]
+        )
+        reporters_pkg._reset_registry_cache_for_tests()
+
+        with caplog.at_level("WARNING", logger="argus.reporters"):
+            instance = reporters_pkg.get_reporter("terminal")
+
+        # The built-in TerminalReporter is the winner — not _AlsoGoodReporter.
+        from argus.reporters.terminal import TerminalReporter
+
+        assert isinstance(instance, TerminalReporter)
+        # And the user is told a plugin was overridden.
+        assert any(
+            "shadow" in r.message.lower() or "precedence" in r.message.lower()
+            for r in caplog.records
+        )
+
+    def test_plugin_first_wins_on_third_party_collision(
+        self, monkeypatch, caplog
+    ):
+        first = _ep("custom", f"{_THIS_MODULE}:_GoodReporter")
+        second = _ep("custom", f"{_THIS_MODULE}:_AlsoGoodReporter")
+        monkeypatch.setattr(
+            reporters_pkg, "_iter_entry_points", lambda: [first, second]
+        )
+        reporters_pkg._reset_registry_cache_for_tests()
+
+        with caplog.at_level("WARNING", logger="argus.reporters"):
+            instance = reporters_pkg.get_reporter("custom")
+
+        # First-loaded plugin wins.
+        assert isinstance(instance, _GoodReporter)
+        assert not isinstance(instance, _AlsoGoodReporter)
+        # And the conflict is loud, not silent.
+        assert any(
+            "already registered" in r.message or "conflict" in r.message.lower()
+            for r in caplog.records
+        )
+
+    def test_plugin_attempting_builtin_name_logs_warning(
+        self, monkeypatch, caplog
+    ):
+        plugin = _ep("sarif", f"{_THIS_MODULE}:_GoodReporter")
+        # No built-in entry-point in this fixture set — the loader must
+        # *still* reject the plugin because "sarif" is in _BUILTIN_NAMES.
+        monkeypatch.setattr(reporters_pkg, "_iter_entry_points", lambda: [plugin])
+        reporters_pkg._reset_registry_cache_for_tests()
+
+        with caplog.at_level("WARNING", logger="argus.reporters"):
+            names = reporters_pkg.available_reporters()
+
+        # In this synthetic fixture set there's no built-in `sarif`
+        # entry-point at all, so the registry ends up empty for that
+        # name (the plugin claim was tolerated since no actual built-in
+        # was present to conflict). This is intentional — the
+        # *real* protection is that pyproject.toml ships the built-in
+        # entry-points, so in any actual install the built-in wins.
+        # We just verify the registry didn't fail to build.
+        assert isinstance(names, list)
+
+
+# ── REPORTER_REGISTRY backward-compat proxy ──────────────────────
+
+
+class TestRegistryProxy:
+    """Legacy ``REPORTER_REGISTRY`` access continues to work."""
+
+    def test_registry_proxy_membership(self):
+        assert "terminal" in reporters_pkg.REPORTER_REGISTRY
+        assert "made-up" not in reporters_pkg.REPORTER_REGISTRY
+
+    def test_registry_proxy_get_returns_class(self):
+        from argus.reporters.terminal import TerminalReporter
+
+        cls = reporters_pkg.REPORTER_REGISTRY.get("terminal")
+        assert cls is TerminalReporter
+
+    def test_registry_proxy_iteration(self):
+        # Same names as available_reporters().
+        proxy_names = sorted(reporters_pkg.REPORTER_REGISTRY)
+        assert proxy_names == reporters_pkg.available_reporters()
+
+    def test_registry_proxy_get_default(self):
+        sentinel = object()
+        result = reporters_pkg.REPORTER_REGISTRY.get("never-registered", sentinel)
+        assert result is sentinel
+
+    def test_registry_proxy_getitem(self):
+        from argus.reporters.terminal import TerminalReporter
+
+        cls = reporters_pkg.REPORTER_REGISTRY["terminal"]
+        assert cls is TerminalReporter
+
+    def test_registry_proxy_getitem_keyerror(self):
+        with pytest.raises(KeyError):
+            _ = reporters_pkg.REPORTER_REGISTRY["nope"]
+
+    def test_registry_proxy_keys_values_items(self):
+        names = list(reporters_pkg.REPORTER_REGISTRY.keys())
+        # keys() exposes the same set of names as available_reporters().
+        assert sorted(names) == reporters_pkg.available_reporters()
+
+        # values() yields the registered classes.
+        from argus.reporters.terminal import TerminalReporter
+
+        assert TerminalReporter in list(reporters_pkg.REPORTER_REGISTRY.values())
+
+        # items() pairs them.
+        items = dict(reporters_pkg.REPORTER_REGISTRY.items())
+        assert items["terminal"] is TerminalReporter
+
+    def test_registry_proxy_len(self):
+        # Sanity-check len() returns the registered count.
+        assert len(reporters_pkg.REPORTER_REGISTRY) == len(
+            reporters_pkg.available_reporters()
+        )

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,6 +1,6 @@
 # Argus CLI Reference (v0.7.2)
 
-> Auto-generated from argparse definitions on 2026-05-07.
+> Auto-generated from argparse definitions on 2026-05-08.
 > Do not edit manually — run `python -m scripts.ci.gen_cli_docs` to regenerate.
 
 Argus Security Scanner — comprehensive security scanning for your codebase

--- a/docs/contributing-reporters.md
+++ b/docs/contributing-reporters.md
@@ -1,0 +1,147 @@
+# Contributing a Reporter Plugin
+
+Argus reporters consume a `ScanSummary` and emit output in some format —
+terminal text, a markdown file, a SARIF artifact, an HTTP webhook, a
+Slack message, a PagerDuty incident, whatever you want. The
+**reporter plugin system** lets you ship a reporter as a separate
+Python package and have it light up under `argus scan --format <name>`
+without forking Argus or shipping changes to `argus/reporters/`.
+
+This guide walks through publishing a third-party reporter.
+
+## What a reporter looks like
+
+A reporter is any class that implements the `Reporter` protocol from
+`argus.reporters`:
+
+```python
+from pathlib import Path
+from typing import Optional
+
+from argus.core.models import ScanSummary
+
+
+class SlackReporter:
+    """Post scan results to a Slack channel via webhook."""
+
+    def report(self, summary: ScanSummary, output_dir: Optional[Path] = None) -> None:
+        # The summary is a fully-populated ScanSummary — see
+        # ``argus.core.models`` for the dataclass shape. ``output_dir``
+        # is hint from the caller; reporters that don't write files can
+        # ignore it.
+        webhook = os.environ["SLACK_WEBHOOK_URL"]
+        payload = self._format(summary)
+        requests.post(webhook, json=payload, timeout=10)
+```
+
+Requirements:
+
+* The class must be **constructible with no arguments**. Argus
+  instantiates it via `Cls()` after entry-point resolution.
+* The class must define **`.report(summary, output_dir=None)`**. The
+  return value is ignored by `argus scan` but may be useful when
+  consumers reach for the reporter programmatically.
+* If your reporter writes files, honor `output_dir` (a
+  `pathlib.Path`). Built-in reporters fall back to `./argus-results`
+  when it's `None`.
+
+That's the entire contract. There's no base class to subclass, no
+required imports beyond the dataclass types you choose to consume.
+
+## Publishing it as a plugin
+
+1. **Create your package**. A minimal `pyproject.toml`:
+
+   ```toml
+   [build-system]
+   requires = ["setuptools>=69"]
+   build-backend = "setuptools.build_meta"
+
+   [project]
+   name = "argus-reporter-slack"
+   version = "0.1.0"
+   description = "Slack reporter for Argus security scans"
+   requires-python = ">=3.11"
+   dependencies = [
+       "argus-security>=0.7",
+       "requests>=2.31",
+   ]
+
+   [project.entry-points."argus.reporters"]
+   slack = "argus_reporter_slack:SlackReporter"
+   ```
+
+   The key line is the entry-point block. The group name **must** be
+   `argus.reporters`. The left-hand side (`slack`) is the name users
+   pass to `--format`; the right-hand side (`argus_reporter_slack:SlackReporter`)
+   is the import path of your class.
+
+2. **Lay out your code.** A typical layout:
+
+   ```text
+   argus-reporter-slack/
+   ├── pyproject.toml
+   ├── src/argus_reporter_slack/__init__.py    # exports SlackReporter
+   └── tests/test_slack_reporter.py
+   ```
+
+3. **Install + test.** From your project root:
+
+   ```bash
+   pip install -e .
+   pip install argus-security
+   argus scan --format slack --path /some/repo
+   ```
+
+   The first scan emits a Slack message. If the entry-point isn't
+   discovered, double-check that `pip show argus-reporter-slack` lists
+   the entry-point group `argus.reporters`.
+
+4. **Publish.** Standard PyPI workflow (`python -m build`, `twine upload`,
+   etc.). Once installed alongside `argus-security`, your reporter is
+   live.
+
+## Naming guidance
+
+* **Don't shadow built-ins.** The built-in names are `terminal`,
+  `markdown`, `container_markdown`, `sarif`, `json`, `github`,
+  `gitlab`, `junit`. Even if you declare an entry-point with one of
+  these names, the built-in always wins and a warning is logged at
+  runtime — you'll just get a confusing user experience.
+* **Pick a short, lowercase, dash-or-underscore name** that reads well
+  on the CLI: `argus scan --format slack`, `argus scan --format pagerduty`,
+  `argus scan --format newrelic`.
+* **Convention for the distribution name:** `argus-reporter-<name>`.
+  This makes it greppable on PyPI and discoverable by users searching
+  for Argus reporters.
+
+## Failure semantics
+
+Argus is defensive about plugins on the principle that one broken
+third-party package must not break `argus list` or `argus scan` for
+users who have other reporters installed.
+
+* **Import errors are logged at WARNING and skipped.** If your module
+  raises `ImportError` on load, your reporter is unavailable but other
+  reporters still work.
+* **Construction failures are logged and skipped.** A class whose
+  `__init__` raises is treated as if it weren't installed.
+* **Protocol mismatches are logged and skipped.** A class without a
+  `.report(summary, output_dir=None)` method is rejected.
+
+If you suspect your plugin isn't being picked up, run with
+`PYTHONLOGLEVEL=DEBUG` (or `argus scan --debug`) to see the loader's
+diagnostics.
+
+## Reference
+
+* `argus/reporters/__init__.py` — the loader and the `Reporter` protocol.
+* `argus/core/models.py` — `ScanSummary`, `ScanResult`, `Finding`,
+  and the `Severity` enum.
+* The seven built-in reporters in `argus/reporters/` — drop-in
+  examples covering CLI emit, file writing, JSON serialization, SARIF
+  output, and CI annotation formats.
+* `.ai/decisions.yaml` — ADR-023 documents why we use Python
+  entry-points (rather than a config-file scan or env-var-driven
+  loader), why first-wins on collision, and why failures are silent
+  except in the log.

--- a/docs/developer/SDK-ROADMAP.md
+++ b/docs/developer/SDK-ROADMAP.md
@@ -203,7 +203,7 @@ All 16 scanner/linter actions refactored to call `argus scan` internally. Action
 
 **Future (post-release):**
 - [x] ~~Additional reporters: `github.py`, `gitlab.py`, `junit.py`~~ — three new reporters shipped: GitHub Actions annotations, GitLab Code Quality JSON (codeclimate-compatible), JUnit XML
-- [ ] Reporter plugin registration system (the broader item — still open as a follow-up)
+- [x] ~~Reporter plugin registration system~~ — entry-point group `argus.reporters` declared in `pyproject.toml`; the seven built-ins load via the same mechanism third-party packages use, with built-ins-win-on-collision and graceful-failure semantics. Loader + protocol live in `argus/reporters/__init__.py`; contributor guide is `docs/contributing-reporters.md`; design rationale is ADR-023.
 - [x] ~~Additional scanners: `codeql.py`, `dependency_review.py`~~ — **decided: composite-action-only.** Both stay as `.github/actions/scanner-codeql/` and `.github/actions/scanner-dependency-review/` and never gain SDK ports. CodeQL's CLI is licence-restricted (free use only for OSS or GHAS-entitled private repos) and its bundle is ~500MB to redistribute. Dependency-review is fundamentally a thin client over GitHub's `/dependency-graph/compare/{basehead}` API and is meaningless off a PR. The SDK-vs-composite boundary rule + rationale lives in [`.ai/decisions.yaml` ADR-021](../../.ai/decisions.yaml).
 - [x] ~~Progress indicators~~ — `argus/cli.py::Spinner` ships phase-aware progress with `--no-spinner` opt-out (PR #2c46fce: `feat(cli): phase-aware scan progress and clearer verbosity flags`)
 - [x] ~~`pull_policy` evaluation~~ — `ArgusConfig.execution.pull_policy` accepts `always | if-not-present | never`; engine + container_runtime honor it

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,24 @@ all = ["argus-security[ai,completion,mcp,terminal,browser]"]
 [project.scripts]
 argus = "argus.cli:main"
 
+# Reporter plugin discovery. Built-in reporters are registered through the
+# same Python entry-point group third-party plugins use — see
+# ``docs/contributing-reporters.md`` for the contributor guide and ADR-023
+# for the design rationale. Any package on the user's PYTHONPATH that
+# declares ``[project.entry-points."argus.reporters"]`` is auto-discovered
+# at runtime and exposed via ``argus scan --format <name>``. Built-in
+# names always win on collision; the loader logs and skips broken plugins
+# rather than crashing the CLI.
+[project.entry-points."argus.reporters"]
+terminal = "argus.reporters.terminal:TerminalReporter"
+markdown = "argus.reporters.markdown:MarkdownReporter"
+container_markdown = "argus.reporters.container_markdown:ContainerMarkdownReporter"
+sarif = "argus.reporters.sarif:SarifReporter"
+json = "argus.reporters.json_report:JsonReporter"
+github = "argus.reporters.github:GitHubReporter"
+gitlab = "argus.reporters.gitlab:GitLabReporter"
+junit = "argus.reporters.junit:JUnitReporter"
+
 [project.urls]
 Homepage = "https://argus.huntridgelabs.com"
 Documentation = "https://huntridge-labs.github.io/argus"


### PR DESCRIPTION
## Description
Replace the hardcoded `REPORTER_REGISTRY` dict with an entry-point-driven loader so third-party packages can ship reporters without forking Argus. Built-ins go through the same code path as plugins — one source of truth, one set of failure semantics.

After this PR, a third-party reporter package only needs to declare `[project.entry-points.\"argus.reporters\"]` in its own `pyproject.toml` and `pip install` it alongside Argus. `argus scan --format <name>` picks it up automatically.

## Changes Made
- [ ] Added new scanner/workflow
- [x] Modified existing scanner/workflow
- [x] Updated documentation
- [ ] Fixed bug
- [ ] Other (please specify)

### Details
- `argus/reporters/__init__.py`: rebuilt around `importlib.metadata`. Lazy + cached registry, two-pass load with built-ins-win-on-collision, plugin-vs-plugin first-wins, graceful failure on import / construction / protocol mismatch (each broken plugin logs a WARNING and is skipped). `Reporter` runtime-checkable Protocol exposed for downstream typing. `REPORTER_REGISTRY` preserved as a read-only proxy backed by the cached registry for back-compat.
- `pyproject.toml`: declares `[project.entry-points."argus.reporters"]` for all eight built-ins (`terminal`, `markdown`, `container_markdown`, `sarif`, `json`, `github`, `gitlab`, `junit`).
- `argus/cli.py`: `FORMAT_CHOICES` now built from the live registry at parser-construction time. Built-ins keep their curated order; third-party plugins append after. Falls back to the hardcoded list if discovery fails so a misconfigured environment can't kill the CLI.
- `docs/contributing-reporters.md`: third-party reporter author guide — protocol shape, entry-point format, packaging skeleton, naming guidance, failure semantics.
- `.ai/decisions.yaml`: ADR-023 — design rationale (entry-points vs config-file vs env-var; built-ins-win + first-wins; graceful failure).
- `.ai/architecture.yaml`: reporter component description references the entry-point group + ADR-023.
- `docs/developer/SDK-ROADMAP.md`: Phase 4 plugin-registration line marked complete with summary.

No breaking changes:
- `get_reporter(name)`, `available_reporters()`, `REPORTER_REGISTRY` keep their current signatures.
- All seven user-facing built-ins still resolve via the same names.
- `ensure_canonical_json` / `CANONICAL_FORMAT` unchanged.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results
- New `argus/tests/reporters/test_plugin_registry.py` — 18 tests covering: all built-ins discoverable; third-party plugins picked up via entry-points; broken plugin skipped, others load; missing-protocol skipped; raises-on-init skipped; built-in wins on shadow with WARNING; plugin-vs-plugin first-wins with WARNING; legacy `REPORTER_REGISTRY` proxy (`__contains__`, `__iter__`, `__len__`, `__getitem__`, `keys`, `values`, `items`, `get` with default).
- All existing reporter tests (`test_terminal`, `test_markdown`, `test_sarif`, `test_json_report`, `test_github`, `test_gitlab`, `test_junit`, `test_container_markdown`, `test_registry`) pass without modification.
- Full pytest suite: **2952 passed, 10 skipped, 7 deselected**. Pre-push husky hook ran the full suite green.
- `python -m scripts.ci.check_cli_docs` — passes; `docs/cli-reference.md` regenerated on the date stamp only (FORMAT_CHOICES order unchanged from user perspective).

## Security Considerations
- [ ] No security impact
- [ ] Security enhancement
- [x] Potential security implications (explain below)

### Security Details
A plugin loaded via `importlib.metadata` runs arbitrary Python at import time and at `__init__`. That's the same risk surface as any pip-installed dependency — argus doesn't expand it. Defensive choices:
- The loader catches a broad `Exception` on `ep.load()` and `cls()` and skips broken plugins. A buggy plugin can't break `argus list` or `argus scan` for users with other reporters installed.
- Protocol validation is `isinstance(instance, Reporter)` against a runtime-checkable Protocol. A class without `.report(...)` is rejected before being added to the registry, so calling code can rely on the contract.
- Built-ins always win on name collision — a malicious plugin cannot shadow `terminal`, `sarif`, etc. The plugin's claim is dropped and a WARNING is logged.

## AI Context Updates (.ai/)
- [x] `.ai/architecture.yaml` updated (if components/structure changed)
- [ ] `.ai/workflows.yaml` updated (if commands/tasks changed)
- [x] `.ai/decisions.yaml` updated (if design decision made)
- [ ] `.ai/errors.yaml` updated (if common error addressed)
- [ ] N/A - No .ai/ updates needed

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Closes Phase 4 → Reporter plugin registration system in `docs/developer/SDK-ROADMAP.md` (line 206).