### PR TITLE
fix(test-fixtures): bump flask/werkzeug floor past known-CVE versions

### DIFF
--- a/tests/fixtures/test-apps/python-app/requirements.txt
+++ b/tests/fixtures/test-apps/python-app/requirements.txt
@@ -1,2 +1,2 @@
-flask>=3.0.0
-werkzeug>=3.0.0
+flask>=3.1.3
+werkzeug>=3.1.6


### PR DESCRIPTION
## Description
Argus-on-Argus surfaced loose `>=3.0.0` floors in `tests/fixtures/test-apps/python-app/requirements.txt`, permitting known-vulnerable Flask 3.0.x and Werkzeug 3.0.x versions to resolve. Bump the floors to close out the CVE window while keeping the floor-only style that matches the rest of the fixture's posture.

## Changes Made
- [ ] Added new scanner/workflow
- [ ] Modified existing scanner/workflow
- [ ] Updated documentation
- [x] Fixed bug
- [ ] Other (please specify)

### Details
- `tests/fixtures/test-apps/python-app/requirements.txt`:
  - `flask>=3.0.0` → `flask>=3.1.3`
  - `werkzeug>=3.0.0` → `werkzeug>=3.1.6`

Still floor-only (no upper bound), same shape as before. Low urgency — fixture is CI-test-only and never ships to users — but no reason to carry a fixture that fails our own DevSecOps assessment.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results
Trivial dependency-pin change; no test surface affected. Pre-commit hooks all pass; pre-push suite runs as usual.

## Security Considerations
- [ ] No security impact
- [x] Security enhancement
- [ ] Potential security implications (explain below)

### Security Details
Closes the known-CVE window on the Flask 3.0.x / Werkzeug 3.0.x releases by raising the floor. Impact is limited to CI test environments — production users never resolve against this fixture.

## AI Context Updates (.ai/)
- [ ] `.ai/architecture.yaml` updated (if components/structure changed)
- [ ] `.ai/workflows.yaml` updated (if commands/tasks changed)
- [ ] `.ai/decisions.yaml` updated (if design decision made)
- [ ] `.ai/errors.yaml` updated (if common error addressed)
- [x] N/A - No .ai/ updates needed

## Checklist
- [x] Code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

### For New Scanners/Actions (if applicable)
- [ ] Composite action created (`.github/actions/scanner-*`)
- [ ] Parser and summary scripts included
- [ ] Unit tests added (`.github/actions/*/tests/`)
- [ ] Action documented (README.md in action directory)
- [ ] Added to actions catalog (`.github/actions/README.md`)
- [ ] Examples updated
- [ ] No breaking changes to existing scanners

## Related Issues
Closes # (issue number)

## Screenshots/Logs (if applicable)
Surfaced by an Argus assessment of the fixture file:

> tests/fixtures/test-apps/python-app/requirements.txt pins flask>=3.0.0 and werkzeug>=3.0.0 — these test fixture containers may be running vulnerable versions depending on what pip resolves. Impact is limited to CI test environments (not production), but could matter if fixtures run on Windows runners.
>
> Action: Pin fixture deps to flask>=3.1.3 and werkzeug>=3.1.6. Low urgency given test-only scope.