### PR TITLE
docs: close scanner-container scan_mode + gitleaks notify_users decisions

### DIFF
--- a/.github/actions/scanner-container/action.yml
+++ b/.github/actions/scanner-container/action.yml
@@ -4,6 +4,25 @@ description: |
   via the Argus SDK. The SDK handles tool execution, CVE deduplication,
   and report generation.
 
+  ### Migrating from 0.6.x?
+
+  The `scan_mode: discover` input was removed — the auto-find-and-build
+  semantic moved into the `containers:` block in `argus.yml`, matching
+  the rest of the SDK's config-driven posture. The composite action's
+  `with:` surface now takes one image per invocation; multi-image
+  workflows drive a matrix from `containers.images` (config-driven) or
+  let argus auto-discover Dockerfiles via `containers.discover: true`.
+
+  | Removed `with:` key (0.6.x) | New home (1.x) |
+  |---|---|
+  | `scan_mode: discover` | `containers.discover: true` + `containers.search_paths: [...]` in argus.yml |
+  | `scan_mode: manifest` | `containers.images: [...]` list in argus.yml (`parse-container-config` action emits the matrix) |
+  | `allow_failure` | `fail_on_severity: none` (the canonical "informational scan" knob) |
+  | `skip_summary` | Use `security-summary` composite's `scan_statuses` input (silent-failure aware) |
+
+  Worked examples in [`docs/container-scanning.md`](https://github.com/huntridge-labs/argus/blob/main/docs/container-scanning.md)
+  and side-by-side migration in [`docs/migration/0.6.x-to-1.x.md`](https://github.com/huntridge-labs/argus/blob/main/docs/migration/0.6.x-to-1.x.md).
+
 branding:
   icon: 'package'
   color: 'blue'

--- a/docs/container-scanning.md
+++ b/docs/container-scanning.md
@@ -141,6 +141,48 @@ image:
 image: "nginx:latest@sha256:abc123..."
 ```
 
+## Discover mode (multi-image monorepos)
+
+If your repo has multiple `Dockerfile`s scattered across services or
+component directories and you don't want to maintain a hand-written
+`containers.images` list, enable auto-discovery:
+
+```yaml
+containers:
+  discover: true
+  search_paths:
+    - "services"
+    - "tools"
+  scanners:
+    - trivy
+    - grype
+    - syft
+```
+
+argus walks each path, treats every `Dockerfile*` it finds as a
+build-then-scan target, builds the image locally (no registry push),
+and runs the configured sub-scanners against the built artifact.
+Cleanup defaults to `true` — the temporary image is removed once the
+scan completes.
+
+You can mix discovery with an explicit list — discovered Dockerfiles
+augment the `containers.images` entries rather than replacing them:
+
+```yaml
+containers:
+  images:
+    - image: ghcr.io/myorg/external-runtime:1.4.0   # explicit pull
+  discover: true
+  search_paths:
+    - "services"                                     # in-tree builds
+```
+
+This is the SDK-driven replacement for the `scan_mode: discover` input
+the `scanner-container` composite action carried in 0.6.x. Use the
+[`parse-container-config`](../README.md#composite-actions) action to
+emit a GitHub Actions matrix from the `containers.images` list when
+you want one job per image.
+
 ## Environment Variables
 
 Use `${VAR_NAME}` syntax for dynamic values:

--- a/docs/developer/SDK-ROADMAP.md
+++ b/docs/developer/SDK-ROADMAP.md
@@ -696,36 +696,9 @@ respect the deliberate trim.
   - [x] ~~Docs: extend `docs/scanners.md` and `docs/config-reference.md` with the new keys and an authenticated-scan worked example (ZAP context-file pattern + env-var credentials).~~ Shipped in PR #142 — `docs/config-reference.md` carries the credential-precedence section + `scanners.zap.auth` walkthrough, and `docs/scanners.md` got the "Configuring ZAP via argus.yml" subsection.
   - [x] ~~Migration note: 0.6.8 `with:` block → 1.x `argus.yml` shape, side-by-side, appended to `docs/developer/release-management.md` or a new `docs/migration/0.6.x-to-1.x.md`.~~ Shipped as [`docs/migration/0.6.x-to-1.x.md`](../migration/0.6.x-to-1.x.md). Quick-reference table covering all seven moved inputs + side-by-side 0.6.x → 1.x snippets for every config key + registry-auth migration path (literal `${{ secrets.X }}` → `*_env` reference) + a "what to do next" checklist (`argus init` → move keys → wire env vars → `argus validate`).
 
-- [ ] **scanner-container `scan_mode` recovery.** `scan_mode`
-  (alongside `allow_failure` and `skip_summary`) was removed from
-  scanner-container. The old `discover` mode auto-found
-  Dockerfiles in the repo, built them, and scanned the resulting
-  images — closing a gap where users with a multi-image monorepo
-  didn't have to enumerate `image_ref` for each. The new contract
-  takes a single `image_ref` + `container_name` per invocation.
-  Consumers wanting discover semantics now have to:
-  1. Build their own Dockerfile-discovery + docker-build step
-     (or use `parse-container-config` with a hand-maintained list).
-  2. Loop over the result with a matrix.
+- [x] ~~**scanner-container `scan_mode` recovery.**~~ **Decided: do NOT restore.** The discover semantic already lives in the SDK as a first-class `argus.yml` block — `containers.discover: true` + `containers.search_paths: [...]` walks the repo, builds every `Dockerfile*` it finds, and scans the result; the explicit `containers.images: [...]` list covers the manifest case. Same posture as ADR-024 for ZAP: scanner-specific orchestration lives in the config file; the composite action's `with:` surface stays minimal. Same SDK config works locally / on GitLab CI / on Jenkins / on Azure DevOps without changes. Shipped: (a) deprecation note + 0.6.x→1.x mapping table in `.github/actions/scanner-container/action.yml` description block (visible in the docsite + auto-generated workflow pages); (b) new "Discover mode (multi-image monorepos)" section in `docs/container-scanning.md` with worked examples; (c) `scanner-container` section in `docs/migration/0.6.x-to-1.x.md` covering `scan_mode: discover` → `containers.discover`, `scan_mode: manifest` → `containers.images`, and the 1:1 mappings for `allow_failure` (use `fail_on_severity: none`) and `skip_summary` (use `security-summary`'s `scan_statuses` input). The SDK schema already validates the `containers:` block; the audit gate (`scripts/ci/check_example_inputs.py`) already guards examples.
 
-  *Decision pending*: re-introduce `scan_mode: discover` as a
-  first-class flow, OR formalize the
-  `parse-container-config` + matrix pattern as the canonical
-  multi-image entry point and document it loudly.
-
-- [ ] **scanner-gitleaks user-mention notifications.** The
-  removed `gitleaks_notify_user_list` input took a comma-separated
-  list of GitHub usernames to `@`-mention in the PR comment when
-  secrets were detected. The new contract has no equivalent —
-  `post_pr_comment` controls comment presence but not who gets
-  pinged. Low priority but worth recording **as removed-on-purpose
-  vs. removed-by-omission** so a future contributor doesn't
-  silently re-add it under a different name without considering
-  whether `@`-mention spam is the right escalation.
-
-  *Decision pending*: confirm intentional removal (mostly likely)
-  or wire a `notify_users` input back through that's noisier than
-  a generic PR comment, e.g. only-on-secrets.
+- [x] ~~**scanner-gitleaks user-mention notifications.**~~ **Decided: intentional removal confirmed.** `@`-mention escalation is tightly coupled to GitHub-as-notification, gets noisy fast (transient false positives ping the entire security team on every PR), and doesn't compose with the alert pipelines most teams already own (Slack, PagerDuty, Opsgenie). `post_pr_comment` already gives visibility on the PR itself; teams wanting paging behavior route SARIF or `argus-results.json` into their existing alert system at the workflow level — keeps the *who/when/how loud* decision owned by the team's alerting config rather than the scanner's. Shipped a new "Alert routing — paging and escalation" section in `docs/security.md` with a worked Slack-webhook example so a future contributor proposing to re-add `notify_users` (or any equivalent) lands here first and sees the rationale + the alternative.
 
 ### Companion items already addressed
 

--- a/docs/migration/0.6.x-to-1.x.md
+++ b/docs/migration/0.6.x-to-1.x.md
@@ -219,6 +219,92 @@ for the full credential-precedence table.
 
 ---
 
+## scanner-container — multi-image scanning
+
+`scanner-container`'s `scan_mode` input was removed alongside the
+ZAP changes. The auto-discover / matrix semantic now lives in
+`argus.yml` under the top-level `containers:` block — same posture
+as `scanners.zap.*` — so the same configuration works across every
+CI platform and locally.
+
+### Quick-reference table
+
+| 0.6.x — composite action input | 1.x — location |
+|---|---|
+| `scan_mode: discover` | `containers.discover: true` + `containers.search_paths: [...]` |
+| `scan_mode: manifest` | `containers.images: [...]` (`parse-container-config` action emits a matrix) |
+| `allow_failure` | `fail_on_severity: none` (the canonical "informational scan" knob) |
+| `skip_summary` | Use `security-summary` composite's `scan_statuses` input |
+
+### `scan_mode: discover` → `containers.discover`
+
+Auto-find every `Dockerfile*` in the named paths, build each locally,
+scan the built artifact, clean up.
+
+```yaml
+# 0.6.x
+- uses: huntridge-labs/argus/.github/actions/scanner-container@0.6.8
+  with:
+    scan_mode: discover
+```
+
+```yaml
+# 1.x — argus.yml
+containers:
+  discover: true
+  search_paths:
+    - "services"
+    - "tools"
+  scanners:
+    - trivy
+    - grype
+    - syft
+```
+
+### `scan_mode: manifest` → `containers.images`
+
+Explicit list of images to scan. In 0.6.x this came from a separate
+config file consumed by `parse-container-config`; in 1.x it's a
+first-class key in `argus.yml`. The `parse-container-config` action
+still works and emits a GHA matrix from the list when you want one
+job per image.
+
+```yaml
+# 1.x — argus.yml
+containers:
+  images:
+    - image: "nginx:1.27"
+    - image: "ghcr.io/myorg/api:1.4.0@sha256:..."
+    - dockerfile: "services/worker/Dockerfile"
+      name: "worker"
+  scanners:
+    - trivy
+    - grype
+```
+
+You can mix discovery and explicit entries — discovered Dockerfiles
+augment the list rather than replacing it. Worked examples in
+[`docs/container-scanning.md`](../container-scanning.md#discover-mode-multi-image-monorepos).
+
+### `allow_failure` / `skip_summary`
+
+These mapped 1:1 to existing argus patterns and didn't need their
+own composite knobs:
+
+- **`allow_failure: true`** → set `fail_on_severity: none` on the
+  composite. The action runs and emits findings; the job never
+  fails on argus's behalf. The canonical "scan-but-don't-gate"
+  knob, used the same way everywhere else.
+- **`skip_summary: true`** → the per-scanner summary still gets
+  written to artifacts; what 0.6.x's `skip_summary` actually
+  controlled was whether the run participated in the aggregated
+  `security-summary` PR comment. In 1.x the `security-summary`
+  composite's `scan_statuses` input is the explicit gate — pass
+  the scanner's `result` per the silent-failure-gating pattern
+  (ADR-016) and the aggregator includes or excludes it cleanly.
+
+---
+
 ## What stayed on the composite action
 
 The action's `with:` surface keeps the inputs that are cross-scanner

--- a/docs/security.md
+++ b/docs/security.md
@@ -275,6 +275,53 @@ dependency.
 
 ---
 
+## Alert routing — paging and escalation
+
+argus stays out of the paging-channel business. The composite
+actions emit findings to:
+
+- The job's stdout / step summary (always)
+- A SARIF artifact (always)
+- The PR as an aggregated comment when `post_pr_comment: true`
+- The GitHub Security tab when `enable_code_security: true`
+
+argus does **not** `@`-mention specific users, post directly to
+Slack / PagerDuty / Opsgenie, or otherwise pick a notification
+channel on the team's behalf. The 0.6.x `gitleaks_notify_user_list`
+input that routed secret-detection events through GitHub
+`@`-mentions was removed intentionally — `@`-mention escalation
+gets noisy fast (transient false positives ping the whole security
+team on every PR), is tightly coupled to GitHub-as-notification,
+and doesn't compose with the alert pipelines most teams already
+own.
+
+If you need broader-than-PR-comment escalation, pipe argus output
+into your existing alert system at the workflow level. SARIF and
+`argus-results.json` are both stable schemas; one extra workflow
+step is usually enough:
+
+```yaml
+- name: Run argus
+  uses: huntridge-labs/argus/.github/actions/scanner-gitleaks@1.0.0
+  id: scan
+  with:
+    enable_code_security: true
+    fail_on_severity: high
+
+- name: Page on-call (only on high-severity findings)
+  if: failure() && steps.scan.outputs.high_count > 0
+  env:
+    SLACK_WEBHOOK_URL: ${{ secrets.SLACK_SECURITY_WEBHOOK }}
+  run: |
+    curl -X POST -H 'Content-Type: application/json' \
+      -d @argus-results.json "$SLACK_WEBHOOK_URL"
+```
+
+This keeps the paging decision (who, when, how loud) owned by the
+team's alerting config rather than the scanner's config.
+
+---
+
 ## Reporting a vulnerability
 
 Security issues with argus itself (the CLI, SDK, MCP server, or


### PR DESCRIPTION
## Description

Resolves the two long-pending "Decision pending" entries under `docs/developer/SDK-ROADMAP.md` → "DAST + Container Scanner Parity (Post-1.0 Regressions)". Both have natural answers grounded in patterns argus already supports — neither needs new code.

## Changes Made
- [ ] Added new scanner/workflow
- [ ] Modified existing scanner/workflow
- [x] Updated documentation
- [ ] Fixed bug
- [ ] Other

### Details

**1. scanner-container `scan_mode` recovery — Decided: do NOT restore.**

The discover semantic the 0.6.x `scan_mode: discover` input carried already lives in the SDK as a first-class `argus.yml` block: `containers.discover: true` + `containers.search_paths: [...]` walks the repo, builds every `Dockerfile*` it finds, scans the result. `containers.images: [...]` covers the manifest case. The schema validates both (`_CONTAINERS_KEYS` in `argus/core/schema.py`) and the audit gate (`scripts/ci/check_example_inputs.py`) already guards examples. Same posture as ADR-024 for ZAP — scanner-specific orchestration lives in the config file; composite action stays minimal; same config works on every CI platform + locally.

| 0.6.x | 1.x |
|---|---|
| `scan_mode: discover` | `containers.discover: true` + `containers.search_paths: [...]` |
| `scan_mode: manifest` | `containers.images: [...]` (`parse-container-config` emits the matrix) |
| `allow_failure` | `fail_on_severity: none` |
| `skip_summary` | `security-summary`'s `scan_statuses` input (ADR-016) |

Shipped: deprecation note + 0.6.x→1.x mapping table in `.github/actions/scanner-container/action.yml` (renders in docsite + auto-generated workflow pages), new "Discover mode (multi-image monorepos)" section in `docs/container-scanning.md` with worked examples, scanner-container section in `docs/migration/0.6.x-to-1.x.md` covering all four removed inputs side-by-side.

**2. scanner-gitleaks user-mention notifications — Decided: intentional removal confirmed.**

`@`-mention escalation is tightly coupled to GitHub-as-notification, gets noisy fast (transient false positives ping the security team on every PR), and doesn't compose with alert pipelines most teams already own (Slack, PagerDuty, Opsgenie). `post_pr_comment` already covers PR visibility; teams wanting paging behavior route SARIF or `argus-results.json` into their existing alert system at the workflow level — keeps the *who/when/how-loud* decision owned by the team's alerting config.

Shipped: new "Alert routing — paging and escalation" section in `docs/security.md` with a worked Slack-webhook example. Future contributors proposing to re-add `notify_users` (or any equivalent) land here first and see the rationale + the alternative pattern.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

### Test Results

```
✅ python -m docsite --validate            — docsite configuration is valid
✅ mkdocs build --strict                    — site built, no errors
✅ scripts.ci.check_example_inputs           — no example drift
✅ yaml.safe_load(scanner-container/action.yml)
```

## Security Considerations
- [ ] No security impact
- [x] Security enhancement — the alert-routing guidance in `docs/security.md` documents the threat-model boundary explicitly so contributors understand why argus stays out of paging-channel territory.
- [ ] Potential security implications (explain below)

## AI Context Updates (.ai/)

- [ ] `.ai/architecture.yaml` updated — no architectural change
- [ ] `.ai/workflows.yaml` updated
- [ ] `.ai/decisions.yaml` updated — both decisions live in the roadmap entries with full rationale; no new ADR warranted (these are confirmations + documentation, not new architectural decisions)
- [ ] `.ai/errors.yaml` updated
- [x] N/A

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues

Closes the last two "Decision pending" entries in `docs/developer/SDK-ROADMAP.md` → "DAST + Container Scanner Parity (Post-1.0 Regressions)". All 4 sub-items in that section are now resolved:

- scanner-zap target setup parity → ADR-024 (decided + implemented in PRs #141 / #142 / #145 / #154)
- scanner-container scan_mode → **decided in this PR**
- scanner-gitleaks notify_users → **decided in this PR**
- CI audit gate → already shipped in PR #136

## Screenshots/Logs (if applicable)

Diff: 5 files, +197 / -30.