### PR TITLE
chore(release): Phase 4 release-blocker cleanup

### DIFF
--- a/QUICK-START.md
+++ b/QUICK-START.md
@@ -7,8 +7,7 @@ Get running with Argus in minutes. The argus SDK is the primary interface; compo
 ### Install
 
 ```bash
-# Install from TestPyPI (pre-release — will become: pip install argus-security)
-pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ argus-security
+pip install argus-security
 ```
 
 ### Enable shell tab-completion (recommended)

--- a/README.md
+++ b/README.md
@@ -41,8 +41,7 @@ Unified security scanning — SAST, containers, IaC, secrets, and DAST from a si
 The argus Python SDK is the primary interface for running security scans. It works locally, in CI, and on any platform with Python 3.11+.
 
 ```bash
-# Install from TestPyPI (pre-release — will become: pip install argus-security)
-pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ argus-security
+pip install argus-security
 
 # Initialize config and scan
 argus init

--- a/argus/init.py
+++ b/argus/init.py
@@ -496,5 +496,13 @@ def _print_summary(
     print(f"    {B}3.{R} Run: {G}argus scan{R}")
     print(f"    {B}4.{R} AI integration: {G}pip install argus-security[mcp]{R} + {G}argus mcp{R}")
 
+    # Shareable install hint — argus init runs once locally but the
+    # config it just wrote is typically committed and used by
+    # teammates / CI. Surface the canonical install command here so
+    # the operator can paste it into a teammate's onboarding message
+    # or a CI workflow without hunting for the right invocation.
+    print(f"\n{G}  Share with your team:{R}")
+    print(f"    {G}pip install argus-security{R}")
+
     print(f"\n  {D}{_DOCS_URL}{R}")
     print()

--- a/docs/developer/SDK-ROADMAP.md
+++ b/docs/developer/SDK-ROADMAP.md
@@ -194,12 +194,12 @@ All 16 scanner/linter actions refactored to call `argus scan` internally. Action
 ### Remaining
 
 **Release blockers (Post-PyPI Cleanup):**
-- [ ] README.md and QUICK-START.md: remove TestPyPI `--index-url` flags
+- [x] ~~README.md and QUICK-START.md: remove TestPyPI `--index-url` flags~~ — both install snippets now read simply `pip install argus-security`. The TestPyPI variant remains documented in `docs/developer/test-pypi-validation.md` where it belongs (that doc is the canonical TestPyPI dev playbook).
 - [x] ~~Update all 16 action wrappers: `pip install pyyaml` → `pip install argus-security`~~ — **approach changed:** install SDK from composite's own checkout (`pip install "${{ github.action_path }}/../../.."`) instead of PyPI, which implicitly pins SDK version to composite ref and sidesteps PyPI-release lag. Applied to `scanner-container` and `scanner-zap` in PR #91.
 - [x] ~~Apply the install-from-source pattern to the remaining 14 wrappers~~ — completed for `scanner-bandit`, `scanner-gitleaks`, `scanner-opengrep`, `scanner-clamav`, `scanner-trivy-iac`, `scanner-checkov`, `scanner-osv`, `scanner-supply-chain`, plus the 6 linter wrappers. (`scanner-dependency-review` was mistakenly listed — it wraps GitHub's `dependency-review-action` and doesn't use the SDK.)
 - [x] ~~Rename action step "Install dependencies" → "Install Argus SDK"~~ — applied across all 16 SDK-using wrappers as part of the install-from-source migration
 - [x] ~~Remove `bin/argus` wrapper~~ — deleted; pip's `[project.scripts]` entry (`argus = "argus.cli:main"`) is the canonical entry point. All doc references were already pointing at the pip-installed `.venv/bin/argus`, not the repo shim.
-- [ ] `argus init` summary: show `pip install argus-security` command
+- [x] ~~`argus init` summary: show `pip install argus-security` command~~ — added as a "Share with your team" footer line after the numbered Next-Steps list. `argus init` runs once locally but the `argus.yml` it produces is typically committed for teammates / CI, so surfacing the canonical install command here means the operator can paste it directly into onboarding without hunting for the right invocation.
 
 **Future (post-release):**
 - [x] ~~Additional reporters: `github.py`, `gitlab.py`, `junit.py`~~ — three new reporters shipped: GitHub Actions annotations, GitLab Code Quality JSON (codeclimate-compatible), JUnit XML


### PR DESCRIPTION
## Description

PR 3/3 of the autopilot batch. Closes the two open release-blocker entries under "Phase 4 — Distribution + Multi-Platform" → "Post-PyPI Cleanup" in `docs/developer/SDK-ROADMAP.md`.

## Changes Made
- [ ] Added new scanner/workflow
- [ ] Modified existing scanner/workflow
- [x] Updated documentation
- [ ] Fixed bug
- [x] Other (CLI banner enhancement)

### Details

**1. Remove TestPyPI `--index-url` flags from README and QUICK-START.**

The pre-release install snippet
```bash
pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ argus-security
```
is replaced with the canonical
```bash
pip install argus-security
```
in both `README.md` and `QUICK-START.md`.

The TestPyPI form is still documented where it actually belongs — `docs/developer/test-pypi-validation.md`, which is the dev playbook for validating builds before release. Keeping it there means contributors validating a release candidate still have the right command, but new users following the README don't get steered to TestPyPI by default.

**2. Surface `pip install argus-security` in `argus init` banner.**

The Next-Steps output gains a "Share with your team:" footer carrying the install command. `argus init` runs once locally but the `argus.yml` it produces is typically committed for teammates / CI, so surfacing the canonical install command here means the operator can paste it directly into onboarding instead of hunting for the right invocation.

Placement: below the existing 4-step Next-Steps list (1. review, 2. validate, 3. scan, 4. AI integration) — preserves numbering and keeps the "what to do right now" instructions front and center.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

### Test Results

Doc + CLI-banner changes. Full pre-push suite passes: **3165 passed**, 2 skipped, 7 deselected.

## Security Considerations
- [x] No security impact

## AI Context Updates (.ai/)

- [ ] `.ai/architecture.yaml` updated — no architectural shape change
- [ ] `.ai/workflows.yaml` updated
- [ ] `.ai/decisions.yaml` updated — no new ADR
- [ ] `.ai/errors.yaml` updated
- [x] N/A — cleanup of a previously-decided release-blocker pair

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues

Closes the two open entries under `docs/developer/SDK-ROADMAP.md` → "Phase 4 — Distribution + Multi-Platform" → "Release blockers (Post-PyPI Cleanup)". Both flipped to shipped.

Completes the autopilot batch:
- PR 1/3 `#151` digest-pin migration → **merged**
- PR 2/3 `#152` version-aware GITHUB_BLOB ref → open
- PR 3/3 `#???` (this) Phase 4 cleanup → open

## Screenshots/Logs (if applicable)

```
============================== 3165 passed, 2 skipped, 7 deselected, 20 warnings in 20.79s ==============================
```

Diff: 4 files, +12 / -6.