### PR TITLE
docs(docsite): version-aware GITHUB_BLOB ref instead of hardcoded main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,11 +32,44 @@ jobs:
       - name: Install dependencies
         run: pip install 'mkdocs>=1.6,<2' 'mkdocs-material>=9.7,<10' pyyaml mike
 
+      - name: Resolve docs ref
+        # Per-trigger blob ref so the docsite's cross-repo links point
+        # to content that actually exists at the matching version,
+        # instead of always hardcoding ``main`` (which is the bug this
+        # step closes — see docs/developer/SDK-ROADMAP.md → Docsite
+        # Maintenance → "Version-aware GITHUB_BLOB rewrite").
+        #
+        #   release           → version tag from version.yaml (e.g. v0.7.2)
+        #   pull_request      → PR head SHA (immutable, exists during the run)
+        #   push:main         → "main"
+        #   workflow_dispatch → "main"
+        #
+        # The PR head SHA comes from ``github.event.pull_request.head.sha``,
+        # which is sourced from a controlled set (hex SHA only) but still
+        # routed through ``env:`` per workflow-injection best practices.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          case "$EVENT_NAME" in
+            release)
+              VERSION=$(head -1 version.yaml | awk '{print $1}')
+              REF="v${VERSION}"
+              ;;
+            pull_request)
+              REF="${PR_HEAD_SHA}"
+              ;;
+            *)
+              REF="main"
+              ;;
+          esac
+          echo "ARGUS_DOCS_REF=${REF}" >> "$GITHUB_ENV"
+
       - name: Validate docsite config
         run: cd scripts && python -m docsite --validate
 
       - name: Build docs
-        run: cd scripts && python -m docsite --output-dir /tmp/argus-docs
+        run: cd scripts && python -m docsite --output-dir /tmp/argus-docs --ref "$ARGUS_DOCS_REF"
 
       - name: Verify site builds
         run: cd /tmp/argus-docs && mkdocs build --strict --site-dir /tmp/site

--- a/docs/developer/SDK-ROADMAP.md
+++ b/docs/developer/SDK-ROADMAP.md
@@ -1059,7 +1059,7 @@ Open follow-ups for the auto-generated docsite
 (`scripts/docsite/`). Not blockers — the pipeline is fully automated
 today and ships clean — but small hardening items worth tracking.
 
-- [ ] **Version-aware `GITHUB_BLOB` rewrite for relative repo links.**
+- [x] ~~**Version-aware `GITHUB_BLOB` rewrite for relative repo links.**~~ Shipped. `scripts/docsite/config.py` now resolves the blob ref via (1) explicit `--ref` CLI flag, (2) `ARGUS_DOCS_REF` env var, (3) fallback `"main"`. The docsite `__main__.py` exposes `--ref` and `build()` threads it through to `load_site_config`. `.github/workflows/docs.yml` resolves the right ref per trigger before building: release → `v<X.Y.Z>` from `version.yaml`, pull_request → PR head SHA (passed through `env:` per workflow-injection best practice), push:main / workflow_dispatch → `main`. Versioned doc URLs at `/argus/vX.Y.Z/` now link to matching `/blob/vX.Y.Z/` blob URLs, and PR-preview builds link to the PR's own SHA so reviewers can click through to the exact files under review. 7 new tests in `scripts/docsite/tests/test_config.py::TestBlobRefResolution` cover the precedence order (explicit ref > env var > main fallback), whitespace/empty-string handling, and end-to-end propagation through `build()`.
   `scripts/docsite/config.py:59` hardcodes
   `GITHUB_BLOB = f"{repo_url}/blob/main"`. Every relative markdown
   link in source files (`examples/README.md`, scanner READMEs, the

--- a/scripts/docsite/__main__.py
+++ b/scripts/docsite/__main__.py
@@ -27,6 +27,19 @@ def main() -> None:
         action="store_true",
         help="Validate docsite.yml and .docsite.yml files, then exit",
     )
+    parser.add_argument(
+        "--ref",
+        default=None,
+        help=(
+            "Git ref to embed in cross-repo blob URLs "
+            "(e.g. ``v0.7.2`` for release builds, a PR head SHA for "
+            "PR previews, ``main`` for push:main builds). Defaults to "
+            "the ``ARGUS_DOCS_REF`` env var, then ``main``. The CI "
+            "workflow passes the appropriate value per trigger so the "
+            "versioned docs at /argus/<version>/ link to matching "
+            "blob URLs at /blob/<version>/."
+        ),
+    )
     args = parser.parse_args()
 
     repo_root = Path(args.repo_root).resolve()
