### PR TITLE
docs(adr-024): decide scanner-zap config-passthrough; minimal action surface

### DIFF
--- a/.ai/decisions.yaml
+++ b/.ai/decisions.yaml
@@ -1644,3 +1644,211 @@ decisions:
       - ADR-020  # FileDiscoveryScanner shared template for linters (parallel "extract a registration mechanism" play)
     pr_references:
       - "(closes Phase 4 — Distribution + Multi-Platform → Reporter plugin registration system; see docs/developer/SDK-ROADMAP.md)"
+
+  - id: ADR-024
+    title: "DAST scanner tuning moves to argus.yml; composite action stays minimal"
+    status: accepted
+    date: 2026-05-11
+    context: |
+      The SDK refactor between 0.6.8 and the 1.0.0 line shrank the
+      ``scanner-zap`` composite-action input surface from ~19
+      inputs to 5. The simpler contract makes the common case
+      easier and cleaner, but it dropped 14 patterns that 0.6.8
+      consumers depended on — API-spec scans, ZAP ignore-rules
+      customization, additional ZAP CLI flags, max-duration caps,
+      registry-auth for private app images, healthcheck polling,
+      build-image-as-part-of-scan flows, and a few others. The
+      regression was surfaced during the medsecops-argus-workflows
+      GHES migration audit, where every removed input had to be
+      stripped from real consumer workflows. Tracked in
+      ``docs/developer/SDK-ROADMAP.md`` under "DAST + Container
+      Scanner Parity (Post-1.0 Regressions)".
+
+      Two paths to restoration were viable:
+
+      1. Re-add the 14 inputs to ``action.yml``, returning to a
+         ~19-input pre-refactor action surface. Easy to implement,
+         keeps the action-only mental model — but creates a
+         contract bloat that biases users toward "configure
+         everything through GitHub Actions inputs" and forces
+         SDK-direct users on GitLab / Jenkins / local dev to lose
+         access to the same tuning knobs.
+
+      2. Move scanner-specific tuning into ``scanners.zap.*`` in
+         ``argus.yml`` and keep the composite-action surface
+         minimal — matching the config-passthrough pattern already
+         in use for ``container``, ``osv``, ``checkov``, and
+         ``supply-chain``. Single source of truth (the config
+         file) works for both SDK-direct and composite-action
+         users identically.
+
+      Credentials added a third complication. Registry auth (for
+      pulling a private SUT image) and web-app authentication (for
+      logging into the running target app) are different problems:
+
+      - Registry auth — ``docker pull`` credentials, used before
+        ZAP starts.
+      - Web-app auth — ZAP's own auth machinery: login URL, form
+        selectors (XPath/CSS), logged-in detection regex, session
+        management. The DOM specification is per-app and not
+        something argus can abstract cleanly without becoming a
+        leaky wrapper around ZAP's context-file format.
+
+      Neither belongs as YAML literals — ``argus.yml`` is
+      typically VCS-tracked.
+    decision: |
+      Adopt path (2): scanner-specific tuning moves to
+      ``scanners.zap.*`` in ``argus.yml``. The composite-action
+      surface stays minimal — target identification (``target_url``
+      or ``app_image_ref`` + ``app_ports``) plus the common
+      cross-scanner inputs (``fail_on_severity``,
+      ``post_pr_comment``, ``enable_code_security``).
+
+      **Disposition of each removed input:**
+
+      *Restore via config passthrough* (``scanners.zap.<key>``):
+        api_spec              — explicit URL/path for OpenAPI scans
+        rules_file            — renamed from rules_file_name; .tsv ignore-rules path
+        cmd_options           — list[str] appended to ZAP CLI verbatim
+        max_duration_minutes  — int hard cap on scan duration
+        scan_type             — already exists: baseline | full; api implicit when api_spec is set
+        healthcheck_url       — argus polls 2xx before invoking ZAP (default timeout 60s)
+
+      *Restore via env-var-referenced config* (registry auth for
+      private ``app_image_ref``):
+        scanners.zap.registry_username: "${REGISTRY_USER}"
+        scanners.zap.registry_password: "${REGISTRY_TOKEN}"
+      Reuses the existing ``container`` scanner interpolation
+      pattern. Validator warns on literal values that don't match
+      ``${...}`` at config-load time. CLI override
+      ``--registry-password-stdin`` reads the password from stdin
+      (mirrors ``docker login --password-stdin``) for ad-hoc local
+      runs where setting an env var is friction.
+
+      *Web-app authentication (V1)* — ZAP context-file passthrough:
+        scanners.zap.auth.context_file = ".zap/context.xml"
+        scanners.zap.auth.username_env = "ZAP_APP_USER"
+        scanners.zap.auth.password_env = "ZAP_APP_PASSWORD"
+      Argus mounts the context file into the container at a known
+      path and exports the named env vars; ZAP's standard
+      ``{%username%}`` / ``{%password%}`` placeholders in the
+      context file pick them up. The user owns the DOM
+      specification (login URL, form selectors via XPath/CSS,
+      logged-in regex, session management). Argus stays out of
+      that surface.
+
+      *Web-app authentication (V2, deferred)* — an argus-native
+      ``scanners.zap.auth.form`` block we'd translate into a ZAP
+      context. Defer until we have real consumer apps to validate
+      against. Abstracting the DOM is inherently leaky per-app.
+
+      *NOT restoring — intentional simplification* (these belong
+      in the consumer's pipeline, not in argus's surface):
+        app_build_context, app_dockerfile, app_image_tag — image
+          builds belong in a prior workflow step; argus accepts
+          ``app_image_ref`` (pre-built image as sidecar) or a
+          started ``target_url``.
+        compose_file, compose_build — multi-service orchestration
+          belongs in the consumer's pipeline.
+        allow_issue_writing — conflicts with the silent-failure-
+          loud principle (ADR-016); scan findings already ride
+          PR-comments, summary aggregation, and SARIF upload.
+
+      **Composite action surface after the change**
+      (``.github/actions/scanner-zap/action.yml``):
+        target_url, app_image_ref, app_ports, fail_on_severity,
+        post_pr_comment, enable_code_security.
+      Everything else lives in ``argus.yml``.
+
+      The same ``argus.yml`` shape works for SDK-direct users on
+      any CI platform (GitLab, Jenkins, Azure DevOps, local dev) —
+      parity with composite-action users, no per-platform input
+      drift.
+    alternatives_considered:
+      - name: "Re-add all 14 inputs to action.yml (path 1)"
+        rejected_because: |
+          Bloats the composite-action surface back to pre-refactor
+          levels, creates two sources of truth (action inputs vs.
+          argus.yml), and forces SDK-direct users on GitLab /
+          Jenkins / local-dev to lose access to the same tuning
+          knobs. The simpler-contract win of the original refactor
+          goes away. Also biases users toward "configure
+          everything through GitHub Actions" — argus's design
+          principle is that the SDK is the primary interface
+          (ADR-013) and composite actions are thin wrappers
+          (ADR-019).
+
+      - name: "Split: some removed inputs to action.yml, others to config"
+        rejected_because: |
+          Picking which subset goes which way is bikeshedding
+          without a principle. The principle "scanner-specific
+          tuning lives in argus.yml, common cross-scanner inputs
+          live in the composite" is clean and matches existing
+          patterns (container, osv, checkov, supply-chain).
+
+      - name: "Native argus auth block for web-app authentication (V1)"
+        rejected_because: |
+          DOM specification (form selectors, logged-in detection
+          regex, session management) is per-app and not something
+          argus can abstract cleanly. We'd either invent a narrow
+          DSL that misses real apps (custom JS auth flows, SAML
+          redirects, MFA screens, refresh-token rotation) or
+          expose so many knobs that we're re-implementing ZAP's
+          context-file format with worse tooling. Context-file
+          passthrough lets users author auth in ZAP's native
+          language with ZAP's existing tooling (the ZAP GUI can
+          record auth flows and emit context files). A V2 native
+          block remains on the table if real demand surfaces.
+
+      - name: "Plaintext credentials in argus.yml"
+        rejected_because: |
+          ``argus.yml`` is typically VCS-tracked. Plaintext
+          credentials there would be a baseline security violation
+          and would force every team to add it to .gitignore (or
+          accept the leak). Env-var interpolation
+          (``${REGISTRY_PASSWORD}``) plus the
+          ``--registry-password-stdin`` CLI flag covers both CI
+          (env var set by the runner) and ad-hoc local scans
+          (stdin pipe). Validator-side rejection of literals turns
+          the rule into a config-load-time error, not a runtime
+          regret.
+
+      - name: "Restore allow_issue_writing"
+        rejected_because: |
+          GitHub Issues from scan findings creates noise that
+          competes with the existing surfaces (PR comments,
+          summary aggregation, SARIF in the Security tab) and
+          conflicts with the silent-failure-loud principle
+          (ADR-016). The signal users need ("did this scan fail or
+          pass") rides those existing channels. Adding issue
+          writing reopens a question (which findings warrant an
+          issue, who owns the issue, how does it get closed) that
+          we're better off staying out of.
+
+      - name: "Restore the build-image-as-part-of-scan flows"
+        rejected_because: |
+          ``app_build_context`` + ``app_dockerfile`` +
+          ``app_image_tag`` (and ``compose_file`` +
+          ``compose_build``) embed image-build orchestration into
+          the scanner's responsibility. That's a CI-pipeline
+          concern with well-established patterns in every CI
+          platform (``docker build``, ``docker compose up``,
+          ``buildx``). Consumers retain full control by running
+          those steps before invoking argus and passing the
+          resulting ``app_image_ref`` or ``target_url``. Argus
+          stays focused on scanning, not on image lifecycle.
+    consequences:
+      - "SDK-direct users on GitLab, Jenkins, Azure DevOps, or local dev get parity with composite-action users — same scanner tuning, same config file, same behavior."
+      - "Composite-action surface stays small: scanner-zap action.yml keeps target identification and common cross-scanner inputs, nothing else. Easier for new users to read."
+      - "Migrating from 0.6.8 inputs to 1.x config is a one-time YAML rewrite — move scanner-specific tuning from `with:` blocks into `argus.yml`. A side-by-side migration guide ships with the implementation PR."
+      - "Web-app authentication remains a ZAP-native concern in V1. Users with HTTP basic-auth or static-header setups can already configure those via ``cmd_options`` + env vars; users with form-based auth use a ZAP context file (the path the ZAP team itself recommends)."
+      - "Adding scanner-zap configuration knobs in the future means editing ``scanners.zap.*`` in the config schema, not adding action.yml inputs. The composite-action surface stays stable across releases."
+      - "Validator-enforced env-var interpolation for credentials prevents accidental literal-password commits at config-load time. Users who try to commit ``registry_password: hunter2`` get a warning before the scan starts, not after the secret hits VCS."
+      - "Three credential surfaces are now distinct and documented: registry creds (env-var-referenced YAML), web-app creds (ZAP context-file + env-var-named-references), and CLI-stdin (ad-hoc override). Each has a clear use case and none overlap."
+    related:
+      - ADR-001  # Composite actions as primary architecture (this preserves the composite surface for what it's good at)
+      - ADR-013  # Python SDK as primary interface (the config-file path this leans into)
+      - ADR-016  # Silent-failure gating (rationale for not restoring allow_issue_writing)
+      - ADR-019  # Install-from-source pattern (the composite-action thinness this preserves)
+    pr_references:
+      - "(addresses DAST + Container Scanner Parity → scanner-zap target setup parity; see docs/developer/SDK-ROADMAP.md)"

--- a/docs/developer/SDK-ROADMAP.md
+++ b/docs/developer/SDK-ROADMAP.md
@@ -650,27 +650,51 @@ respect the deliberate trim.
 
 ### Sub-items
 
-- [ ] **scanner-zap target setup parity.** 14 inputs were removed:
-  `api_spec`, `app_build_context`, `app_dockerfile`,
-  `app_image_tag`, `compose_build`, `compose_file`, `cmd_options`,
-  `healthcheck_url`, `max_duration_minutes`, `registry_password`,
-  `registry_username`, `rules_file_name`, `scan_mode`,
-  `allow_issue_writing`. The new contract handles "URL is already
-  running" (`target_url`) and "bring up a pre-built image as a
-  sidecar" (`app_image_ref` + `app_ports`) cleanly, but excludes:
+- [ ] **scanner-zap target setup parity — decided** (see ADR-024 in `.ai/decisions.yaml`).
+  Scanner-specific tuning moves to `scanners.zap.*` in `argus.yml`, matching the
+  config-passthrough pattern already in use for `container`, `osv`, `checkov`,
+  and `supply-chain`. The composite-action surface stays minimal (target
+  identification + common cross-scanner inputs). One source of truth — SDK-
+  direct users on GitLab / Jenkins / local dev get parity with composite-action
+  users, no surface bloat on either side.
 
-  - **Build-image-as-part-of-scan** — Dockerfile builds (`app_build_context` + `app_dockerfile` + `app_image_tag`) and docker-compose stacks (`compose_file` + `compose_build`).
-  - **API-spec scans** — `api_spec` URL passthrough for `scan_type=api`. The new shape relies on ZAP discovering endpoints from `target_url`, which is a real behavior difference for OpenAPI-driven testing.
-  - **Healthcheck poll** — `healthcheck_url`. Consumers must now poll readiness in their own step before the action runs.
-  - **Authenticated registry pulls** — `registry_username` + `registry_password` (private images for `app_image_ref`).
-  - **ZAP customization** — `rules_file_name` (ZAP `.tsv` ignore rules) and `cmd_options` (additional `zap-baseline.py` flags).
-  - **Long-running scans** — `max_duration_minutes`. The new action uses ZAP's defaults; consumers can't cap scan time anymore.
+  **Restore via config passthrough (`scanners.zap.<key>` in `argus.yml`):**
+  - `api_spec` — explicit URL/path for OpenAPI scans; setting it implicitly switches scan mode to `api`.
+  - `rules_file` (renamed from `rules_file_name`) — path to a ZAP `.tsv` ignore-rules file, mounted into the container.
+  - `cmd_options` — `list[str]` appended to the ZAP CLI invocation verbatim (escape hatch for ZAP knobs we don't model explicitly).
+  - `max_duration_minutes` — int hard cap on scan duration.
+  - `scan_type` (already in schema: `baseline` | `full`) — `api` becomes implicit when `api_spec` is set.
+  - `healthcheck_url` — argus polls for 2xx readiness (configurable timeout, default 60s) before invoking ZAP.
 
-  *Decision pending*: which of these are must-restore vs.
-  intentional-simplification (build flows in particular are a
-  reasonable "consumer's workflow does the build" boundary, but
-  api-spec / healthcheck / registry-auth feel load-bearing for
-  enterprise users).
+  **Restore via env-var-referenced config (registry auth for private `app_image_ref`):**
+  - `scanners.zap.registry_username: "${REGISTRY_USER}"` — reuses the existing `container` scanner interpolation pattern.
+  - `scanners.zap.registry_password: "${REGISTRY_TOKEN}"` — same; validator warns on literal values that don't match `${...}`.
+  - CLI override: `--registry-password-stdin` reads from stdin (mirrors `docker login --password-stdin`) for ad-hoc local runs where setting an env var is friction.
+
+  **Web-app authentication (V1) — ZAP context-file passthrough:**
+  - `scanners.zap.auth.context_file: ".zap/context.xml"` — user authors the ZAP context (login URL, form selectors via XPath/CSS, logged-in regex, session management) and argus mounts it into the container at a known path.
+  - `scanners.zap.auth.username_env: "ZAP_APP_USER"` / `password_env: "ZAP_APP_PASSWORD"` — env-var *name* references (never literal credentials). Argus exports the named env vars into the container; ZAP's standard `{%username%}` / `{%password%}` placeholders in the context file pick them up.
+  - The user owns the DOM specification (form selectors, logged-in regex). Argus stays out of that surface — DOM abstraction is leaky per-app and ZAP's context-file format is the supported path with first-class ZAP-GUI tooling for recording auth flows.
+
+  **Web-app authentication (V2, deferred):** an argus-native `scanners.zap.auth.form` block we'd translate into a ZAP context. Defer until we have real consumer apps to validate against — abstracting the DOM is inherently leaky and we don't have signal yet that the context-file path is insufficient.
+
+  **NOT restoring — intentional simplification:**
+  - `app_build_context` / `app_dockerfile` / `app_image_tag` — image builds belong in a prior workflow step; argus accepts `app_image_ref` (for a pre-built image to bring up as sidecar) or a started `target_url`.
+  - `compose_file` / `compose_build` — multi-service orchestration belongs in the consumer's pipeline.
+  - `allow_issue_writing` — conflicts with the silent-failure-loud principle (ADR-016); scan findings already ride PR comments, summary aggregation, and SARIF upload.
+
+  **Composite action surface after the change** (`.github/actions/scanner-zap`):
+  `target_url`, `app_image_ref`, `app_ports`, `fail_on_severity`, `post_pr_comment`, `enable_code_security`. Everything else lives in `argus.yml`.
+
+  **Implementation tasks** (separate PRs, all gated by ADR-024):
+  - [ ] Schema: extend `ScannerConfig` and `docs/config-reference.md` with the new `scanners.zap.*` keys plus the `scanners.zap.auth.*` sub-block.
+  - [ ] Validator: env-var-interpolation requirement for `registry_password`, `auth.password_env`, `auth.username_env` — warn on literal values at config-load time, not at scan time.
+  - [ ] `argus/scanners/zap.py`: read the new config keys, build the ZAP CLI with `rules_file` / `cmd_options` / `max_duration_minutes` / `api_spec` / context-file mount. Honor `healthcheck_url` with a pre-scan poll.
+  - [ ] CLI: `--registry-password-stdin` flag, wired through to the engine for both `zap` and `container`.
+  - [ ] Composite action trim: remove `api_spec`, `rules_file_name`, `cmd_options`, `max_duration_minutes`, `healthcheck_url`, `registry_username`, `registry_password` from `.github/actions/scanner-zap/action.yml`. Add a deprecation note pointing at the config-file path for any 0.6.8-shaped consumer workflows.
+  - [ ] Tests: `argus/tests/scanners/test_zap.py` covers config passthrough; integration test for env-var-referenced auth substitution.
+  - [ ] Docs: extend `docs/scanners.md` and `docs/config-reference.md` with the new keys and an authenticated-scan worked example (ZAP context-file pattern + env-var credentials).
+  - [ ] Migration note: 0.6.8 `with:` block → 1.x `argus.yml` shape, side-by-side, appended to `docs/developer/release-management.md` or a new `docs/migration/0.6.x-to-1.x.md`.
 
 - [ ] **scanner-container `scan_mode` recovery.** `scan_mode`
   (alongside `allow_failure` and `skip_summary`) was removed from


### PR DESCRIPTION
## Description

Converts the **scanner-zap target setup parity** roadmap entry from "decision pending" to a decided design, captured as ADR-024 in `.ai/decisions.yaml`. No code yet — this PR locks the strategic decision so the implementation work (separate PRs) can move ahead with a clear shape.

## Changes Made
- [ ] Added new scanner/workflow
- [ ] Modified existing scanner/workflow
- [x] Updated documentation
- [ ] Fixed bug
- [x] Other (please specify): added ADR-024 design decision

### Details

**The shape we're committing to.** Scanner-specific tuning for ZAP moves to `scanners.zap.*` in `argus.yml`, matching the config-passthrough pattern already used by `container`, `osv`, `checkov`, and `supply-chain`. The composite-action surface stays minimal (target identification + common cross-scanner inputs). One source of truth — SDK-direct users on GitLab / Jenkins / local dev get parity with composite-action users.

**Disposition of the 14 removed inputs:**

| Disposition | Inputs |
|---|---|
| Restore via config passthrough | `api_spec`, `rules_file` (renamed from `rules_file_name`), `cmd_options`, `max_duration_minutes`, `scan_type` (already in schema), `healthcheck_url` |
| Restore via env-var-referenced config | `registry_username`, `registry_password` — `${ENV_VAR}` interpolation reusing the existing `container` scanner pattern. New CLI override `--registry-password-stdin` for ad-hoc runs (mirrors `docker login --password-stdin`). |
| **NOT restoring** (intentional simplification) | `app_build_context`, `app_dockerfile`, `app_image_tag`, `compose_file`, `compose_build` — image-build / multi-service orchestration belongs in the consumer's pipeline. `allow_issue_writing` — conflicts with the silent-failure-loud principle (ADR-016). |

**Web-app authentication** is treated as a separate sub-decision:

- **V1** — ZAP context-file passthrough: `scanners.zap.auth.context_file` points at the user's `.zap/context.xml`; argus mounts it into the container. Credentials supplied via `scanners.zap.auth.username_env` / `password_env` (env-var *name* references, never literals); ZAP's standard `{%username%}` / `{%password%}` placeholders in the context pick them up. User owns the DOM specification (login URL, form selectors via XPath/CSS, logged-in regex, session management) — argus stays out of that surface.
- **V2** — an argus-native `auth.form` block we'd translate to a ZAP context. Deferred until real consumer apps need it; abstracting the DOM is leaky per-app.

**Composite-action surface after the change** (`.github/actions/scanner-zap/action.yml`): `target_url`, `app_image_ref`, `app_ports`, `fail_on_severity`, `post_pr_comment`, `enable_code_security`. Everything else in `argus.yml`.

**Implementation tasks** (each ships as a separate PR gated by this ADR):

- Schema: extend `ScannerConfig` and `docs/config-reference.md` with the new `scanners.zap.*` and `scanners.zap.auth.*` keys
- Validator: env-var-interpolation requirement for credential fields (warn at config-load time, not at scan time)
- `argus/scanners/zap.py`: pass the new config through to the ZAP CLI; honor `healthcheck_url` with a pre-scan poll; mount `rules_file` and `context_file` into the container
- CLI: `--registry-password-stdin` flag, wired for both `zap` and `container`
- Composite action trim: remove the inputs now living in config
- Tests: per-key passthrough + env-var-referenced auth substitution
- Docs: extend `docs/scanners.md` and `docs/config-reference.md` with an authenticated-scan worked example
- Migration note: side-by-side 0.6.8 `with:` → 1.x `argus.yml`

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results

Doc-only diff. Full pre-push suite passes locally (2981 passed, 2 skipped, 7 deselected).

## Security Considerations
- [ ] No security impact
- [x] Security enhancement
- [ ] Potential security implications (explain below)

### Security Details

The decision codifies that credentials (registry passwords, web-app passwords) must never be YAML literals. The validator will warn on literal values at config-load time, and the `--password-stdin` CLI flag covers ad-hoc runs without needing to set an env var.

## AI Context Updates (.ai/)

- [ ] `.ai/architecture.yaml` updated (if components/structure changed)
- [ ] `.ai/workflows.yaml` updated (if commands/tasks changed)
- [x] `.ai/decisions.yaml` updated (ADR-024 added)
- [ ] `.ai/errors.yaml` updated (if common error addressed)
- [ ] N/A - No .ai/ updates needed

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues

Addresses the **DAST + Container Scanner Parity → scanner-zap target setup parity** roadmap item in `docs/developer/SDK-ROADMAP.md`. The `scanner-container scan_mode` and `scanner-gitleaks notify_users` sub-items in the same section remain "decision pending."

## Screenshots/Logs (if applicable)

Diff is two files: `.ai/decisions.yaml` (+208 lines for ADR-024) and `docs/developer/SDK-ROADMAP.md` (66 lines updated to reflect the decision).