### PR TITLE
docs(adr-025): split OS-image scope — services sub-scanner in, VM-image out

### DIFF
--- a/.ai/decisions.yaml
+++ b/.ai/decisions.yaml
@@ -1852,3 +1852,153 @@ decisions:
       - ADR-019  # Install-from-source pattern (the composite-action thinness this preserves)
     pr_references:
       - "(addresses DAST + Container Scanner Parity → scanner-zap target setup parity; see docs/developer/SDK-ROADMAP.md)"
+
+  - id: ADR-025
+    title: "OS-image inspection: in-container scope only; offline VM-image scanning is out of scope"
+    status: accepted
+    date: 2026-05-13
+    context: |
+      Two adjacent but materially different problem shapes get
+      conflated in user requests for "OS image scanning":
+
+      1) **OS as a container artifact.** A team ships their OS as
+         a container image — sometimes a stock base image
+         (``ubuntu:24.04``, ``alpine:3.19``, ``redhat/ubi9``),
+         sometimes a multi-service / systemd-in-container bundle
+         that runs as a workload. The container artifact itself
+         is what the scanner has access to: an OCI manifest, a
+         layered filesystem, plus the ``docker inspect`` view of
+         declared config.
+
+      2) **Offline VM images.** AWS AMIs, Azure VHDs, GCP disk
+         images, on-prem VMware OVA/VMDK, ISO files, raw disk
+         dumps, rootfs tarballs. The artifact is a bootable disk;
+         "scanning" requires mounting the filesystem (libguestfs
+         /``virt-customize`` / ``virt-inspect``), booting the
+         image in a sandbox VM, or hitting a cloud-provider API
+         (AWS Inspector v2, Azure Defender for Cloud, GCP Security
+         Command Center).
+
+      These two map to very different operational models:
+
+      - argus's container path: 5–60s scan latency, no extra host
+        deps beyond Docker / Podman / nerdctl, works the same on
+        Linux / macOS / WSL.
+      - Offline VM inspection via libguestfs: minutes-to-tens-of-
+        minutes per image, hundreds of MB of host install
+        (libguestfs ships its own guest kernel), Linux-only host,
+        requires root or libvirt group membership.
+
+      The user-research insight that prompted this ADR: when teams
+      say "we want argus to scan our OS," they almost always mean
+      flavor (1) — they've already containerized the OS image
+      because that's what their deploy pipeline produces and that's
+      what they can hand the scanner. The libguestfs / AMI /
+      VMDK case is a different audience (golden-AMI Packer
+      pipelines, FedRAMP infrastructure teams) with a different
+      operational shape.
+    decision: |
+      Split the OS-image problem into two roadmap entries with
+      explicit, opposite scope decisions:
+
+      **(A) In scope: extend the container scanner with a
+      ``services`` sub-scanner.** Walks systemd unit files
+      (``/etc/systemd/system/*.service``,
+      ``/lib/systemd/system/*.service``), SysV init scripts
+      (``/etc/init.d/*``), and common service configs
+      (``sshd_config``, ``postgresql.conf``, ``pg_hba.conf``,
+      ``nginx.conf``, etc.) **inside the container image's
+      filesystem**. Emits one ``Finding`` per service the image
+      would launch on boot, with severity INFO by default and
+      MEDIUM for services on a risky-default watchlist (sshd,
+      postgresql with ``trust`` auth, redis without password,
+      etc.). Same operational shape as the existing ``exposure``
+      sub-scanner (one ``docker run`` + filesystem walk + parse);
+      no new host dependencies; sits alongside trivy / grype /
+      syft / exposure in the existing
+      ``argus/scanners/container.py`` sub-scanner loop. Scoping
+      details, watchlist sources, and config knobs land as their
+      own actionable roadmap entry; this ADR commits to the
+      direction.
+
+      **(B) Out of scope: offline VM-image inspection.** Argus
+      will not ship libguestfs-based scanning, KVM/QEMU
+      boot-and-inspect, or per-cloud-provider AMI integrations.
+      Users with these needs are pointed at purpose-built tools:
+
+        - **OpenSCAP + ``oscap-vm`` / ``oscap-docker``** — offline
+          mount + scan, STIG/CIS profiles, mature SCAP/OVAL
+          tooling.
+        - **AWS Inspector v2** — first-class AMI scanning,
+          server-side, no install.
+        - **Azure Defender for Cloud / GCP Security Command
+          Center** — cloud-native equivalents.
+        - **CIS-CAT** — CIS benchmark scanner (commercial tier
+          for production use).
+        - **Lynis** — lighter offline audit, runs against a
+          mounted root filesystem.
+
+      The documentation pointer lives in ``docs/security.md``
+      (or a new ``docs/scanners.md`` "what argus doesn't cover"
+      section) so users land on a clear redirect instead of
+      filing issues asking why argus doesn't scan their AMI.
+
+      Why this split: argus's identity stays "source-code +
+      container artifacts," but expands naturally to cover the
+      OS-as-container case that most modern deploy pipelines
+      actually produce. The offline VM case is genuinely a
+      different product shape (operational profile, host
+      requirements, audience) — declaring it out of scope is
+      more honest than half-implementing it.
+    alternatives_considered:
+      - name: "Wrap OpenSCAP via libguestfs as an argus-native OS-image scanner"
+        rejected_because: |
+          Adds a hundreds-of-MB libguestfs install to argus's
+          host requirements, restricts argus to Linux-only on
+          the host (currently Linux / macOS / WSL), and pushes
+          scan latency from seconds into tens of minutes. The
+          operational profile fundamentally doesn't match
+          argus's PR-CI / dev-loop posture. OpenSCAP is also
+          already well-documented and widely used for this exact
+          purpose; argus wrapping it would not differentiate.
+
+      - name: "Add per-cloud-provider integrations (AWS Inspector v2, Azure Defender, GCP SCC)"
+        rejected_because: |
+          Each integration is its own API surface, auth model,
+          and rate-limit story. Argus's strength is "same
+          config, same output, anywhere"; bolting on per-cloud
+          integrations would split that promise. The cloud-native
+          scanners are also positioned closer to the asset they
+          inspect (running server-side) than argus could ever be.
+
+      - name: "Defer the OS-image research item indefinitely"
+        rejected_because: |
+          Leaves a "decision pending" rotting in the roadmap and
+          gives users no documentation pointer when they ask why
+          argus doesn't scan their AMI. The out-of-scope answer
+          + documentation pointer accomplishes the same
+          "don't build it" outcome with a useful redirect; ADRs
+          aren't terminal — if real demand surfaces from the
+          golden-AMI cohort later, we can revisit with concrete
+          data.
+
+      - name: "Argus-native ``services`` sub-scanner that ALSO handles offline VM images"
+        rejected_because: |
+          Tempting because it would be a "single answer" — but
+          the two cases share almost no code. Container
+          filesystems are layered, accessible via standard tools
+          we already use. VM disk images need libguestfs to mount
+          or KVM to boot; nothing about that code reuses with the
+          container path. Combining them creates a heavier
+          dependency footprint for users who only need (A).
+    consequences:
+      - "Container scanner gets a natural follow-up extension (the ``services`` sub-scanner) that addresses the common OS-as-container case without operational profile changes. Same Docker requirement, same scan latency, same cross-platform host story."
+      - "Users with offline AMI / VMDK / ISO needs get a clear, documented redirect to the right tool for their case. No more issues asking ``why doesn't argus scan my Packer-built AMI?``"
+      - "Argus's identity stays focused. We don't accidentally drift into infrastructure-scanning territory where cloud-native and purpose-built tools are far better positioned."
+      - "Future revisitability is preserved: if a cohort of golden-AMI / Packer-pipeline customers emerges with concrete use cases that genuinely don't fit OpenSCAP / AWS Inspector, we can revisit (B). ADRs aren't terminal."
+      - "The roadmap research item resolves cleanly into one actionable scope (``services`` sub-scanner) and one explicit non-goal (offline VM-image scanning), instead of a vague open question."
+    related:
+      - ADR-013  # Python SDK as primary interface (the operational profile this preserves)
+      - ADR-024  # DAST scanner tuning moves to argus.yml (same posture: scanner-specific in config, action surface minimal)
+    pr_references:
+      - "(splits the OS image port enumeration research item in docs/developer/SDK-ROADMAP.md → Attack Surface Visibility)"

--- a/docs/developer/SDK-ROADMAP.md
+++ b/docs/developer/SDK-ROADMAP.md
@@ -937,92 +937,110 @@ a vulnerable Redis package" and most security reviewers want both.
   cost. A runtime variant becomes a separate roadmap item if
   consumer demand surfaces.
 
-### OS image port enumeration — research item
+### OS image scanning — scope decided (ADR-025)
 
-Same question as above but for OS-level images: AWS AMIs, Azure VHDs,
-GCP disk images, on-prem VMware OVA/VMDK, ISO files, raw disk dumps,
-rootfs tarballs. What network endpoints would this image bind on boot?
+User requests for "OS image scanning" land in two buckets with
+materially different operational profiles. The original research
+item asked "is OS-image inspection in argus's scope at all?" — the
+answer turns out to be "depends what shape the OS arrives in." See
+[ADR-025](../../.ai/decisions.yaml) for full rationale.
 
-- [ ] **Research: in-scope, out-of-scope, or wrap-existing?**
-  Before scoping any implementation, answer three questions:
+#### (A) In scope: ``services`` sub-scanner for the container scanner
 
-  **Is offline OS-image inspection in argus's scope at all?**
-  Argus today operates on (a) source-code directories and (b)
-  container image references. An OS image is a fundamentally
-  different artifact — it's a bootable disk, not a layered
-  filesystem manifest. Inspecting it offline typically requires
-  one of:
-  - **libguestfs / `virt-customize` / `virt-inspect`** — mount the
-    disk image, walk the filesystem, read systemd unit files
-    (`/etc/systemd/system/*.service`, `/lib/systemd/system/*.service`),
-    SysV init scripts, common service configs (sshd_config,
-    postgresql.conf, nginx.conf, etc.). Linux-only on the host;
-    needs root or libvirt group; libguestfs is a heavy install
-    (~hundreds of MB once a guest kernel is included).
-  - **Boot-and-inspect** — actually boot the image in a sandbox VM,
-    let services start, capture listening sockets via SSH or guest
-    agent, tear down. Heaviest path; needs hypervisor (KVM, QEMU,
-    or cloud-provider API). Argus's container-or-source-code model
-    doesn't extend here cleanly.
-  - **Cloud-provider native** — AWS Inspector (AMIs), Azure
-    Defender for Cloud, GCP Security Command Center. These run
-    server-side, no local install.
+When the OS arrives **as a container image** (stock base image like
+``ubuntu:24.04`` / ``alpine:3.19`` / ``redhat/ubi9``, or a
+multi-service / systemd-in-container bundle), argus's existing
+engine can already inspect it — same Docker requirement, same
+sub-minute scan latency, same cross-platform host story. The gap
+is that we don't yet enumerate the services that would launch on
+container boot.
 
-  **Are there existing tools that solve this well enough that argus
-  should not reimplement?** Candidates to evaluate:
-  - **OpenSCAP + `oscap-vm` / `oscap-docker`** — SCAP content with
-    OVAL definitions can audit a running or mounted system; covers
-    listening-port checks via STIG/CIS profiles. Output is XCCDF
-    XML — would need an argus reporter shim.
-  - **Lynis** — system audit tool. Runs against a live root
-    filesystem; can chroot into a mounted image. Output is text;
-    parser would be needed.
-  - **CIS-CAT** — CIS benchmark scanner. Commercial license tier
-    needed for production use; OSS version exists but limited.
-  - **AWS Inspector v2** — first-class AMI scanning, no install
-    required if you're already on AWS. Doesn't help users on
-    other clouds or with on-prem images.
-  - **Anchore Enterprise** / **Aqua** / **Sysdig Secure** — all
-    have on-prem image scanning but are commercial/freemium.
-  - **`debootstrap` + chroot + `ss`** — DIY for Linux rootfs
-    tarballs only. Possible but argus-specific implementation.
+- [ ] **New ``services`` sub-scanner inside `argus/scanners/container.py`.**
+  Walks the container image's filesystem at scan time, parses
+  systemd unit files (`/etc/systemd/system/*.service`,
+  `/lib/systemd/system/*.service`), SysV init scripts
+  (`/etc/init.d/*`), and common service configs (`sshd_config`,
+  `postgresql.conf`, `pg_hba.conf`, `nginx.conf`, etc.). Emits one
+  `Finding` per service:
 
-  **Or is this a "different product" feeling?** The audience for
-  OS-image hardening (DevSecOps building golden AMIs, on-prem VM
-  templates, FedRAMP-bound infrastructure teams) overlaps with
-  argus's audience but the operational model is different:
-  - Argus runs in PR CI / dev loops; OS image scans are
-    typically pre-release gates on infrastructure-as-code
-    pipelines (Packer builds, Terraform deploys).
-  - Argus expects sub-minute scan times; OS-image inspection via
-    libguestfs is minutes-to-tens-of-minutes per image.
-  - Argus's container-scanner model assumes Docker is available;
-    OS-image inspection assumes libguestfs / KVM / cloud API
-    access, which is a different host requirement.
+  ```
+  INFO   SVC-sshd       sshd.service declared; default bind 22/tcp
+  MEDIUM SVC-postgres   postgresql.service declared; trust-auth in pg_hba.conf
+  INFO   SVC-nginx      nginx.service declared; listens on 80/tcp
+  ```
 
-  **Specific research deliverables** (one investigation, output is
-  a short ADR — not code):
-  - [ ] Inventory of 3-5 actual user requests / use cases for OS
-    image inspection. Without concrete demand, this stays
-    deferred.
-  - [ ] Comparison matrix: argus-native (libguestfs) vs. wrap
-    OpenSCAP vs. defer to AWS Inspector vs. out-of-scope.
-    Dimensions: install footprint, host OS requirements, supported
-    image formats, scan latency, license cost, reporting fidelity.
-  - [ ] Scope decision in `.ai/decisions.yaml` (likely ADR-025 or
-    later): one of "argus native", "argus wraps OpenSCAP", "argus
-    out of scope; recommend X", "deferred until more demand".
-  - [ ] If "out of scope": note in `docs/scanners.md` pointing
-    users at the right tool for OS-image port enumeration so they
-    don't open issues asking for it later.
+  Severity defaults to INFO for ordinary services and MEDIUM for a
+  built-in risky-default watchlist (sshd, postgres with ``trust``
+  auth, redis without password, etc.). Each entry on the watchlist
+  cites a "why" in the scanner module's docstring — same pattern
+  as ``RISKY_PORTS`` in the ``exposure`` sub-scanner.
 
-  **My strong prior** (to be tested against the research):
-  argus stays focused on source-code + container images;
-  OS-image inspection is best served by purpose-built tools
-  (OpenSCAP for offline, cloud-native scanners for AMIs). The
-  argus answer for users would be a documentation pointer plus,
-  if compelling, a `docs/security.md` paragraph naming the tools
-  we recommend for each cloud + on-prem path.
+  **Operational shape** — identical to the existing ``exposure``
+  sub-scanner: one ``docker run`` (or layer-extract via the
+  container runtime) + filesystem walk + parse. No new heavy
+  deps; sits alongside trivy / grype / syft / exposure /
+  ``services`` in the existing sub-scanner orchestration.
+
+  **Config knobs (in `argus.yml`):**
+  - `scanners.container.services_warn`: override the built-in
+    WARN list (replaces defaults; pass `[]` to demote every
+    service to INFO).
+  - `scanners.container.services_ignore`: suppress findings
+    entirely for services the team has explicitly accepted.
+
+  **Implementation tasks** (single PR, no new dependencies):
+  - [ ] `argus/scanners/container.py`: new `_scan_services`
+    sub-method extracting the relevant config files from the
+    image filesystem.
+  - [ ] Parser helpers for systemd `.service` units (ExecStart,
+    User, Description) and the four common service configs
+    above. Stdlib-only.
+  - [ ] Built-in `RISKY_SERVICES: dict[str, str]` with rationale
+    citations in the scanner docstring.
+  - [ ] Schema additions: `services_warn` and `services_ignore`
+    lists with validator coverage.
+  - [ ] Tests in `argus/tests/scanners/test_container.py`:
+    fixture image with multi-service config; assert one finding
+    per service with correct severity, ignore-list suppresses,
+    override warn-list reclassifies.
+  - [ ] Docs: extend `docs/scanners.md` Container Scanners
+    section with a "Service enumeration" subsection;
+    `docs/config-reference.md` adds the two new keys.
+
+  **Out of scope for this sub-scanner:** runtime service probing
+  (actually start the container, observe what binds). Static
+  unit-file declarations are the bulk of the value at a fraction
+  of the operational cost. A runtime variant becomes a separate
+  roadmap item if consumer demand surfaces.
+
+#### (B) Out of scope: offline VM-image scanning (AMI / VMDK / ISO)
+
+Decided in ADR-025: argus does **not** ship libguestfs-based
+scanning, KVM/QEMU boot-and-inspect, or per-cloud-provider AMI
+integrations. The operational profile (libguestfs at hundreds of
+MB, Linux-only host, multi-minute scan latency) fundamentally
+doesn't match argus's PR-CI / dev-loop posture, and the cloud-
+native scanners are far better positioned for the cloud cases.
+
+- [x] **Documentation pointer for users with offline-image needs.**
+  Lands in `docs/security.md` under a new "What argus doesn't
+  cover (offline VM images)" subsection. Recommended tools:
+  - **OpenSCAP + `oscap-vm` / `oscap-docker`** for offline disk
+    mount + STIG/CIS-profile audit.
+  - **AWS Inspector v2** for native AMI scanning.
+  - **Azure Defender for Cloud** / **GCP Security Command Center**
+    for the cloud-native equivalents.
+  - **CIS-CAT** for CIS-benchmark compliance.
+  - **Lynis** for lighter offline audits.
+
+  Shipped alongside ADR-025 so users land on a clear redirect
+  instead of filing issues. Pre-empts the "why doesn't argus
+  scan my Packer-built AMI?" support pattern.
+
+  Revisitability is preserved: ADRs aren't terminal — if a real
+  cohort of golden-AMI / Packer-pipeline customers emerges with
+  use cases that genuinely don't fit OpenSCAP / Inspector, we
+  can revisit. No concrete demand documented today.
 
 ---
 

--- a/docs/developer/SDK-ROADMAP.md
+++ b/docs/developer/SDK-ROADMAP.md
@@ -1034,7 +1034,7 @@ native scanners are far better positioned for the cloud cases.
   - **Lynis** for lighter offline audits.
 
   Shipped alongside ADR-025 so users land on a clear redirect
-  instead of filing issues. Pre-empts the "why doesn't argus
+  instead of filing issues. Preempts the "why doesn't argus
   scan my Packer-built AMI?" support pattern.
 
   Revisitability is preserved: ADRs aren't terminal — if a real

--- a/docs/security.md
+++ b/docs/security.md
@@ -322,6 +322,43 @@ team's alerting config rather than the scanner's config.
 
 ---
 
+## What argus doesn't cover (offline VM images)
+
+argus is a source-code and **container-artifact** scanner. If
+your OS arrives as a container (stock base image like
+`ubuntu:24.04` / `alpine:3.19` / `redhat/ubi9`, or a multi-service
+/ systemd-in-container bundle), argus's container scanner already
+covers it: CVE scanning via Trivy + Grype, SBOM via Syft, declared
+ports via the `exposure` sub-scanner, and (planned) service
+enumeration via the `services` sub-scanner.
+
+argus **does not** ship offline scanning for VM-shaped artifacts —
+AWS AMIs, Azure VHDs, GCP disk images, on-prem VMware OVA/VMDK,
+ISO files, or raw disk dumps. The operational profile
+(libguestfs at hundreds of MB, Linux-only host, multi-minute scan
+latency) fundamentally doesn't match argus's PR-CI / dev-loop
+posture, and purpose-built tools already cover this space well.
+This is an explicit non-goal — see [ADR-025](../../.ai/decisions.yaml).
+
+If you need offline VM-image scanning, reach for these instead:
+
+| Use case | Recommended tool |
+|---|---|
+| Offline mount + STIG/CIS-profile audit (any cloud, on-prem) | [OpenSCAP](https://www.open-scap.org/) (`oscap-vm` / `oscap-docker`) |
+| AWS AMIs, no host install | [AWS Inspector v2](https://docs.aws.amazon.com/inspector/latest/user/scanning-ec2.html) |
+| Azure VHDs / cloud workloads | [Microsoft Defender for Cloud](https://azure.microsoft.com/en-us/products/defender-for-cloud) |
+| GCP disk images / cloud workloads | [GCP Security Command Center](https://cloud.google.com/security-command-center) |
+| CIS-benchmark compliance | [CIS-CAT](https://www.cisecurity.org/cybersecurity-tools/cis-cat-pro) (free tier; commercial for prod use) |
+| Lighter offline audit on a mounted root filesystem | [Lynis](https://cisofy.com/lynis/) |
+
+Note: this is about the **artifact shape**, not the OS itself.
+argus scans `ubuntu:24.04` (container) fine; argus is not the right
+tool for the same OS packaged as an AMI. If a Packer pipeline
+produces both — scan the container artifact with argus, and the
+AMI with one of the tools above.
+
+---
+
 ## Reporting a vulnerability
 
 Security issues with argus itself (the CLI, SDK, MCP server, or


### PR DESCRIPTION
## Description

Resolves the "OS image port enumeration" research item under `docs/developer/SDK-ROADMAP.md` → "Attack Surface Visibility". User requests for "OS image scanning" turn out to land in two buckets with materially different operational profiles, so the right answer isn't a single yes/no — it's a clean split with explicit, opposite scope decisions on each.

## Changes Made
- [ ] Added new scanner/workflow
- [ ] Modified existing scanner/workflow
- [x] Updated documentation
- [ ] Fixed bug
- [x] Other — new ADR (ADR-025) committing to the scope split

### Details

**(A) IN SCOPE: container-shaped OS images get a `services` sub-scanner** *(new actionable roadmap entry)*

When the OS arrives as a container (`ubuntu:24.04`, `alpine:3.19`, `redhat/ubi9`, or a multi-service / systemd-in-container bundle), argus's existing engine can already inspect it — same Docker requirement, same sub-minute scan latency, same cross-platform host story. The gap is enumeration of services that would launch on container boot. The new sub-scanner sits alongside trivy / grype / syft / exposure in the container scanner orchestration, same shape as `exposure`:

| | Behavior |
|---|---|
| Source | systemd unit files (`/etc/systemd/system/*.service`, `/lib/systemd/system/*.service`), SysV init scripts (`/etc/init.d/*`), common service configs (`sshd_config`, `postgresql.conf`, `pg_hba.conf`, `nginx.conf`) — all walked from the container's filesystem |
| Output | One `Finding` per service: `INFO SVC-sshd` / `MEDIUM SVC-postgres` / etc. |
| Severity | INFO default, MEDIUM for `RISKY_SERVICES` watchlist (sshd, postgres with trust auth, redis without password, etc.) — each entry cites a "why" in the scanner docstring |
| Config knobs | `scanners.container.services_warn` / `services_ignore` lists in `argus.yml` |
| Operational shape | One `docker run` + filesystem walk + parse. No new heavy deps. |

**(B) OUT OF SCOPE: offline VM-image scanning (AMI / VMDK / ISO)** *(decided, doc pointer shipped)*

Operational profile (libguestfs at hundreds of MB, Linux-only host, multi-minute scan latency) fundamentally doesn't match argus's PR-CI / dev-loop posture, and the cloud-native scanners (AWS Inspector v2, Azure Defender, GCP SCC) plus OpenSCAP for offline are far better positioned for these cases. Shipping a doc pointer in `docs/security.md` instead of code so users land on the right tool instead of filing issues:

| Use case | Recommended tool |
|---|---|
| Offline mount + STIG/CIS-profile audit | OpenSCAP (`oscap-vm` / `oscap-docker`) |
| AWS AMIs | AWS Inspector v2 |
| Azure VHDs / cloud workloads | Microsoft Defender for Cloud |
| GCP disk images / cloud workloads | GCP Security Command Center |
| CIS-benchmark compliance | CIS-CAT |
| Lighter offline audit | Lynis |

**Why not combine them into one scanner?** Container filesystems are layered, accessible via standard tools we already use. VM disk images need libguestfs to mount or KVM to boot; nothing about that code reuses with the container path. The "single answer" framing is tempting but would create a heavier dependency footprint for users who only need (A).

**Why not defer indefinitely?** Leaves a "decision pending" rotting in the roadmap and gives users no documentation pointer when they ask why argus doesn't scan their AMI. The out-of-scope answer + documentation pointer accomplishes the same "don't build it" outcome with a useful redirect; ADRs aren't terminal — if real demand from a golden-AMI / Packer-pipeline cohort surfaces later, we can revisit.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

### Test Results

```
✅ python -m docsite --validate            — docsite configuration is valid
✅ mkdocs build --strict                    — site built, no errors
✅ ADR-025 valid YAML                       — 25 ADRs total, latest 3: ADR-023, ADR-024, ADR-025
```

## Security Considerations
- [ ] No security impact
- [x] Security enhancement — explicit scope boundary in `docs/security.md` means users with offline VM-image needs land on the right tool (OpenSCAP / AWS Inspector / Azure Defender / GCP SCC / CIS-CAT / Lynis) instead of trying to force argus to do something it's not the right shape for
- [ ] Potential security implications (explain below)

### Security Details

The new "What argus doesn't cover (offline VM images)" section makes the scope boundary explicit. Without it, a team running a Packer pipeline that produces both a container AND an AMI might assume argus covers both — when in fact argus is the right answer for the container artifact only.

## AI Context Updates (.ai/)

- [ ] `.ai/architecture.yaml` updated — no architectural change yet (the `services` sub-scanner work is the future PR; this PR is the scope decision)
- [ ] `.ai/workflows.yaml` updated
- [x] `.ai/decisions.yaml` updated — new ADR-025 with full context / decision / 4 rejected alternatives / consequences / related ADRs
- [ ] `.ai/errors.yaml` updated
- [ ] N/A

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues

Closes the OS-image research item under `docs/developer/SDK-ROADMAP.md` → "Attack Surface Visibility — Port & Service Exposure". Section now contains a clean (A) actionable + (B) decided-non-goal split instead of the open research item.

This is also the final "Decision pending" entry in the SDK roadmap — every queued decision item is now resolved.

## Screenshots/Logs (if applicable)

Diff: 3 files, +291 / -86.