@@ -40,7 +53,7 @@ def main() -> None:
         valid = validate(repo_root)
         sys.exit(0 if valid else 1)
 
-    build(repo_root, output_dir)
+    build(repo_root, output_dir, ref=args.ref)
 
 
 if __name__ == "__main__":

--- a/scripts/docsite/builder.py
+++ b/scripts/docsite/builder.py
@@ -45,10 +45,17 @@ CUSTOM_CSS = (
 
 # ─── Build ───────────────────────────────────────────────────────────────────
 
-def build(repo_root: Path, output_dir: Path) -> None:
-    """Generate the full MkDocs documentation site."""
+def build(repo_root: Path, output_dir: Path, *, ref: str | None = None) -> None:
+    """Generate the full MkDocs documentation site.
+
+    ``ref`` controls the git ref embedded in cross-repo blob URLs (see
+    ``config.load_site_config``). Pass the release tag for versioned
+    builds; ``main`` (or ``None``) for unversioned / dev builds. The
+    docsite CLI's ``--ref`` flag and ``ARGUS_DOCS_REF`` env var are
+    routed through here.
+    """
     # Load site config from docsite.yml before anything else
-    load_site_config(repo_root)
+    load_site_config(repo_root, ref=ref)
 
     version = get_version(repo_root)
     actions_dir = repo_root / ".github" / "actions"

--- a/scripts/docsite/config.py
+++ b/scripts/docsite/config.py
@@ -1,11 +1,16 @@
 """Site configuration — loaded from repo-level docsite.yml at build time.
 
-Call ``load_site_config(repo_root)`` once at the start of a build.
-There are NO fallback defaults — ``docsite.yml`` must be complete.
+Call ``load_site_config(repo_root, ref=...)`` once at the start of a
+build. There are NO fallback defaults — ``docsite.yml`` must be
+complete. The ``ref`` argument controls the git ref used in the
+``GITHUB_BLOB`` rewrite (e.g. ``main``, ``v0.7.2``, or a PR head SHA)
+so that versioned doc URLs link to the matching blob URLs instead of
+always hardcoding ``main``.
 """
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
@@ -28,10 +33,38 @@ GROUP_LABELS: dict[str, str] = {}
 _REQUIRED_TOP_KEYS = {"repo_url", "categories", "excluded_actions", "excluded_workflows"}
 
 
-def load_site_config(repo_root: Path) -> None:
+def _resolve_blob_ref(ref: str | None) -> str:
+    """Resolve the git ref to use in GITHUB_BLOB rewrites.
+
+    Precedence (highest first):
+      1. The ``ref`` argument (caller-supplied — typically the docsite
+         CLI ``--ref`` flag).
+      2. ``ARGUS_DOCS_REF`` env var (CI sets this per trigger: tag for
+         release events, head SHA for pull requests, ``main`` for push
+         events).
+      3. Fallback ``"main"`` — preserves legacy behavior when neither
+         is supplied, matching what every published-docs URL points at
+         today.
+    """
+    if ref:
+        return ref
+    env = os.environ.get("ARGUS_DOCS_REF", "").strip()
+    if env:
+        return env
+    return "main"
+
+
+def load_site_config(repo_root: Path, *, ref: str | None = None) -> None:
     """Read ``docsite.yml`` from *repo_root* and populate module-level state.
 
     Exits with an error if the file is missing or incomplete.
+
+    ``ref`` controls the git ref encoded in ``GITHUB_BLOB`` — used by
+    ``rewrite_repo_links`` to turn relative markdown links into
+    absolute ``github.com/.../blob/<ref>/<path>`` URLs. Versioned
+    builds pass the release tag here so doc URLs at
+    ``/argus/v0.7.2/`` point at matching blob URLs at
+    ``/blob/v0.7.2/`` instead of drifting onto ``main``.
     """
     global CATEGORY_LABELS, CATEGORY_ICONS
     global EXCLUDED_ACTIONS, EXCLUDED_WORKFLOWS, EXCLUDED_GUIDE_DIRS
@@ -56,7 +89,8 @@ def load_site_config(repo_root: Path) -> None:
 
     # Repo URL → GITHUB_BLOB
     repo_url = str(data["repo_url"]).rstrip("/")
-    GITHUB_BLOB = f"{repo_url}/blob/main"
+    blob_ref = _resolve_blob_ref(ref)
+    GITHUB_BLOB = f"{repo_url}/blob/{blob_ref}"
 
     # Categories
     categories_raw = data.get("categories") or {}

--- a/scripts/docsite/tests/test_config.py
+++ b/scripts/docsite/tests/test_config.py
@@ -98,3 +98,70 @@ class TestLoadSiteConfig:
 
         config.load_site_config(tmp_repo)
         assert config.EXCLUDED_GUIDE_DIRS == {"developer", "internal"}
+
+
+class TestBlobRefResolution:
+    """``GITHUB_BLOB`` reflects the per-build git ref so versioned docs
+    link to matching ``/blob/<version>/`` URLs instead of always
+    hardcoding ``main``.
+    """
+
+    def test_explicit_ref_arg_wins(self, tmp_repo: Path, monkeypatch):
+        # Even with an env var set, the explicit kwarg wins.
+        monkeypatch.setenv("ARGUS_DOCS_REF", "env-ref")
+        config.load_site_config(tmp_repo, ref="v0.7.2")
+        assert config.GITHUB_BLOB.endswith("/blob/v0.7.2")
+
+    def test_env_var_used_when_no_explicit_ref(
+        self, tmp_repo: Path, monkeypatch,
+    ):
+        monkeypatch.setenv("ARGUS_DOCS_REF", "abc123def456")
+        config.load_site_config(tmp_repo)
+        assert config.GITHUB_BLOB.endswith("/blob/abc123def456")
+
+    def test_fallback_to_main_when_no_ref_or_env(
+        self, tmp_repo: Path, monkeypatch,
+    ):
+        monkeypatch.delenv("ARGUS_DOCS_REF", raising=False)
+        config.load_site_config(tmp_repo)
+        assert config.GITHUB_BLOB.endswith("/blob/main")
+
+    def test_empty_string_ref_arg_falls_through_to_env(
+        self, tmp_repo: Path, monkeypatch,
+    ):
+        """An empty-string ``ref`` should NOT count as a real value —
+        the resolver falls through to the env var. This protects
+        against the CI script accidentally passing ``--ref=``."""
+        monkeypatch.setenv("ARGUS_DOCS_REF", "v9.9.9")
+        config.load_site_config(tmp_repo, ref="")
+        assert config.GITHUB_BLOB.endswith("/blob/v9.9.9")
+
+    def test_whitespace_env_var_falls_back_to_main(
+        self, tmp_repo: Path, monkeypatch,
+    ):
+        """An env var that's just whitespace doesn't count as a ref —
+        otherwise a CI step that exports ``ARGUS_DOCS_REF=`` (e.g. a
+        missing variable in a templated shell script) would produce a
+        ``/blob//`` URL that 404s on everything."""
+        monkeypatch.setenv("ARGUS_DOCS_REF", "   ")
+        config.load_site_config(tmp_repo)
+        assert config.GITHUB_BLOB.endswith("/blob/main")
+
+    def test_repo_url_with_ref(self, tmp_repo: Path):
+        """The ref is appended AFTER the repo_url's ``/blob/`` segment."""
+        cfg = yaml.safe_load((tmp_repo / "docsite.yml").read_text())
+        cfg["repo_url"] = "https://github.com/myorg/myrepo"
+        (tmp_repo / "docsite.yml").write_text(
+            yaml.dump(cfg, allow_unicode=True),
+        )
+        config.load_site_config(tmp_repo, ref="v1.2.3")
+        assert config.GITHUB_BLOB == "https://github.com/myorg/myrepo/blob/v1.2.3"
+
+    def test_build_threads_ref_through(self, tmp_repo: Path, tmp_path: Path):
+        """End-to-end: ``build(..., ref=...)`` propagates into
+        ``GITHUB_BLOB`` so generated pages get the right blob URLs."""
+        from docsite.builder import build
+
+        out = tmp_path / "out"
+        build(tmp_repo, out, ref="v3.14.15")
+        assert config.GITHUB_BLOB.endswith("/blob/v3.14.15")


### PR DESCRIPTION
## Description

PR 2/3 of the autopilot batch. Closes the latent `GITHUB_BLOB`-points-at-main bug surfaced during the PR #150 docsite review: versioned doc URLs at `/argus/v0.7.2/` linked to `/blob/main/...` URLs which can drift if `main` moves ahead between releases, and PR-preview builds 404 against `main` for any newly-added file.

## Changes Made
- [ ] Added new scanner/workflow
- [ ] Modified existing scanner/workflow
- [x] Updated documentation
- [x] Fixed bug
- [x] CI workflow change

### Details

**Three-source ref resolution** in `scripts/docsite/config.py` (`load_site_config` now accepts a `ref` kwarg):

| Source | Priority |
|---|---|
| Explicit `--ref` CLI arg | highest |
| `ARGUS_DOCS_REF` env var | middle |
| Fallback `"main"` | lowest (legacy behavior preserved) |

**CLI exposure** in `scripts/docsite/__main__.py`:

```bash
python -m docsite --ref v0.7.2 --output-dir /tmp/argus-docs
```

**Workflow wiring** in `.github/workflows/docs.yml` — new "Resolve docs ref" step computes the right value per trigger:

| Trigger | Ref used | Why |
|---|---|---|
| `release: published` | `v<X.Y.Z>` from `version.yaml` | Versioned `/argus/vX.Y.Z/` doc → matching `/blob/vX.Y.Z/` content |
| `pull_request` | PR head SHA | Preview links resolve against the PR's actual files |
| `push: main` | `main` | Push-to-main rebuild → unchanged behavior |
| `workflow_dispatch` | `main` | Manual rebuild → unchanged behavior |

The PR-head-SHA value comes through an `env:` block rather than inline `${{ }}` interpolation, per [workflow-injection best practices](https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/) — even though `head.sha` is hex-only, routing it through `env:` makes the contract explicit and future-proof.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

### Test Results

**7 new tests** in `scripts/docsite/tests/test_config.py::TestBlobRefResolution`:

- `test_explicit_ref_arg_wins` — explicit kwarg beats env var
- `test_env_var_used_when_no_explicit_ref` — env var picked up when kwarg omitted
- `test_fallback_to_main_when_no_ref_or_env` — legacy behavior preserved
- `test_empty_string_ref_arg_falls_through_to_env` — CI safety: `--ref=""` doesn't lock in an empty ref
- `test_whitespace_env_var_falls_back_to_main` — catches the unbound-shell-variable case that would otherwise produce `/blob//...` URLs that 404 on everything
- `test_repo_url_with_ref` — composition with custom `repo_url`
- `test_build_threads_ref_through` — end-to-end propagation through `build()`

Full suite: **3172 passed**, 2 skipped, 7 deselected.

## Security Considerations
- [ ] No security impact
- [x] Security enhancement (workflow-injection guard on the PR-head-SHA pathway)
- [ ] Potential security implications (explain below)

### Security Details

The PR-head-SHA value is sourced from `github.event.pull_request.head.sha` (hex-only, not free-text user-controlled). It's still routed through a workflow-level `env:` block rather than inline `${{ }}` interpolation in the `run:` script, so the pattern is correct even if a future contributor adds a less-trusted GitHub-event field next to it.

## AI Context Updates (.ai/)

- [ ] `.ai/architecture.yaml` updated — no architectural shape change; the docsite is just gaining a ref parameter on its existing function
- [ ] `.ai/workflows.yaml` updated
- [ ] `.ai/decisions.yaml` updated — no new ADR
- [ ] `.ai/errors.yaml` updated
- [x] N/A

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues

Implements the "Docsite Maintenance → Version-aware `GITHUB_BLOB` rewrite" entry in `docs/developer/SDK-ROADMAP.md`. Roadmap entry flipped to shipped state.

Part of the autopilot batch — PR 1/3 (`#151` digest-pin migration) merged; PR 3/3 (Phase 4 release-blocker cleanup) follows once this lands.

## Screenshots/Logs (if applicable)

```
============================== 3172 passed, 2 skipped, 7 deselected, 20 warnings in 20.86s ==============================
```

Diff: 6 files, +164 / -10.