### PR TITLE
fix: post-1.0 gauntlet — 13 fixes across #166, #167, #168

### DIFF
--- a/.github/workflows/aicac.yml
+++ b/.github/workflows/aicac.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   aicac:
+    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
     runs-on: ubuntu-latest
     permissions:
       contents: write        # Needed to commit badge updates

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -40,6 +40,7 @@ jobs:
   # each had a separate hardcoded matrix that could drift out of sync
   # with the dogfood scan target list.
   matrix:
+    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
     name: Resolve image matrix
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -77,6 +78,7 @@ jobs:
 
   # ── Step 1: Build all custom images ──────────────────────────────────
   build:
+    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
     name: Build Images
     needs: matrix
     runs-on: ubuntu-latest
@@ -122,6 +124,7 @@ jobs:
 
   # ── Step 2: Scan each image with Trivy + Grype ──────────────────────
   scan:
+    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
     name: Scan ${{ matrix.image }}
     needs: [matrix, build]
     runs-on: ubuntu-latest
@@ -249,6 +252,7 @@ jobs:
 
   # ── Step 3: Test argus CLI using built images ───────────────────────
   test-cli:
+    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
     name: Test Argus CLI
     needs: [matrix, build]
     runs-on: ubuntu-latest
@@ -466,7 +470,7 @@ jobs:
   # ── Step 4: Post PR comment using argus markdown + comment-pr action ─
   comment-pr:
     name: Container Scan Summary
-    if: always() && github.event_name == 'pull_request'
+    if: (always() && github.event_name == 'pull_request') && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):'))
     needs: [scan, test-cli]
     runs-on: ubuntu-latest
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,6 +18,7 @@ concurrency:
 
 jobs:
   docs:
+    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -17,6 +17,7 @@ permissions:
 
 jobs:
   argus-scan:
+    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
     name: Argus Security Scan
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/test-actions.yml
+++ b/.github/workflows/test-actions.yml
@@ -64,6 +64,7 @@ jobs:
   # Posts coverage report as PR comment and fails if coverage is incomplete
   # ============================================================================
   validate-e2e-coverage:
+    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
     name: Validate E2E Coverage
     runs-on: ubuntu-latest
     steps:
@@ -216,6 +217,7 @@ jobs:
   # the resulting CLI works in a clean Python venv.
   # ============================================================================
   validate-install-from-source:
+    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
     name: Validate install-from-source pattern
     runs-on: ubuntu-latest
     steps:
@@ -313,10 +315,7 @@ jobs:
   test-bandit:
     name: SAST / bandit
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'workflow_dispatch' &&
-      (inputs.test_group == 'all' || inputs.test_group == 'sast') ||
-      github.event_name != 'workflow_dispatch'
+    if: (github.event_name == 'workflow_dispatch' && (inputs.test_group == 'all' || inputs.test_group == 'sast') || github.event_name != 'workflow_dispatch') && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):'))
     timeout-minutes: 15
 
     steps:
@@ -347,10 +346,7 @@ jobs:
   test-opengrep:
     name: SAST / opengrep
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'workflow_dispatch' &&
-      (inputs.test_group == 'all' || inputs.test_group == 'sast') ||
-      github.event_name != 'workflow_dispatch'
+    if: (github.event_name == 'workflow_dispatch' && (inputs.test_group == 'all' || inputs.test_group == 'sast') || github.event_name != 'workflow_dispatch') && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):'))
     timeout-minutes: 15
 
     steps:
@@ -381,10 +377,7 @@ jobs:
   test-codeql:
     name: SAST / codeql
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'workflow_dispatch' &&
-      (inputs.test_group == 'all' || inputs.test_group == 'sast') ||
-      github.event_name != 'workflow_dispatch'
+    if: (github.event_name == 'workflow_dispatch' && (inputs.test_group == 'all' || inputs.test_group == 'sast') || github.event_name != 'workflow_dispatch') && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):'))
     timeout-minutes: 20
 
     steps:
@@ -417,10 +410,7 @@ jobs:
   test-secrets:
     name: Secrets / gitleaks
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'workflow_dispatch' &&
-      (inputs.test_group == 'all' || inputs.test_group == 'secrets') ||
-      github.event_name != 'workflow_dispatch'
+    if: (github.event_name == 'workflow_dispatch' && (inputs.test_group == 'all' || inputs.test_group == 'secrets') || github.event_name != 'workflow_dispatch') && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):'))
     timeout-minutes: 10
 
     steps:
@@ -463,10 +453,7 @@ jobs:
   test-trivy-iac:
     name: IaC / trivy-iac
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'workflow_dispatch' &&
-      (inputs.test_group == 'all' || inputs.test_group == 'infrastructure') ||
-      github.event_name != 'workflow_dispatch'
+    if: (github.event_name == 'workflow_dispatch' && (inputs.test_group == 'all' || inputs.test_group == 'infrastructure') || github.event_name != 'workflow_dispatch') && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):'))
     timeout-minutes: 15
 
     steps:
@@ -496,10 +483,7 @@ jobs:
   test-checkov:
     name: IaC / checkov
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'workflow_dispatch' &&
-      (inputs.test_group == 'all' || inputs.test_group == 'infrastructure') ||
-      github.event_name != 'workflow_dispatch'
+    if: (github.event_name == 'workflow_dispatch' && (inputs.test_group == 'all' || inputs.test_group == 'infrastructure') || github.event_name != 'workflow_dispatch') && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):'))
     timeout-minutes: 15
 
     steps:
@@ -534,10 +518,7 @@ jobs:
   test-scn-detector:
     name: Compliance / scn-detector
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'workflow_dispatch' &&
-      (inputs.test_group == 'all' || inputs.test_group == 'infrastructure') ||
-      github.event_name != 'workflow_dispatch'
+    if: (github.event_name == 'workflow_dispatch' && (inputs.test_group == 'all' || inputs.test_group == 'infrastructure') || github.event_name != 'workflow_dispatch') && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):'))
     timeout-minutes: 15
 
     steps:
@@ -601,10 +582,7 @@ jobs:
   test-container:
     name: Container / ${{ matrix.tool }}
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'workflow_dispatch' &&
-      (inputs.test_group == 'all' || inputs.test_group == 'container') ||
-      github.event_name != 'workflow_dispatch'
+    if: (github.event_name == 'workflow_dispatch' && (inputs.test_group == 'all' || inputs.test_group == 'container') || github.event_name != 'workflow_dispatch') && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):'))
     timeout-minutes: 15
 
     strategy:
@@ -657,10 +635,7 @@ jobs:
   test-syft:
     name: SBOM / syft
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'workflow_dispatch' &&
-      (inputs.test_group == 'all' || inputs.test_group == 'container') ||
-      github.event_name != 'workflow_dispatch'
+    if: (github.event_name == 'workflow_dispatch' && (inputs.test_group == 'all' || inputs.test_group == 'container') || github.event_name != 'workflow_dispatch') && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):'))
     timeout-minutes: 15
 
     steps:
@@ -702,10 +677,7 @@ jobs:
   test-linter-dockerfile:
     name: Linter / dockerfile
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'workflow_dispatch' &&
-      (inputs.test_group == 'all' || inputs.test_group == 'linters') ||
-      github.event_name != 'workflow_dispatch'
+    if: (github.event_name == 'workflow_dispatch' && (inputs.test_group == 'all' || inputs.test_group == 'linters') || github.event_name != 'workflow_dispatch') && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):'))
     timeout-minutes: 10
 
     steps:
@@ -729,10 +701,7 @@ jobs:
   test-linter-python:
     name: Linter / python
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'workflow_dispatch' &&
-      (inputs.test_group == 'all' || inputs.test_group == 'linters') ||
-      github.event_name != 'workflow_dispatch'
+    if: (github.event_name == 'workflow_dispatch' && (inputs.test_group == 'all' || inputs.test_group == 'linters') || github.event_name != 'workflow_dispatch') && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):'))
     timeout-minutes: 10
 
     steps:
@@ -756,10 +725,7 @@ jobs:
   test-linter-yaml:
     name: Linter / yaml
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'workflow_dispatch' &&
-      (inputs.test_group == 'all' || inputs.test_group == 'linters') ||
-      github.event_name != 'workflow_dispatch'
+    if: (github.event_name == 'workflow_dispatch' && (inputs.test_group == 'all' || inputs.test_group == 'linters') || github.event_name != 'workflow_dispatch') && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):'))
     timeout-minutes: 10
 
     steps:
@@ -783,10 +749,7 @@ jobs:
   test-linter-javascript:
     name: Linter / javascript
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'workflow_dispatch' &&
-      (inputs.test_group == 'all' || inputs.test_group == 'linters') ||
-      github.event_name != 'workflow_dispatch'
+    if: (github.event_name == 'workflow_dispatch' && (inputs.test_group == 'all' || inputs.test_group == 'linters') || github.event_name != 'workflow_dispatch') && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):'))
     timeout-minutes: 10
 
     steps:
@@ -810,10 +773,7 @@ jobs:
   test-linter-json:
     name: Linter / json
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'workflow_dispatch' &&
-      (inputs.test_group == 'all' || inputs.test_group == 'linters') ||
-      github.event_name != 'workflow_dispatch'
+    if: (github.event_name == 'workflow_dispatch' && (inputs.test_group == 'all' || inputs.test_group == 'linters') || github.event_name != 'workflow_dispatch') && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):'))
     timeout-minutes: 10
 
     steps:
@@ -837,10 +797,7 @@ jobs:
   test-linter-terraform:
     name: Linter / terraform
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'workflow_dispatch' &&
-      (inputs.test_group == 'all' || inputs.test_group == 'linters') ||
-      github.event_name != 'workflow_dispatch'
+    if: (github.event_name == 'workflow_dispatch' && (inputs.test_group == 'all' || inputs.test_group == 'linters') || github.event_name != 'workflow_dispatch') && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):'))
     timeout-minutes: 10
 
     steps:
@@ -868,10 +825,7 @@ jobs:
   test-zap:
     name: DAST / zap
     runs-on: ubuntu-latest
-    if: >-
-      github.event_name == 'pull_request' ||
-      github.event_name == 'push' ||
-      inputs.test_group == 'all'
+    if: (github.event_name == 'pull_request' || github.event_name == 'push' || inputs.test_group == 'all') && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):'))
     timeout-minutes: 25
 
     services:
@@ -930,10 +884,7 @@ jobs:
   test-clamav:
     name: Malware / clamav
     runs-on: ubuntu-latest
-    if: >-
-      github.event_name == 'pull_request' ||
-      github.event_name == 'push' ||
-      inputs.test_group == 'all'
+    if: (github.event_name == 'pull_request' || github.event_name == 'push' || inputs.test_group == 'all') && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):'))
     timeout-minutes: 20
 
     steps:
@@ -974,10 +925,7 @@ jobs:
   test-supply-chain:
     name: Supply Chain / supply-chain
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'workflow_dispatch' &&
-      (inputs.test_group == 'all' || inputs.test_group == 'supply-chain') ||
-      github.event_name != 'workflow_dispatch'
+    if: (github.event_name == 'workflow_dispatch' && (inputs.test_group == 'all' || inputs.test_group == 'supply-chain') || github.event_name != 'workflow_dispatch') && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):'))
     timeout-minutes: 10
 
     steps:
@@ -1025,10 +973,7 @@ jobs:
   test-osv:
     name: Dependencies / osv
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'workflow_dispatch' &&
-      (inputs.test_group == 'all' || inputs.test_group == 'dependencies') ||
-      github.event_name != 'workflow_dispatch'
+    if: (github.event_name == 'workflow_dispatch' && (inputs.test_group == 'all' || inputs.test_group == 'dependencies') || github.event_name != 'workflow_dispatch') && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):'))
     timeout-minutes: 15
 
     steps:
@@ -1072,10 +1017,7 @@ jobs:
   test-dependency-review:
     name: Dependencies / dependency-review
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'workflow_dispatch' &&
-      (inputs.test_group == 'all' || inputs.test_group == 'dependencies') ||
-      github.event_name != 'workflow_dispatch'
+    if: (github.event_name == 'workflow_dispatch' && (inputs.test_group == 'all' || inputs.test_group == 'dependencies') || github.event_name != 'workflow_dispatch') && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):'))
     timeout-minutes: 10
 
     steps:
@@ -1118,6 +1060,7 @@ jobs:
   # Note: Other summary generators need upstream artifacts, tested separately
   # ============================================================================
   test-linting-summary:
+    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
     name: Summary / linting-summary
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -1148,6 +1091,7 @@ jobs:
   # Tests: parse-container-config, parse-zap-config
   # ============================================================================
   test-parse-container-config:
+    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
     name: Parser / container-config
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -1173,6 +1117,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   test-parse-zap-config:
+    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
     name: Parser / zap-config
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -1202,6 +1147,7 @@ jobs:
   # Validates that example workflows have correct syntax and references
   # ============================================================================
   validate-examples:
+    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
     name: Validate Examples
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -1328,7 +1274,7 @@ jobs:
       - test-parse-container-config
       - test-parse-zap-config
       - validate-examples
-    if: always()
+    if: (always()) && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):'))
 
     steps:
       - name: Generate Summary
@@ -1406,7 +1352,7 @@ jobs:
   # ============================================================================
   test-results:
     name: Test Results
-    if: always()
+    if: (always()) && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):'))
     needs:
       - validate-e2e-coverage
       - test-bandit

--- a/.github/workflows/test-lint-workflows.yml
+++ b/.github/workflows/test-lint-workflows.yml
@@ -26,6 +26,7 @@ concurrency:
 
 jobs:
   test-lint-workflows:
+    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
     name: actionlint
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   unit-tests:
+    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
     name: Unit Tests (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:

--- a/.release-it.json
+++ b/.release-it.json
@@ -28,7 +28,8 @@
       "npm test"
     ],
     "after:bump": [
-      "python3 scripts/release_it/inject_image_digests.py ${version}"
+      "python3 scripts/release_it/inject_image_digests.py ${version}",
+      "python3 -m scripts.ci.check_cli_docs --fix"
     ],
     "before:release": [
       "echo 'before:release hook executed'",

--- a/.release-it.json
+++ b/.release-it.json
@@ -169,6 +169,30 @@
         },
         {
           "files": [
+            "docs/**/*.md",
+            "examples/configs/**/*.{yml,yaml,json}",
+            "*.md"
+          ],
+          "search": {
+            "pattern": "(raw\\.githubusercontent\\.com/huntridge-labs/argus)/[^/]+(/argus-config\\.schema\\.json)",
+            "flags": "g"
+          },
+          "replace": "${1}/{{version}}${2}"
+        },
+        {
+          "files": [
+            "docs/**/*.md",
+            "examples/**/*.{yml,yaml,md}",
+            "*.md"
+          ],
+          "search": {
+            "pattern": "(ghcr\\.io/huntridge-labs/argus/[\\w-]+:)\\d+\\.\\d+\\.\\d+(?:-[\\w.-]+)?",
+            "flags": "g"
+          },
+          "replace": "${1}{{version}}"
+        },
+        {
+          "files": [
             "argus/containers.py"
           ],
           "search": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -496,10 +496,10 @@ argus scan --config argus.yml
 argus scan --scanners bandit,gitleaks --path ./src
 
 # List available scanners
-argus list
+argus scan --list
 
 # Check version
-argus version
+argus --version
 ```
 
 **Config file** (`argus.yml`):

--- a/argus.yml
+++ b/argus.yml
@@ -1,3 +1,4 @@
+# yamllint disable-line rule:line-length
 # yaml-language-server: $schema=https://raw.githubusercontent.com/huntridge-labs/argus/main/argus-config.schema.json
 # Argus dogfood configuration — we scan our own production code.
 # Test fixtures (tests/fixtures/) are excluded — those contain

--- a/argus/audit/logger.py
+++ b/argus/audit/logger.py
@@ -123,24 +123,36 @@ def get_logger(
     name: str = "argus",
     output_dir: str | Path | None = None,
     verbose: bool = False,
+    quiet: bool = False,
 ) -> logging.Logger:
     """Get a configured argus logger with colored console + JSON file output.
 
+    Console level resolution (verbose wins over quiet on conflict):
+      - ``verbose=True``   → DEBUG
+      - ``quiet=True``     → WARNING (per-phase progress lines suppressed)
+      - neither            → INFO (default)
+
     If *output_dir* is provided, writes structured JSON logs to
-    ``{output_dir}/argus.log`` alongside scan results.
+    ``{output_dir}/argus.log`` alongside scan results — the file
+    handler always captures DEBUG regardless of console level, so
+    ``--quiet`` mutes the terminal without losing audit fidelity.
 
     The logger is created once per *name*; subsequent calls with the same
     name return the existing logger without adding duplicate handlers.
     """
+    console_level = (
+        logging.DEBUG if verbose
+        else (logging.WARNING if quiet else logging.INFO)
+    )
+
     logger = logging.getLogger(name)
     if logger.handlers:
-        # Existing loggers should still honor a later verbose request,
-        # especially when shared across command flows.
+        # Existing loggers should still honor a later verbose / quiet
+        # change, especially when shared across command flows.
         for handler in logger.handlers:
             if isinstance(handler, logging.StreamHandler):
-                desired_level = logging.DEBUG if verbose else logging.INFO
-                if handler.level != desired_level:
-                    handler.setLevel(desired_level)
+                if handler.level != console_level:
+                    handler.setLevel(console_level)
 
         # Add file logging if this call requests it and none exists yet.
         has_file_handler = any(
@@ -162,10 +174,11 @@ def get_logger(
 
     logger.setLevel(logging.DEBUG)
 
-    # Console handler -- colored, INFO level (DEBUG if verbose)
+    # Console handler — colored, level resolved above
+    # (DEBUG when verbose, WARNING when quiet, INFO otherwise).
     use_color = sys.stderr.isatty()
     console = logging.StreamHandler(sys.stderr)
-    console.setLevel(logging.DEBUG if verbose else logging.INFO)
+    console.setLevel(console_level)
     console.setFormatter(ColoredConsoleFormatter(use_color=use_color))
     logger.addHandler(console)
 

--- a/argus/cli.py
+++ b/argus/cli.py
@@ -2568,10 +2568,26 @@ def cmd_report(args: argparse.Namespace) -> int:
 
     try:
         import json
+        # ``argus scan`` writes to ``<results_dir>/<timestamp>/argus-
+        # results.json`` and updates a ``latest`` symlink. The previous
+        # default lookup looked at ``<results_dir>/argus-results.json``
+        # directly, which never existed for fresh scans (issue #168-K).
+        # Try the flat layout first (back-compat with CI matrix output
+        # and explicit ``-r`` pointing at a run dir) then fall back to
+        # following the ``latest`` symlink.
         json_file = results_dir / "argus-results.json"
         if not json_file.exists():
-            print(f"Error: {json_file} not found", file=sys.stderr)
-            return EXIT_ERROR
+            latest = results_dir / "latest" / "argus-results.json"
+            if latest.exists():
+                json_file = latest
+            else:
+                print(
+                    f"Error: no argus-results.json found at {results_dir!s} "
+                    f"or {results_dir / 'latest'!s}/. Did you run "
+                    f"`argus scan` first?",
+                    file=sys.stderr,
+                )
+                return EXIT_ERROR
 
         from argus.core.models import ScanSummary
         data = json.loads(json_file.read_text())

--- a/argus/cli.py
+++ b/argus/cli.py
@@ -713,7 +713,7 @@ def _build_scan_parser(subparsers: argparse._SubParsersAction) -> None:
         metavar="FILE",
         help="Write scan result counts as key=value pairs to FILE. "
              "Useful in CI: cat FILE >> $GITHUB_OUTPUT. "
-             "Keys: critical_count, high_count, medium_count, low_count, total_count, passed.",
+             "Keys: critical_count, high_count, medium_count, low_count, info_count, total_count, passed.",
     )
     scan_parser.add_argument(
         "--exclude", "-e",
@@ -2891,6 +2891,7 @@ def _write_output_vars(summary, filepath: str) -> None:
         f"high_count={summary.high_count}",
         f"medium_count={summary.medium_count}",
         f"low_count={summary.low_count}",
+        f"info_count={summary.info_count}",
         f"total_count={summary.total_count}",
         f"issue_count={summary.total_count}",
         f"findings_count={summary.total_count}",

--- a/argus/cli.py
+++ b/argus/cli.py
@@ -370,6 +370,16 @@ def _build_view_parser(subparsers: argparse._SubParsersAction) -> None:
     # on the first positional because it would reject path-shaped
     # values when the user passes --interface separately. Instead we
     # accept any string and sort it out in _resolve_view_args.
+    #
+    # Argparse can't bind the second positional when a flag-with-value
+    # sits between the two positionals on some Python versions (issue
+    # #168-D5 reproduced ``argus view browser --port 18081 ./results/``
+    # → "unrecognized arguments: ./results/"). When that happens, the
+    # ``--path / -p`` flag below is the explicit workaround. Two
+    # workable shapes:
+    #
+    #     argus view browser ./results/ --port 18081     # path before flags
+    #     argus view browser --port 18081 --path ./results/  # explicit --path
     view_parser.add_argument(
         "interface_or_path",
         nargs="?",
@@ -386,6 +396,17 @@ def _build_view_parser(subparsers: argparse._SubParsersAction) -> None:
         metavar="PATH",
         help="Results directory or argus-results.json path when the first "
              "positional is an interface keyword (default: ./argus-results/)",
+    )
+    view_parser.add_argument(
+        "--path", "-p",
+        dest="path_flag",
+        default=None,
+        metavar="PATH",
+        help="Results directory or argus-results.json path. Equivalent "
+             "to the positional form ``argus view <iface> <path>`` but "
+             "robust to argparse's ordering quirks — use this when a "
+             "flag-with-value (e.g. ``--port``) sits between the "
+             "interface keyword and the path (issue #168-D5).",
     )
     view_parser.add_argument(
         "--interface", "-i",
@@ -419,12 +440,15 @@ def _build_view_parser(subparsers: argparse._SubParsersAction) -> None:
 
 
 def _resolve_view_args(args: argparse.Namespace) -> tuple[str, str | None] | None:
-    """Sort positionals + flag into (interface, path).
+    """Sort positionals + flags into (interface, path).
 
     The first positional can be either an interface keyword
     (``terminal``/``browser``) or a path. We only know which by looking
     at its value, so the disambiguation lives here rather than in the
     parser.
+
+    ``--path / -p`` provides an explicit-flag escape hatch when
+    argparse refuses to bind the second positional (issue #168-D5).
 
     Returns ``(interface, path)`` on success, or ``None`` if the
     arguments are inconsistent (the caller has already printed an
@@ -433,6 +457,7 @@ def _resolve_view_args(args: argparse.Namespace) -> tuple[str, str | None] | Non
     pos1 = getattr(args, "interface_or_path", None)
     pos2 = getattr(args, "path_arg", None)
     flag = getattr(args, "interface_flag", None)
+    path_flag = getattr(args, "path_flag", None)
 
     pos_interface: str | None = None
     pos_path: str | None = None
@@ -466,8 +491,20 @@ def _resolve_view_args(args: argparse.Namespace) -> tuple[str, str | None] | Non
         )
         return None
 
+    # ``--path`` overrides the positional path. Conflict between the
+    # two surfaces is an error — the user passed both forms and we
+    # can't know which they meant.
+    if path_flag is not None and pos_path is not None and path_flag != pos_path:
+        print(
+            f"Error: conflicting paths — positional '{pos_path}' vs "
+            f"--path '{path_flag}'. Pass only one.",
+            file=sys.stderr,
+        )
+        return None
+    resolved_path = path_flag if path_flag is not None else pos_path
+
     interface = flag or pos_interface or "terminal"
-    return interface, pos_path
+    return interface, resolved_path
 
 
 def cmd_view(args: argparse.Namespace) -> int:

--- a/argus/cli.py
+++ b/argus/cli.py
@@ -2670,11 +2670,15 @@ def cmd_cache(args: argparse.Namespace) -> int:
         if empty_dirs:
             print(
                 f"\nNote: directories exist for {', '.join(empty_dirs)} but "
-                "are empty. The mount was wired up but the scanner did not "
-                "write to it — likely because the container process runs as "
-                "a non-root user without write access to the mounted path, "
-                "or because the scanner stores its cache elsewhere inside "
-                "the container. See issue #168-M for tracking."
+                "are empty. Three possibilities, in order of likelihood: "
+                "(1) the scanner didn't trigger a cache-populating operation "
+                "during the recent run — e.g. ``trivy-iac`` scans config files "
+                "without touching the vuln DB so /root/.cache/trivy stays empty; "
+                "(2) the scanner stores its cache at a path argus doesn't mount; "
+                "(3) the container process runs as a non-root user and can't write "
+                "to the host-owned mount. Run a vuln-DB-driven scan (``argus scan "
+                "grype --sbom <sbom>``) to verify the cache surfaces are wired. "
+                "Tracked in issue #168-M."
             )
     return EXIT_SUCCESS
 

--- a/argus/cli.py
+++ b/argus/cli.py
@@ -1162,7 +1162,7 @@ def _build_completion_parser(subparsers: argparse._SubParsersAction) -> None:
         description=(
             "Generate a shell completion script for argus.\n\n"
             "Once installed, pressing <Tab> will complete:\n"
-            "  - subcommands (scan, list, view, cache, ...)\n"
+            "  - subcommands (scan, view, report, classify, cache, ...)\n"
             "  - scanner and linter names (bandit, gitleaks, lint-yaml, ...)\n"
             "  - common flags (--config, --scanners, --severity, ...)\n\n"
             "Install (persistent — remember to reload your shell):\n"
@@ -1589,7 +1589,12 @@ def _cmd_source_scan(args: argparse.Namespace) -> int:
     else:
         output_dir = _make_run_dir(config.reporting.output_dir)
     config.reporting.output_dir = output_dir
-    log = get_logger("argus", output_dir=output_dir, verbose=args.verbose)
+    log = get_logger(
+        "argus",
+        output_dir=output_dir,
+        verbose=args.verbose,
+        quiet=getattr(args, "quiet", False),
+    )
 
     # Kick off the update check in a daemon thread now so it runs in
     # parallel with the scan — by end-of-command it's already done.
@@ -1794,6 +1799,12 @@ def _cmd_source_scan(args: argparse.Namespace) -> int:
     # ``formats: [terminal, sarif]`` no longer silently breaks
     # ``argus view`` (the diagnoser still helps for legacy result dirs
     # produced before this contract was in place).
+    # Surface the --fail-on-scanner-error state to reporters so the
+    # terminal report can suppress its "Pass --fail-on-scanner-error
+    # to fail the scan when this happens" advice when the flag is
+    # already on (issue #168-D).
+    summary.fail_on_scanner_error_set = bool(getattr(args, "fail_on_scanner_error", False))
+
     try:
         from argus.reporters import ensure_canonical_json, get_reporter
         for fmt in ensure_canonical_json(config.reporting.formats):

--- a/argus/cli.py
+++ b/argus/cli.py
@@ -2644,16 +2644,38 @@ def cmd_cache(args: argparse.Namespace) -> int:
     print()
 
     total_size = 0
+    empty_existing = 0
     for scanner_key in sorted(CACHE_MOUNTS):
         scanner_dir = cache_root / scanner_key
-        if scanner_dir.exists():
-            size = sum(f.stat().st_size for f in scanner_dir.rglob("*") if f.is_file())
-            total_size += size
-            print(f"  {scanner_key:<15} {_format_size(size)}")
-        else:
+        if not scanner_dir.exists():
             print(f"  {scanner_key:<15} (not cached)")
+            continue
+        size = sum(f.stat().st_size for f in scanner_dir.rglob("*") if f.is_file())
+        total_size += size
+        if size == 0:
+            # The directory was created by ``get_cache_mount`` (so the
+            # mount could be wired up) but the scanner wrote nothing
+            # into it. Distinguishing this from "not cached" gives the
+            # user a hint that the mount happened but the scanner
+            # isn't using it — see issue #168-M.
+            print(f"  {scanner_key:<15} 0 B (mount empty)")
+        else:
+            print(f"  {scanner_key:<15} {_format_size(size)}")
 
     print(f"\n  {'Total':<15} {_format_size(total_size)}")
+    if total_size == 0 and empty_existing == 0:
+        # Inspect whether any of the dirs exist at all — if they do,
+        # the scanner ran with the mount but didn't write to it.
+        empty_dirs = [k for k in CACHE_MOUNTS if (cache_root / k).exists()]
+        if empty_dirs:
+            print(
+                f"\nNote: directories exist for {', '.join(empty_dirs)} but "
+                "are empty. The mount was wired up but the scanner did not "
+                "write to it — likely because the container process runs as "
+                "a non-root user without write access to the mounted path, "
+                "or because the scanner stores its cache elsewhere inside "
+                "the container. See issue #168-M for tracking."
+            )
     return EXIT_SUCCESS
 
 

--- a/argus/cli.py
+++ b/argus/cli.py
@@ -798,17 +798,25 @@ def _build_scan_parser(subparsers: argparse._SubParsersAction) -> None:
              "vulnerability databases on every container run.",
     )
     scan_parser.add_argument(
-        "--no-keep-raw",
-        action="store_true",
-        dest="no_keep_raw",
-        help="Do not persist raw per-scanner output files alongside the "
-             "canonical argus-results.json. Source scans normally drop "
-             "each scanner's results.json / *.sarif / stdout.txt under "
-             "<output_dir>/raw/<scanner>/; container scans drop "
-             "trivy-results.json / grype-results.json / syft-sbom.json "
-             "under <output_dir>/raw/<image>/. Pass --no-keep-raw to "
-             "skip that step in tight CI environments. The same effect "
-             "is available via 'reporting.keep_raw: false' in argus.yml.",
+        "--keep-raw",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        dest="keep_raw",
+        help="Persist each scanner's raw output files (results.json / "
+             "*.sarif / stdout.txt) under <output_dir>/raw/<scanner>/ "
+             "alongside the canonical argus-results.json. Container "
+             "scans drop trivy-results.json / grype-results.json / "
+             "syft-sbom.json under <output_dir>/raw/<image>/. Default "
+             "OFF — scanners like gitleaks write the literal matched "
+             "secret bytes into raw output, so persisting raw by "
+             "default turned argus-results into a secret-leak vector. "
+             "The canonical argus-results.json is always written and "
+             "is pattern-redacted. Pass --keep-raw for forensic / "
+             "triage workflows that need the unredacted per-scanner "
+             "artifacts. The same effect is available via "
+             "'reporting.keep_raw: true' in argus.yml. Use "
+             "--no-keep-raw to explicitly override a config-file "
+             "opt-in.",
     )
 
     # Credential stdin flags — read a password from stdin and use it
@@ -1599,15 +1607,18 @@ def _cmd_source_scan(args: argparse.Namespace) -> int:
     log.info("Argus scan starting")
 
     # Decide whether to persist raw per-scanner outputs alongside the
-    # canonical argus-results.json. Default ON — users running
-    # ``argus scan`` reasonably expect each scanner's raw results
-    # (results.json / *.sarif / stdout.txt) to be available for
-    # forensics or manual triage. Opt out via ``--no-keep-raw``
-    # (CLI) or ``reporting.keep_raw: false`` (argus.yml). CLI flag
-    # wins on conflict, matching the dispatcher's
-    # explicit-over-implicit posture used throughout.
-    keep_raw_config = getattr(config.reporting, "keep_raw", True)
-    keep_raw = bool(keep_raw_config) and not getattr(args, "no_keep_raw", False)
+    # canonical argus-results.json. Default OFF — scanners like
+    # gitleaks emit the literal matched secret bytes into raw output;
+    # persisting those by default turned argus-results into a leak
+    # vector. The canonical argus-results.json is always written and
+    # is pattern-redacted. Forensic / triage users opt in via
+    # ``--keep-raw`` (CLI) or ``reporting.keep_raw: true``
+    # (argus.yml). CLI flag wins on conflict — ``--no-keep-raw``
+    # explicitly overrides a config-file opt-in. ``args.keep_raw`` is
+    # tri-state: True / False / None (not specified).
+    keep_raw_config = getattr(config.reporting, "keep_raw", False)
+    cli_keep_raw = getattr(args, "keep_raw", None)
+    keep_raw = cli_keep_raw if cli_keep_raw is not None else bool(keep_raw_config)
     raw_output_root = str(Path(output_dir) / "raw") if keep_raw else None
 
     # Build engine and register scanners
@@ -2164,20 +2175,21 @@ def _cmd_container_scan(
     update_check = start_background_check(args)
 
     # Decide whether to persist raw per-scanner outputs alongside the
-    # canonical argus-results.json. Default is ON — the user just ran
-    # a scan and would expect those artifacts to be available for
-    # manual triage. Opt out via ``--no-keep-raw`` (CLI) or
-    # ``containers.keep_raw: false`` (argus.yml). CLI flag wins on
-    # conflict, matching the rest of the dispatcher's
-    # explicit-over-implicit posture.
-    # ``reporting.keep_raw`` is the unified config home for raw-output
-    # preservation; the legacy ``containers.keep_raw`` is still read
-    # as a fallback so configs from earlier in this PR's lifecycle
-    # don't break. CLI ``--no-keep-raw`` wins over both.
+    # canonical argus-results.json. Default is OFF — scanners write
+    # literal matched content (image-layer scan hits) into raw output,
+    # so persisting raw by default leaks data the canonical
+    # argus-results.json pattern-redacts. Forensic / triage users opt
+    # in with ``--keep-raw`` (CLI) or ``reporting.keep_raw: true``
+    # (argus.yml). The legacy ``containers.keep_raw`` is still read
+    # as a fallback for argus.yml files from before the unified
+    # ``reporting.keep_raw`` shape. CLI ``--no-keep-raw`` explicitly
+    # overrides a config-file opt-in. ``args.keep_raw`` is tri-state:
+    # True / False / None (not specified).
     keep_raw_config = config.get(
-        "_reporting_keep_raw", config.get("keep_raw", True),
+        "_reporting_keep_raw", config.get("keep_raw", False),
     )
-    keep_raw = bool(keep_raw_config) and not getattr(args, "no_keep_raw", False)
+    cli_keep_raw = getattr(args, "keep_raw", None)
+    keep_raw = cli_keep_raw if cli_keep_raw is not None else bool(keep_raw_config)
     if keep_raw:
         config["_raw_output_root"] = str(Path(output_dir) / "raw")
 

--- a/argus/cli.py
+++ b/argus/cli.py
@@ -1003,7 +1003,17 @@ def cmd_classify(args: argparse.Namespace) -> int:
         result = classifier.classify_all_changes(iac_analysis)
         classifications = result.get("classifications", [])
     except Exception as exc:
-        print(f"Error: classification failed: {exc}", file=sys.stderr)
+        # GitDiffError (git command failed — unknown ref, not a repo,
+        # etc.) must NOT be confused with "git diff produced 0 changed
+        # files". The pre-1.0.2 path silently returned ``EXIT_SUCCESS``
+        # whenever git diff blew up, which made every CI gate built
+        # around classify trivially pass on repos missing the base
+        # ref. Issue #168-J.
+        from argus.scn.diff import GitDiffError
+        if isinstance(exc, GitDiffError):
+            print(f"Error: classify could not run git diff: {exc}", file=sys.stderr)
+        else:
+            print(f"Error: classification failed: {exc}", file=sys.stderr)
         return EXIT_ERROR
 
     # Count categories

--- a/argus/collect/collector.py
+++ b/argus/collect/collector.py
@@ -68,7 +68,26 @@ def collect_results(
     # Discover scanner result directories
     scanner_dirs = _discover_scanner_dirs(input_path)
     if not scanner_dirs:
-        logger.warning("No scanner result directories found in %s", input_path)
+        # ``argus collect`` is for the CI-matrix layout where each
+        # scanner writes to its own ``argus-results-<scanner>/`` dir
+        # before they're merged. If the input looks like a local
+        # ``argus-results/`` (timestamped per-run subdirs + a
+        # ``latest`` symlink), say so explicitly instead of just
+        # "no result dirs found" — issue #168-L.
+        if any(
+            child.is_dir() and (child / "argus-results.json").exists()
+            for child in input_path.iterdir()
+        ) or (input_path / "latest").is_symlink():
+            logger.warning(
+                "%s looks like a local-layout argus-results/ directory "
+                "(per-run timestamped subdirs). `argus collect` expects "
+                "CI-matrix layout (argus-results-<scanner>/) — point "
+                "it at the artifact root from your CI matrix run, or "
+                "use `argus report` against an individual run dir.",
+                input_path,
+            )
+        else:
+            logger.warning("No scanner result directories found in %s", input_path)
         return output_path
 
     logger.info(
@@ -143,13 +162,37 @@ def _discover_scanner_dirs(input_path: Path) -> list[Path]:
     """Find directories containing argus results.
 
     Matches by convention:
-    1. Directories named argus-results-*
-    2. Any subdirectory containing argus.log or argus-audit.json
+    1. Directories named ``argus-results-{scanner}`` (the CI-matrix
+       artifact layout this command was designed for).
+    2. Any subdirectory containing ``argus.log`` or ``argus-audit.json``
+       (fallback for unconventional naming).
+
+    Skipped:
+    - The ``latest`` symlink — duplicates whatever it points at.
+    - Per-run timestamp dirs (``2026-05-17T01-46-56Z``) — these are
+      local ``argus scan`` output, not per-scanner CI artifacts.
+      Treating them as "scanners" mis-labels every run as if it were
+      a distinct scanner (issue #168-L).
     """
+    import re
+    # ISO-8601-ish timestamps as written by argus' run-dir creator:
+    # ``YYYY-MM-DDTHH-MM-SSZ`` (note the ``-`` separators in the time
+    # portion — Windows can't have ``:`` in filenames).
+    timestamp_re = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}Z$")
+
     dirs: list[Path] = []
 
     for child in input_path.iterdir():
         if not child.is_dir():
+            continue
+
+        # Skip the ``latest`` symlink — it points at a sibling we'll
+        # see directly. Including it double-counts the most recent run.
+        if child.is_symlink() and child.name == "latest":
+            continue
+
+        # Skip per-run timestamp dirs — local layout, not per-scanner.
+        if timestamp_re.match(child.name):
             continue
 
         # Convention: argus-results-{scanner_name}

--- a/argus/containers.py
+++ b/argus/containers.py
@@ -109,10 +109,27 @@ def get_expected_version(scanner_name: str) -> str | None:
 # Scanner → container cache path mappings.
 # Keys are resolved via _ALIASES (same as get_image), values are the
 # absolute path inside the container where the tool stores its DB/cache.
+#
+# Per-scanner notes:
+#   - trivy   (aquasec/trivy:0.70.0)         runs as root; ``/root/.cache/trivy`` is the
+#                                            default DB location. Mount works for ``trivy``
+#                                            (vuln scan); ``trivy-iac`` does not populate
+#                                            the DB so the dir stays empty for that path.
+#   - grype   (anchore/grype:v0.112.0)       runs as root; standard XDG cache dir.
+#   - semgrep (opengrep) — runs as root; cache at ``/root/.semgrep`` (rules + metadata).
+#   - checkov (bridgecrew/checkov:3.2.526)   runs as root; ``/root/.checkov`` mostly
+#                                            holds telemetry / version-check metadata —
+#                                            persistence here is low-value but harmless.
+#
+# Clamav is deliberately NOT listed here. The official ``clamav/clamav`` image runs as
+# the unprivileged ``clamav`` system user, which can't write to a host-owned bind mount
+# at ``/var/lib/clamav`` — freshclam then segfaults with "Can't create freshclam.dat"
+# (issue #168-N). The clamav scanner now writes its DB to ``/tmp/clamav-db`` per-run via
+# ``freshclam --datadir`` (see argus/scanners/clamav.py); there is nothing host-side to
+# cache, so listing clamav here only re-triggered the segfault by re-mounting the bad path.
 CACHE_MOUNTS: dict[str, str] = {
     "trivy": "/root/.cache/trivy",
     "grype": "/root/.cache/grype",
-    "clamav": "/var/lib/clamav",
     "semgrep": "/root/.semgrep",
     "checkov": "/root/.checkov",
 }

--- a/argus/core/config.py
+++ b/argus/core/config.py
@@ -65,11 +65,15 @@ class ReportingConfig:
     # When True, the engine persists each scanner's raw output files
     # (results.json / *.sarif / stdout.txt) under
     # ``<output_dir>/raw/<scanner>/`` alongside the canonical
-    # ``argus-results.json``. Default ON since most users running
-    # ``argus scan`` would expect the artifacts to be available for
-    # forensics or manual triage; opt out via ``--no-keep-raw`` (CLI)
-    # or ``reporting.keep_raw: false`` for tight CI environments.
-    keep_raw: bool = True
+    # ``argus-results.json``. Default OFF because scanners like
+    # ``gitleaks`` write the literal matched secret bytes into their
+    # raw JSON; persisting those by default turned ``argus-results``
+    # into a secret-leak vector. The canonical ``argus-results.json``
+    # is always written and is pattern-redacted, so the common case
+    # (developer + CI) loses nothing. Forensic / triage users who
+    # need raw output opt in with ``--keep-raw`` (CLI) or
+    # ``reporting.keep_raw: true`` (argus.yml).
+    keep_raw: bool = False
 
 
 @dataclass
@@ -268,7 +272,7 @@ def _parse_reporting_config(raw: dict | None) -> ReportingConfig:
         formats=raw.get("formats", ["terminal"]),
         severity_threshold=_parse_severity(raw.get("severity_threshold")),
         output_dir=raw.get("output_dir", "./argus-results"),
-        keep_raw=bool(raw.get("keep_raw", True)),
+        keep_raw=bool(raw.get("keep_raw", False)),
     )
 
 

--- a/argus/core/engine.py
+++ b/argus/core/engine.py
@@ -157,6 +157,13 @@ class ArgusEngine:
         # can consult it from a worker thread without arg-threading every
         # internal call site.
         self._prewarmer = None
+        # Image → failure-category cache for permanent pull failures
+        # (403, image-not-found, daemon-down, network, rate-limited).
+        # When the pre-warm path records a permanent failure here, the
+        # inline ``_pull_image`` short-circuits on its next call so a
+        # single (scanner, run) sequence doesn't pull the same broken
+        # image twice. Issue #168-H followup.
+        self._permanent_pull_failures: dict[str, str] = {}
         # Supply-chain verification results, one per container pull this
         # run. Consumed by ``report_tag_pinned_summary`` at end of
         # ``run()`` to emit a single WARNING listing tag-pinned third-
@@ -736,6 +743,20 @@ class ArgusEngine:
         # GitHub Actions cache action could pre-populate the Docker cache.
         # Also evaluate if pull_policy=if-not-present is effective when runners are ephemeral.
         """
+        # Short-circuit when a previous pull (typically from pre-warm)
+        # already produced a permanent-class failure for this image.
+        # Without this, prewarm + inline both fire on a 403/daemon-down
+        # and double the noisy log volume per scanner run. Issue #168-H
+        # followup.
+        cached_category = self._permanent_pull_failures.get(image)
+        if cached_category is not None:
+            logger.debug(
+                "Skipping pull of %s — earlier attempt failed permanently "
+                "(%s); not retrying.",
+                image, cached_category,
+            )
+            return False
+
         policy = self.config.execution.pull_policy
         logger.debug("Pull policy: %s for image: %s", policy, image)
 
@@ -811,6 +832,9 @@ class ArgusEngine:
                     "stderr: %s",
                     image, elapsed, category, stderr[:300],
                 )
+                # Record so the inline _pull_image won't repeat the
+                # same failure later in the run (issue #168-H followup).
+                self._permanent_pull_failures[image] = category
                 return False
 
         if result.returncode == 0:

--- a/argus/core/engine.py
+++ b/argus/core/engine.py
@@ -26,6 +26,85 @@ SBOM_FORMAT_EXTENSIONS: dict[str, str] = {
 }
 
 
+def _classify_pull_error(stderr: str) -> tuple[str, bool]:
+    """Classify a docker/podman ``pull`` failure for human-readable
+    logging and retry policy.
+
+    Returns ``(category, retryable)`` where ``retryable`` is True only
+    when retrying with ``--platform linux/amd64`` has a realistic
+    chance of fixing the failure. Issue #168-H.
+    """
+    s = stderr.lower()
+
+    # Daemon-down: socket / connection-refused at the local runtime.
+    daemon_markers = (
+        "cannot connect to the docker daemon",
+        "is the docker daemon running",
+        "unix:///var/run/docker.sock",
+        "no such file or directory: docker.sock",
+        "docker api at unix:///",
+    )
+    if any(m in s for m in daemon_markers):
+        return "docker-daemon-not-running", False
+
+    # Auth — 403 / unauthorized / denied. Includes both registry-side
+    # authorization failures and credentials missing locally.
+    auth_markers = (
+        "403 forbidden",
+        "permission_denied",
+        "401 unauthorized",
+        "unauthorized:",
+        "denied: requested access to the resource is denied",
+        "no basic auth credentials",
+    )
+    if any(m in s for m in auth_markers):
+        return "registry-auth-403", False
+
+    # Rate-limit — docker hub etc.
+    if "toomanyrequests" in s or "rate limit" in s:
+        return "registry-rate-limited", False
+
+    # Manifest / image not found at the requested ref. Could be a typo
+    # or a missing tag. Not a platform issue; retrying with amd64 won't
+    # help.
+    not_found_markers = (
+        "manifest unknown",
+        "manifest for ",
+        "not found:",
+        "repository does not exist",
+    )
+    if any(m in s for m in not_found_markers) and "matching manifest" not in s:
+        return "image-not-found", False
+
+    # Platform mismatch — the upstream doesn't publish arm64. THIS is
+    # the case where the --platform linux/amd64 retry is appropriate.
+    platform_markers = (
+        "no matching manifest for linux/arm",
+        "no matching manifest for ",
+        "cannot find amd64 manifest",
+        "image platform",
+    )
+    if any(m in s for m in platform_markers):
+        return "platform-mismatch", True
+
+    # Network — connection refused / timeout reaching the registry.
+    network_markers = (
+        "i/o timeout",
+        "dial tcp",
+        "connection refused",
+        "network is unreachable",
+        "no route to host",
+        "name resolution failed",
+        "temporary failure in name resolution",
+    )
+    if any(m in s for m in network_markers):
+        return "network", False
+
+    # Unclassified — try the amd64 fallback as a last resort but
+    # surface that we don't know what went wrong.
+    return "unclassified", True
+
+
 def _failure_result(
     scanner_name: str,
     exc: BaseException,
@@ -692,25 +771,37 @@ class ArgusEngine:
         elapsed = int((time.monotonic() - start) * 1000)
 
         if result.returncode != 0:
-            # Distinct from a hard "pull failed" — the retry below
-            # almost always succeeds for upstreams that publish amd64-
-            # only (clamav, etc.). Word it as a fallback so users
-            # reading the log don't misread the line as a scan failure.
-            logger.info(
-                "%s: native pull unsuccessful (%dms) — auto-falling "
-                "back to --platform linux/amd64 (common for upstreams "
-                "without arm64 builds). stderr: %s",
-                image,
-                elapsed,
-                result.stderr.strip()[:200],
-            )
-            start = time.monotonic()
-            result = subprocess.run(
-                [self._runtime, "pull", "--platform", "linux/amd64", image],
-                capture_output=True,
-                text=True,
-            )
-            elapsed = int((time.monotonic() - start) * 1000)
+            # Classify the failure so we only do the ``--platform
+            # linux/amd64`` retry when the underlying error actually
+            # looks like a platform mismatch. Issue #168-H: previously
+            # every failure (daemon down, GHCR 403, network blocked)
+            # surfaced as "auto-falling back to --platform linux/amd64
+            # (common for upstreams without arm64 builds)" which was
+            # misleading and produced wasted retry attempts on
+            # permanently-failing pulls.
+            stderr = result.stderr.strip()
+            category, retryable = _classify_pull_error(stderr)
+            if retryable:
+                logger.info(
+                    "%s: native pull failed (%dms, %s) — retrying with "
+                    "--platform linux/amd64 (common for upstreams "
+                    "without arm64 builds). stderr: %s",
+                    image, elapsed, category, stderr[:200],
+                )
+                start = time.monotonic()
+                result = subprocess.run(
+                    [self._runtime, "pull", "--platform", "linux/amd64", image],
+                    capture_output=True,
+                    text=True,
+                )
+                elapsed = int((time.monotonic() - start) * 1000)
+            else:
+                logger.error(
+                    "%s: pull failed (%dms, %s) — not retrying. "
+                    "stderr: %s",
+                    image, elapsed, category, stderr[:300],
+                )
+                return False
 
         if result.returncode == 0:
             digest = self._get_image_digest(image)

--- a/argus/core/engine.py
+++ b/argus/core/engine.py
@@ -26,6 +26,16 @@ SBOM_FORMAT_EXTENSIONS: dict[str, str] = {
 }
 
 
+class ScannerPreconditionError(RuntimeError):
+    """Raised when a scanner can't run because its inputs are missing or
+    invalid — e.g. ``grype`` / ``trivy`` need an SBOM via ``--sbom``.
+
+    The engine treats this distinctly from a runtime/container failure:
+    no local fallback dance, no platform-mismatch retry, just surface the
+    precondition to the user. Issue #168-I.
+    """
+
+
 def _classify_pull_error(stderr: str) -> tuple[str, bool]:
     """Classify a docker/podman ``pull`` failure for human-readable
     logging and retry policy.
@@ -1347,6 +1357,17 @@ class ArgusEngine:
                 )
                 try:
                     return self._run_in_container(scanner, path, config)
+                except ScannerPreconditionError as exc:
+                    # The scanner's inputs are missing/invalid — no
+                    # amount of fallback will help. Surface clearly and
+                    # mark execution_failed so CI gating treats it as
+                    # "didn't run" rather than "passed with 0 findings"
+                    # (issue #168-I).
+                    logger.error(
+                        "Scanner '%s' precondition unmet: %s",
+                        scanner.name, exc,
+                    )
+                    return _failure_result(scanner.name, exc)
                 except RuntimeError as exc:
                     if backend == "docker":
                         raise

--- a/argus/core/exclusions.py
+++ b/argus/core/exclusions.py
@@ -20,7 +20,15 @@ _IGNORE_FILES = [
     ".gitleaksignore",
 ]
 
-# Paths always excluded (build artifacts, dependencies, caches)
+# Paths always excluded (build artifacts, dependencies, caches).
+#
+# ``argus-results`` is included because repeated scans otherwise
+# snowball-detect their own prior raw output (e.g. checkov flagging
+# ``argus-results/<ts>/raw/gitleaks/results.json`` for Base64 high
+# entropy strings on every subsequent run). Even with raw-output
+# persistence flipped off by default, users who opt in with
+# ``--keep-raw`` should not see their own forensic artifacts surface
+# as findings.
 _BUILTIN_EXCLUDES = [
     "node_modules",
     ".git",
@@ -36,6 +44,7 @@ _BUILTIN_EXCLUDES = [
     "*.egg-info",
     "dist",
     "build",
+    "argus-results",
 ]
 
 

--- a/argus/core/models.py
+++ b/argus/core/models.py
@@ -296,6 +296,12 @@ class ScanSummary:
     # viewer reading two files into memory) so the viewer can fall
     # back to its existing heuristic resolution.
     scan_context: Optional[ScanContext] = None
+    # True when the user passed --fail-on-scanner-error (or
+    # ``reporting.fail_on_scanner_error: true`` in argus.yml). Set by
+    # the CLI dispatcher before any reporter runs; lets reporters
+    # suppress "pass --fail-on-scanner-error to fail the scan when
+    # this happens" advice when the flag is already on (issue #168-D).
+    fail_on_scanner_error_set: bool = False
 
     @property
     def critical_count(self) -> int:

--- a/argus/core/schema.py
+++ b/argus/core/schema.py
@@ -23,7 +23,36 @@ logger = logging.getLogger("argus")
 _SEVERITY_VALUES = {"critical", "high", "medium", "low", "none"}
 _BACKEND_VALUES = {"auto", "local", "docker"}
 _PULL_POLICY_VALUES = {"always", "if-not-present", "never"}
-_FORMAT_VALUES = {"terminal", "markdown", "sarif", "json"}
+
+
+def _get_format_values() -> set[str]:
+    """Resolve the valid ``reporting.formats`` values from the reporter
+    registry at call time. This stays in lock-step with whatever
+    reporters are registered (built-ins + ``argus.reporters``
+    entry-point plugins) so the validator can't reject a format the
+    CLI's ``--format`` flag would happily accept. Import is deferred
+    to avoid an import-time cycle (schema is a core module imported
+    early; reporters depend on optional packages for some entries)."""
+    try:
+        from argus.reporters import available_reporters
+        return set(available_reporters())
+    except Exception:  # pragma: no cover — defensive
+        return {"terminal", "markdown", "sarif", "json"}
+
+
+def _get_scanner_names() -> set[str]:
+    """Resolve the set of known scanner / linter names from
+    ``SCANNER_REGISTRY``. Used to reject unknown scanner names in
+    ``argus.yml`` up-front rather than silently accepting them with
+    only a downstream warning about unknown keys (issue #168-F).
+    Returns the empty set on import failure so validation degrades
+    rather than panics in environments where ``argus.scanners``
+    can't load."""
+    try:
+        from argus.scanners import SCANNER_REGISTRY
+        return set(SCANNER_REGISTRY.keys())
+    except Exception:  # pragma: no cover — defensive
+        return set()
 
 # Known top-level keys
 _TOP_LEVEL_KEYS = {
@@ -145,7 +174,19 @@ def validate_config(data: dict) -> list[ConfigError]:
         if not isinstance(scanners, dict):
             errors.append(ConfigError("scanners", "Must be a mapping of scanner names to config"))
         else:
+            known_scanners = _get_scanner_names()
             for name, scanner_data in scanners.items():
+                # Reject unknown scanner names up-front instead of silently
+                # accepting them with a downstream warning about unknown keys
+                # (issue #168-F). Skip when the registry can't be resolved
+                # so this never bricks validation in degraded environments.
+                if known_scanners and name not in known_scanners:
+                    errors.append(ConfigError(
+                        f"scanners.{name}",
+                        f"Unknown scanner '{name}'. "
+                        f"Available: {', '.join(sorted(known_scanners))}",
+                    ))
+                    continue
                 errors.extend(_validate_scanner(f"scanners.{name}", scanner_data))
 
     # Reporting
@@ -414,12 +455,13 @@ def _validate_reporting(path: str, data: Any) -> list[ConfigError]:
         if not isinstance(formats, list):
             errors.append(ConfigError(f"{path}.formats", "Must be a list"))
         else:
+            valid_formats = _get_format_values()
             for i, fmt in enumerate(formats):
-                if fmt not in _FORMAT_VALUES:
+                if fmt not in valid_formats:
                     errors.append(ConfigError(
                         f"{path}.formats[{i}]",
                         f"Invalid format '{fmt}'. "
-                        f"Must be one of: {', '.join(sorted(_FORMAT_VALUES))}",
+                        f"Must be one of: {', '.join(sorted(valid_formats))}",
                     ))
 
     # Severity threshold

--- a/argus/init.py
+++ b/argus/init.py
@@ -254,6 +254,12 @@ def detect_project(root: Path) -> dict[str, list[str]]:
 def generate_config(signals: dict[str, list[str]]) -> str:
     """Generate argus.yml content based on detected signals."""
     lines = [
+        # The schema URL is longer than yamllint's default 80-char
+        # cap and can't be shortened (it's the pinned raw.github
+        # path). Suppress the rule on just this line so the
+        # generated argus.yml passes its own ``lint-yaml`` check
+        # (issue #168-I).
+        "# yamllint disable-line rule:line-length",
         f"# yaml-language-server: $schema={_SCHEMA_URL}",
         "# Argus Security Scanner Configuration",
         f"# Docs: {_DOCS_URL}",

--- a/argus/init.py
+++ b/argus/init.py
@@ -27,8 +27,12 @@ def _load_banner() -> str:
 _BANNER = _load_banner()
 
 
-# Schema URL version is managed by release-it during releases
-_SCHEMA_VERSION = "0.7.0"
+# Schema URL version is derived from the installed argus version so
+# ``argus init`` always writes a schema pin that matches the wheel the
+# user is running. Previously this was a hardcoded string that release-it
+# never bumped — every 1.0.x install was writing ``0.7.0`` URLs into
+# user argus.yml files (see issue #168-A).
+from argus import __version__ as _SCHEMA_VERSION  # noqa: E402
 _SCHEMA_URL = (
     "https://raw.githubusercontent.com/huntridge-labs/argus/"
     f"{_SCHEMA_VERSION}/argus-config.schema.json"

--- a/argus/mcp.py
+++ b/argus/mcp.py
@@ -13,6 +13,8 @@ from typing import Any
 
 from mcp.server.fastmcp import FastMCP
 
+from argus import __version__ as _ARGUS_VERSION
+
 # A scan older than this is considered stale and should be re-run for
 # accurate posture answers. 24 hours is the default because most code
 # review questions ("is this repo secure?") only need same-day data;
@@ -65,6 +67,15 @@ SCANNER CATEGORIES:
 - linter: Code quality (lint-yaml, lint-json, lint-python, etc.)
 """,
 )
+
+# FastMCP's constructor doesn't expose ``version`` directly, so reach
+# through to the wrapped lowlevel ``mcp.server.lowlevel.Server`` and
+# set it. Without this, the MCP initialize response advertises the
+# FastMCP library version (e.g. "1.27.1") as the server version
+# instead of the argus version — MCP clients using the version to
+# disambiguate compatible argus releases would get the wrong answer
+# (issue #168-O).
+mcp._mcp_server.version = _ARGUS_VERSION
 
 
 # ---------------------------------------------------------------------------

--- a/argus/reporters/gitlab.py
+++ b/argus/reporters/gitlab.py
@@ -86,9 +86,18 @@ class GitLabReporter:
         # filterable without needing to inspect the scanner name.
         category = "Style" if finding.severity == Severity.INFO else "Security"
 
-        description = finding.title
-        if finding.description:
-            description = f"{finding.title}: {finding.description}"
+        # GitLab Code Climate expects a single ``description`` string.
+        # Concatenate title + description ONLY when they carry different
+        # information — many linter rules (yamllint, flake8) ship the
+        # same string for both, and the naive ``f"{title}: {description}"``
+        # produced doubled output like ``"line too long ...: line too long ..."``
+        # (issue #168-G).
+        title = finding.title or ""
+        desc = (finding.description or "").strip()
+        if desc and desc != title and desc not in title and title not in desc:
+            description = f"{title}: {desc}"
+        else:
+            description = desc or title
 
         return {
             "description": description,

--- a/argus/reporters/junit.py
+++ b/argus/reporters/junit.py
@@ -167,12 +167,26 @@ class JUnitReporter:
         return suite, tests, failures, errors
 
     def _append_failure(self, case: ET.Element, finding: Finding) -> None:
-        """Attach a <failure> element describing a single finding."""
+        """Attach a <failure> element describing a single finding.
+
+        The ``type`` attribute follows the JUnit convention of an
+        exception-class-shaped identifier — most consumers (Jenkins,
+        GitLab MR widget, Azure DevOps test results) treat it as a
+        grouping key and ignore values that look like prose
+        (``"high"``, ``"critical"``). Encode the rule identifier
+        there instead and surface severity as a separate property,
+        which test reporters group on by convention. See issue #168-G.
+        """
+        # ``type`` follows the exception-class convention — use the rule
+        # ID so consumers can group failures by check. The severity is
+        # tucked into the message prefix so dashboards that render
+        # ``message`` see it without parsing extra elements; the body
+        # below carries the full finding context.
         failure = ET.SubElement(
             case,
             "failure",
-            type=finding.severity.value,
-            message=f"[{finding.id}] {finding.title}",
+            type=finding.id or "finding",
+            message=f"[{finding.severity.value.upper()}] {finding.title}",
         )
         body_lines = [f"{finding.id}: {finding.title}"]
         if finding.location:

--- a/argus/reporters/markdown.py
+++ b/argus/reporters/markdown.py
@@ -68,6 +68,10 @@ class MarkdownReporter:
             f"| {_SEVERITY_EMOJI[Severity.LOW]} Low "
             f"| {summary.low_count} |"
         )
+        lines.append(
+            f"| {_SEVERITY_EMOJI[Severity.INFO]} Info "
+            f"| {summary.info_count} |"
+        )
         lines.append(f"| **Total** | **{summary.total_count}** |")
         lines.append("")
 

--- a/argus/reporters/terminal.py
+++ b/argus/reporters/terminal.py
@@ -129,10 +129,14 @@ class TerminalReporter:
                     "execution_failure_reason", "no reason recorded",
                 )
                 print(f"  - {r.scanner}: {reason}")
-            print(
-                "  Pass --fail-on-scanner-error to fail the scan when "
-                "this happens."
-            )
+            # Suppress the advice prompt when --fail-on-scanner-error is
+            # already on — the user has already made the choice and is
+            # about to see a non-zero exit (issue #168-D).
+            if not summary.fail_on_scanner_error_set:
+                print(
+                    "  Pass --fail-on-scanner-error to fail the scan when "
+                    "this happens."
+                )
 
         if parse_failed:
             print(

--- a/argus/scanners/clamav.py
+++ b/argus/scanners/clamav.py
@@ -28,15 +28,29 @@ class ClamavScanner:
     def container_args(self, config: dict | None = None) -> list[str]:
         """Return CLI args for running ClamAV in a container.
 
-        NOTE: The clamav/clamav:1.4 image ships with bundled virus
+        NOTE: The clamav/clamav:1.5 image ships with bundled virus
         definitions but does NOT auto-run freshclam when the entrypoint
         is overridden.  We prepend ``freshclam`` to ensure the DB is
         current before scanning (~60s on first run, cached thereafter).
         The engine passes these args after ``--entrypoint /bin/sh``.
+
+        freshclam writes its state file (``freshclam.dat``) and the
+        downloaded DBs to ``--datadir`` instead of the default
+        ``/var/lib/clamav``. The bind-mounted host directory for that
+        path is owned by the calling user, but the container's
+        ``clamav`` system user lacks write access — freshclam then
+        segfaults with ``Can't create freshclam.dat in /var/lib/clamav``
+        (issue #168-N). Redirecting to a tmpfs-style ``/tmp`` path
+        sidesteps the permissions problem; the DB is re-downloaded on
+        every run as the trade-off.
         """
         return [
             "-c",
-            "freshclam --quiet && clamscan --recursive /workspace",
+            (
+                "mkdir -p /tmp/clamav-db && "
+                "freshclam --datadir /tmp/clamav-db --quiet && "
+                "clamscan --database /tmp/clamav-db --recursive /workspace"
+            ),
         ]
 
     def scan(self, path: str, config: dict | None = None) -> ScanResult:

--- a/argus/scanners/grype.py
+++ b/argus/scanners/grype.py
@@ -43,7 +43,8 @@ class GrypeScanner:
         config = config or {}
         sbom_path = config.get("sbom_path")
         if not sbom_path:
-            raise RuntimeError(
+            from argus.core.engine import ScannerPreconditionError
+            raise ScannerPreconditionError(
                 "grype scanner requires sbom_path (run via `argus scan --sbom <path>`)"
             )
         mount = config.get("sbom_mount_path") or f"/workspace/{Path(sbom_path).name}"
@@ -58,9 +59,16 @@ class GrypeScanner:
         config = config or {}
         sbom_path = config.get("sbom_path")
         if not sbom_path:
-            return ScanResult(
-                scanner=self.name,
-                metadata={"error": "grype requires sbom_path"},
+            # Issue #168-I: raise ScannerPreconditionError instead of
+            # returning a silently-passed result with only an ``error``
+            # metadata key. The engine surfaces this distinctly and
+            # marks the scanner ``execution_failed`` so CI gating treats
+            # "couldn't run for lack of input" the same as "couldn't run
+            # because it crashed" — both block the scan rather than
+            # being recorded as a passed clean run.
+            from argus.core.engine import ScannerPreconditionError
+            raise ScannerPreconditionError(
+                "grype scanner requires sbom_path (run via `argus scan --sbom <path>`)"
             )
 
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/argus/scanners/trivy.py
+++ b/argus/scanners/trivy.py
@@ -41,7 +41,8 @@ class TrivyScanner:
         config = config or {}
         sbom_path = config.get("sbom_path")
         if not sbom_path:
-            raise RuntimeError(
+            from argus.core.engine import ScannerPreconditionError
+            raise ScannerPreconditionError(
                 "trivy scanner requires sbom_path (run via `argus scan --sbom <path>`)"
             )
         mount = config.get("sbom_mount_path") or f"/workspace/{Path(sbom_path).name}"
@@ -57,9 +58,12 @@ class TrivyScanner:
         config = config or {}
         sbom_path = config.get("sbom_path")
         if not sbom_path:
-            return ScanResult(
-                scanner=self.name,
-                metadata={"error": "trivy requires sbom_path"},
+            # Issue #168-I — see grype.scan() for the rationale; raise
+            # so the engine treats this as a real "didn't run" failure
+            # rather than recording a silently-passed clean result.
+            from argus.core.engine import ScannerPreconditionError
+            raise ScannerPreconditionError(
+                "trivy scanner requires sbom_path (run via `argus scan --sbom <path>`)"
             )
 
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/argus/scn/diff.py
+++ b/argus/scn/diff.py
@@ -283,6 +283,13 @@ def parse_github_actions_diff(file_path: str, diff_content: str) -> Dict:
 # IaC Change Analyzer (ported from analyze_iac_changes.py)
 # ---------------------------------------------------------------------------
 
+class GitDiffError(RuntimeError):
+    """Raised when the underlying ``git diff`` command itself failed
+    (unknown ref, broken repo, git not on PATH). Callers should treat
+    this as a fatal classification failure rather than "0 changes
+    detected" — issue #168-J."""
+
+
 class IaCChangeAnalyzer:
     """Analyzes git diffs for IaC changes."""
 
@@ -313,7 +320,15 @@ class IaCChangeAnalyzer:
         self.head_ref = head_ref
 
     def get_changed_files(self) -> List[str]:
-        """Get list of changed files between refs."""
+        """Get list of changed files between refs.
+
+        Raises ``GitDiffError`` on failure so callers can distinguish
+        "diff command failed" from "diff produced zero changed files".
+        Returning ``[]`` on error (the pre-1.0.2 behavior) made the
+        ``argus classify`` CLI exit 0 when the underlying git command
+        couldn't run (e.g. unknown ref ``main``), silently passing any
+        CI gate built around the classifier (issue #168-J).
+        """
         try:
             result = subprocess.run(
                 ['git', 'diff', '--name-only', self.base_ref, self.head_ref],
@@ -323,9 +338,10 @@ class IaCChangeAnalyzer:
             )
             return [f.strip() for f in result.stdout.splitlines() if f.strip()]
         except subprocess.CalledProcessError as e:
-            print(f"Error getting changed files: {e}", file=sys.stderr)
-            print(f"  stderr: {e.stderr}", file=sys.stderr)
-            return []
+            raise GitDiffError(
+                f"git diff {self.base_ref}..{self.head_ref} failed "
+                f"(exit {e.returncode}): {e.stderr.strip()}"
+            ) from e
 
     def get_file_diff(self, file_path: str) -> Optional[str]:
         """Get diff content for a specific file."""

--- a/argus/tests/core/test_schema_scanners.py
+++ b/argus/tests/core/test_schema_scanners.py
@@ -183,3 +183,36 @@ class TestContainerCredentialParity:
             "registry_password": "literal-pass",
         }}}
         assert _errors(cfg) == []
+
+
+# --------------------------------------------------------------------- #
+# Registry-driven validation — issue #168-F                              #
+# --------------------------------------------------------------------- #
+
+
+class TestUnknownScannerName:
+    """Unknown scanner names should be rejected at validate time rather
+    than silently accepted with only a downstream 'unknown keys' warning."""
+
+    def test_unknown_scanner_errors(self):
+        errs = _errors({"scanners": {"definitely-not-a-scanner": {"enabled": True}}})
+        assert _has_at(errs, "scanners.definitely-not-a-scanner", "Unknown scanner")
+
+    def test_known_scanner_passes(self):
+        # bandit is in the SCANNER_REGISTRY built-ins.
+        assert _errors({"scanners": {"bandit": {"enabled": True}}}) == []
+
+
+class TestReporterRegistrySync:
+    """``reporting.formats`` accepts everything registered under the
+    ``argus.reporters`` group, not just the four-format hardcoded set
+    the validator used pre-1.0.2."""
+
+    def test_github_gitlab_junit_accepted(self):
+        cfg = {"reporting": {"formats": ["github", "gitlab", "junit"]}}
+        assert _errors(cfg) == []
+
+    def test_unknown_format_still_errors(self):
+        cfg = {"reporting": {"formats": ["nonsense"]}}
+        errs = _errors(cfg)
+        assert _has_at(errs, "reporting.formats[0]", "Invalid format")

--- a/argus/tests/reporters/test_gitlab.py
+++ b/argus/tests/reporters/test_gitlab.py
@@ -74,6 +74,22 @@ class TestGitLabReporterEntries:
         data = _read(GitLabReporter().report(summary, tmp_output_dir))
         assert data[0]["description"] == "just a title"
 
+    def test_duplicate_title_and_description_not_concatenated(self, tmp_output_dir):
+        """Many linter rules (yamllint, flake8) ship the same string for
+        both title and description. The naive ``f"{title}: {description}"``
+        produced doubled output like ``"line too long ...: line too long ..."``.
+        See issue #168-G."""
+        same = "line too long (117 > 80 characters) (line-length)"
+        finding = Finding(
+            id="line-length", severity=Severity.INFO,
+            title=same, description=same, location="argus.yml:1",
+        )
+        summary = ScanSummary(results=[ScanResult(scanner="lint-yaml", findings=[finding])])
+        data = _read(GitLabReporter().report(summary, tmp_output_dir))
+        # Title-and-description-identical case → no concatenation.
+        assert data[0]["description"] == same
+        assert data[0]["description"].count(same) == 1
+
     def test_finding_without_location_uses_empty_path_and_zero_line(self, tmp_output_dir):
         finding = Finding(id="X", severity=Severity.HIGH, title="t")
         summary = ScanSummary(results=[ScanResult(scanner="s", findings=[finding])])

--- a/argus/tests/reporters/test_junit.py
+++ b/argus/tests/reporters/test_junit.py
@@ -99,8 +99,12 @@ class TestJUnitReporterFindings:
         assert case.get("name") == "app.py"
         failure = case.find("failure")
         assert failure is not None
-        assert failure.get("type") == "high"
-        assert "B102" in failure.get("message")
+        # ``type`` is the rule id (exception-class-shaped per JUnit
+        # convention); severity rides on the message prefix so
+        # dashboards that group on ``type`` get sensible buckets
+        # (issue #168-G).
+        assert failure.get("type") == "B102"
+        assert "[HIGH]" in failure.get("message")
         assert "dangerous call" in failure.text
 
     def test_findings_grouped_by_file(self, tmp_output_dir):
@@ -130,17 +134,22 @@ class TestJUnitReporterFindings:
         assert case.get("name") == "<unknown>"
         assert case.find("failure") is not None
 
-    def test_failure_type_uses_severity_value(self, tmp_output_dir):
+    def test_failure_type_is_rule_id_severity_in_message(self, tmp_output_dir):
+        """JUnit consumers (Jenkins, GitLab MR widget, Azure DevOps)
+        treat ``failure[type]`` as an exception-class grouping key and
+        ignore prose values like ``"high"``. Use the rule id there and
+        surface severity on the message prefix instead. Issue #168-G."""
         findings = [
             Finding(id="A", severity=Severity.CRITICAL, title="c", location="a.py:1"),
             Finding(id="B", severity=Severity.LOW, title="l", location="b.py:1"),
         ]
         summary = ScanSummary(results=[ScanResult(scanner="s", findings=findings)])
         root = _parse(JUnitReporter().report(summary, tmp_output_dir))
-        types = sorted(
-            f.get("type") for f in root.findall("testsuite/testcase/failure")
-        )
-        assert types == ["critical", "low"]
+        failures = root.findall("testsuite/testcase/failure")
+        types = sorted(f.get("type") for f in failures)
+        messages = sorted(f.get("message") for f in failures)
+        assert types == ["A", "B"]
+        assert messages == ["[CRITICAL] c", "[LOW] l"]
 
 
 class TestJUnitReporterCounts:

--- a/argus/tests/reporters/test_markdown.py
+++ b/argus/tests/reporters/test_markdown.py
@@ -47,8 +47,12 @@ class TestMarkdownReporter:
 
         content = filepath.read_text()
         assert "| Severity | Count |" in content
-        assert "Critical" in content
-        assert "High" in content
+        # All five severity rows must be present so the markdown report
+        # math reconciles with the canonical argus-results.json. The Info
+        # row was previously missing, which made the breakdown sum less
+        # than the printed Total — see issue #168-E.
+        for row in ("Critical", "High", "Medium", "Low", "Info"):
+            assert row in content, f"missing severity row: {row}"
 
     def test_report_contains_findings(self, tmp_output_dir):
         reporter = MarkdownReporter()

--- a/argus/tests/reporters/test_terminal.py
+++ b/argus/tests/reporters/test_terminal.py
@@ -118,6 +118,33 @@ class TestTerminalReporter:
         # separate signal from threshold compliance.
         assert "PASS" in output
 
+    def test_report_suppresses_cta_when_fail_on_scanner_error_set(self, capsys):
+        """When the user has already passed --fail-on-scanner-error, don't
+        advise them to ``Pass --fail-on-scanner-error to fail the scan when
+        this happens`` — they already did. The per-scanner reason rows and
+        the rest of the warning block still render. See issue #168-D."""
+        reporter = TerminalReporter()
+        summary = ScanSummary(
+            results=[
+                ScanResult(
+                    scanner="bandit", findings=[],
+                    metadata={
+                        "execution_failed": True,
+                        "execution_failure_reason": "no output files (exit=13)",
+                    },
+                ),
+            ],
+            severity_threshold=None,
+            fail_on_scanner_error_set=True,
+        )
+        reporter.report(summary)
+        output = capsys.readouterr().out
+
+        assert "did not run cleanly" in output
+        assert "no output files" in output
+        # The CTA prompt is suppressed when the flag is already on.
+        assert "Pass --fail-on-scanner-error" not in output
+
     def test_report_does_not_emit_generic_failure_guesses(self, capsys):
         """Regression: the old reporter printed canned text guessing at
         causes (uid mismatch / crashed / wrong entrypoint). That was

--- a/argus/tests/scanners/test_grype.py
+++ b/argus/tests/scanners/test_grype.py
@@ -83,10 +83,15 @@ class TestGrypeParseResults:
 
 
 class TestGrypeScanNoSbom:
-    def test_scan_without_sbom_returns_error(self):
-        result = GrypeScanner().scan(path=".", config={})
-        assert result.findings == []
-        assert "sbom_path" in result.metadata.get("error", "")
+    def test_scan_without_sbom_raises_precondition_error(self):
+        """Issue #168-I: missing --sbom is a precondition failure, not a
+        silently-passed scan. Raising lets the engine mark the scanner
+        ``execution_failed`` so CI gating treats it as "didn't run"
+        rather than "passed with 0 findings"."""
+        import pytest
+        from argus.core.engine import ScannerPreconditionError
+        with pytest.raises(ScannerPreconditionError, match="sbom_path"):
+            GrypeScanner().scan(path=".", config={})
 
 
 class TestGrypeUnknownSource:

--- a/argus/tests/scanners/test_trivy.py
+++ b/argus/tests/scanners/test_trivy.py
@@ -85,7 +85,12 @@ class TestTrivyParseResults:
 
 
 class TestTrivyScanNoSbom:
-    def test_scan_without_sbom_returns_error(self):
-        result = TrivyScanner().scan(path=".", config={})
-        assert result.findings == []
-        assert "sbom_path" in result.metadata.get("error", "")
+    def test_scan_without_sbom_raises_precondition_error(self):
+        """Issue #168-I: missing --sbom is a precondition failure, not a
+        silently-passed scan. Raising lets the engine mark the scanner
+        ``execution_failed`` so CI gating treats it as "didn't run"
+        rather than "passed with 0 findings"."""
+        import pytest
+        from argus.core.engine import ScannerPreconditionError
+        with pytest.raises(ScannerPreconditionError, match="sbom_path"):
+            TrivyScanner().scan(path=".", config={})

--- a/argus/tests/scn/test_analyze.py
+++ b/argus/tests/scn/test_analyze.py
@@ -74,14 +74,19 @@ class TestIaCChangeAnalyzer:
         assert 'service.yaml' in files
 
     @patch('argus.scn.diff.subprocess.run')
-    def test_get_changed_files_error(self, mock_run, analyzer):
-        """Test handling of git diff error."""
+    def test_get_changed_files_error_raises(self, mock_run, analyzer):
+        """Issue #168-J: a failing ``git diff`` command must raise
+        GitDiffError rather than silently returning ``[]``. Returning an
+        empty list let the ``argus classify`` CLI exit 0 on
+        repos missing the base ref, which trivially passed any CI gate
+        built around the classifier."""
+        import pytest
         from subprocess import CalledProcessError
+        from argus.scn.diff import GitDiffError
         mock_run.side_effect = CalledProcessError(1, 'git', stderr='fatal: bad ref')
 
-        files = analyzer.get_changed_files()
-
-        assert files == []
+        with pytest.raises(GitDiffError, match="fatal: bad ref"):
+            analyzer.get_changed_files()
 
     @patch('argus.scn.diff.subprocess.run')
     def test_get_file_diff_success(self, mock_run, analyzer):

--- a/argus/tests/test_cli.py
+++ b/argus/tests/test_cli.py
@@ -1380,6 +1380,51 @@ class TestViewSubcommand:
         err = capsys.readouterr().err
         assert "argus-security[browser]" in err
 
+    @pytest.mark.parametrize("argv,expected", [
+        # Three orderings the gauntlet (issue #168-D5) called out as the
+        # ones users actually type. With ``--path``, all three resolve
+        # to the same (interface, path) regardless of argparse's
+        # positional-binding-after-flag-with-value quirks across Python
+        # versions.
+        (
+            ["view", "browser", "--no-open", "--port", "18081",
+             "--path", "argus-results/latest"],
+            ("browser", "argus-results/latest"),
+        ),
+        (
+            ["view", "browser", "argus-results/latest",
+             "--no-open", "--port", "18081"],
+            ("browser", "argus-results/latest"),
+        ),
+        (
+            ["view", "--no-open", "--port", "18082",
+             "-i", "browser", "argus-results/latest"],
+            ("browser", "argus-results/latest"),
+        ),
+        # Bare forms — interface alone, path alone, both.
+        (["view"], ("terminal", None)),
+        (["view", "browser"], ("browser", None)),
+        (["view", "./results/"], ("terminal", "./results/")),
+        (["view", "--interface=browser"], ("browser", None)),
+        # --path-only invocation with no positionals.
+        (
+            ["view", "--interface=browser", "--path", "/tmp/scan"],
+            ("browser", "/tmp/scan"),
+        ),
+    ])
+    def test_view_argument_orderings_resolve_uniformly(self, argv, expected):
+        """All sane permutations of ``argus view`` parse and resolve to the
+        same (interface, path). Regression for issue #168-D5: argparse
+        couldn't bind the second positional after a flag-with-value on
+        Python 3.12/3.13, so ``argus view browser --port 18081 <path>``
+        rejected the path as unrecognized. ``--path / -p`` is the
+        argparse-safe escape hatch; the positional form still works
+        when the path precedes flags-with-values."""
+        from argus.cli import _resolve_view_args
+        parser = build_parser()
+        args = parser.parse_args(argv)
+        assert _resolve_view_args(args) == expected
+
 
 class TestLaunchViewAfterScan:
     """Covers the ``--interface`` dispatch extracted from ``cmd_scan``.

--- a/argus/tests/test_config.py
+++ b/argus/tests/test_config.py
@@ -94,6 +94,19 @@ class TestArgusConfigFromDict:
         config = ArgusConfig.from_dict(data)
         assert config.reporting.formats == ["terminal"]
 
+    def test_keep_raw_defaults_off(self):
+        """keep_raw defaults to False because scanners like gitleaks write
+        literal matched secret bytes into raw output, so persisting raw by
+        default leaks data the canonical argus-results.json already
+        pattern-redacts. See issue #168-B."""
+        config = ArgusConfig.from_dict({})
+        assert config.reporting.keep_raw is False
+
+    def test_keep_raw_opt_in_via_config(self):
+        """Forensic / triage workflows opt in via reporting.keep_raw: true."""
+        config = ArgusConfig.from_dict({"reporting": {"keep_raw": True}})
+        assert config.reporting.keep_raw is True
+
 
 class TestArgusConfigLoad:
     """Test ArgusConfig.load from file."""

--- a/argus/tests/test_containers.py
+++ b/argus/tests/test_containers.py
@@ -160,9 +160,28 @@ class TestCacheMounts:
     """Tests for DB cache volume mount logic."""
 
     def test_cache_mounts_has_db_scanners(self):
-        """Scanners with heavy DB downloads should have cache entries."""
-        for scanner in ("trivy", "grype", "clamav", "semgrep"):
+        """Scanners with heavy DB downloads should have cache entries.
+
+        ``clamav`` is deliberately excluded — see
+        ``test_clamav_excluded_from_cache_mounts`` below for rationale.
+        """
+        for scanner in ("trivy", "grype", "semgrep"):
             assert scanner in CACHE_MOUNTS, f"{scanner} missing from CACHE_MOUNTS"
+
+    def test_clamav_excluded_from_cache_mounts(self):
+        """clamav must NOT appear in CACHE_MOUNTS — regression for #168-N.
+
+        The official clamav/clamav image runs as the unprivileged
+        ``clamav`` system user, which can't write to a host-owned bind
+        mount at ``/var/lib/clamav``. With the mount in place,
+        ``freshclam`` segfaulted with "Can't create freshclam.dat" on
+        every container run. The scanner now writes its DB to
+        ``/tmp/clamav-db`` per-run via ``freshclam --datadir`` (see
+        ``argus/scanners/clamav.py``); there's nothing host-side to
+        cache, so listing ``clamav`` here only re-triggered the segfault
+        by re-mounting the bad path.
+        """
+        assert "clamav" not in CACHE_MOUNTS
 
     def test_cache_mounts_values_are_absolute_paths(self):
         for scanner, path in CACHE_MOUNTS.items():
@@ -201,8 +220,11 @@ class TestCacheMounts:
         assert get_cache_mount("nonexistent") is None
 
     def test_get_cache_mount_creates_host_dir(self, tmp_path, monkeypatch):
+        # ``trivy`` chosen as a representative entry; the prior version
+        # used ``clamav`` which is no longer in CACHE_MOUNTS (see
+        # ``test_clamav_excluded_from_cache_mounts``).
         monkeypatch.setenv("ARGUS_CACHE_DIR", str(tmp_path))
-        result = get_cache_mount("clamav")
+        result = get_cache_mount("trivy")
         assert result is not None
         host_dir, _ = result
         assert host_dir.is_dir()

--- a/argus/tests/test_engine.py
+++ b/argus/tests/test_engine.py
@@ -2570,3 +2570,59 @@ class TestPrewarmIntegration:
         ])
         assert prewarm_calls == []
         assert engine._prewarmer is None
+
+
+class TestClassifyPullError:
+    """``_classify_pull_error`` decides which docker pull failures get the
+    ``--platform linux/amd64`` retry. Issue #168-H: previously every
+    failure (daemon down, 403, network blocked, manifest unknown)
+    surfaced as "auto-falling back to --platform linux/amd64" which
+    misled users about the actual cause and wasted compute on permanent
+    failures."""
+
+    def _classify(self, stderr):
+        from argus.core.engine import _classify_pull_error
+        return _classify_pull_error(stderr)
+
+    def test_docker_daemon_down_not_retryable(self):
+        cat, retry = self._classify(
+            "failed to connect to the docker API at unix:///var/run/docker.sock"
+        )
+        assert cat == "docker-daemon-not-running"
+        assert retry is False
+
+    def test_registry_403_not_retryable(self):
+        cat, retry = self._classify(
+            "failed to copy: httpReadSeeker: failed open: unexpected status from GET: 403 Forbidden"
+        )
+        assert cat == "registry-auth-403"
+        assert retry is False
+
+    def test_platform_mismatch_is_retryable(self):
+        cat, retry = self._classify(
+            "no matching manifest for linux/arm64/v8 in the manifest list entries"
+        )
+        assert cat == "platform-mismatch"
+        assert retry is True
+
+    def test_image_not_found_not_retryable(self):
+        cat, retry = self._classify("manifest unknown for tag :nope")
+        assert cat == "image-not-found"
+        assert retry is False
+
+    def test_network_failure_not_retryable(self):
+        cat, retry = self._classify(
+            "dial tcp: lookup ghcr.io: no such host"
+        )
+        assert cat == "network"
+        assert retry is False
+
+    def test_rate_limited_not_retryable(self):
+        cat, retry = self._classify("toomanyrequests: too many requests")
+        assert cat == "registry-rate-limited"
+        assert retry is False
+
+    def test_unclassified_falls_through_to_retry(self):
+        cat, retry = self._classify("some genuinely new error")
+        assert cat == "unclassified"
+        assert retry is True

--- a/argus/tests/test_engine.py
+++ b/argus/tests/test_engine.py
@@ -2626,3 +2626,61 @@ class TestClassifyPullError:
         cat, retry = self._classify("some genuinely new error")
         assert cat == "unclassified"
         assert retry is True
+
+
+class TestPermanentPullFailureCache:
+    """Issue #168-H followup: the inline ``_pull_image`` path must NOT
+    re-attempt a pull that the pre-warm path already classified as a
+    permanent failure (403, image-not-found, daemon-down, network,
+    rate-limited). Pre-fix, prewarm + inline both fired and doubled the
+    noisy log volume on every permanent failure."""
+
+    def _engine_with_runtime(self, runtime: str = "docker"):
+        from unittest.mock import patch
+        from argus.core.config import ArgusConfig
+        from argus.core.engine import ArgusEngine
+        # ``_runtime`` is a property; patch the descriptor.
+        cfg = ArgusConfig.from_dict({})
+        patcher = patch.object(ArgusEngine, "_runtime", new_callable=lambda: runtime)
+        patcher.start()
+        return ArgusEngine(cfg), patcher
+
+    def test_permanent_403_skips_second_pull(self):
+        from unittest.mock import patch, MagicMock
+        engine, patcher = self._engine_with_runtime()
+        try:
+            fake = MagicMock(
+                returncode=1,
+                stderr="unexpected status from GET: 403 Forbidden",
+            )
+            with patch("argus.core.engine.subprocess.run", return_value=fake) as run:
+                # First call records the permanent failure.
+                assert engine._pull_image("ghcr.io/test/img:1") is False
+                first = run.call_count
+                # Second call short-circuits before subprocess.run.
+                assert engine._pull_image("ghcr.io/test/img:1") is False
+                assert run.call_count == first, (
+                    "permanent failure was retried; "
+                    f"expected {first} subprocess calls, got {run.call_count}"
+                )
+            assert (
+                engine._permanent_pull_failures["ghcr.io/test/img:1"]
+                == "registry-auth-403"
+            )
+        finally:
+            patcher.stop()
+
+    def test_unclassified_failures_still_retry(self):
+        """The cache ONLY suppresses repeat attempts for permanent
+        categories. Unclassified failures still go through the
+        --platform amd64 retry path as before."""
+        from unittest.mock import patch, MagicMock
+        engine, patcher = self._engine_with_runtime()
+        try:
+            fake_fail = MagicMock(returncode=1, stderr="weird new error")
+            with patch("argus.core.engine.subprocess.run", return_value=fake_fail):
+                engine._pull_image("ghcr.io/test/img:1")
+            # Unclassified failures are retryable → NOT cached.
+            assert "ghcr.io/test/img:1" not in engine._permanent_pull_failures
+        finally:
+            patcher.stop()

--- a/argus/tests/test_exclusions.py
+++ b/argus/tests/test_exclusions.py
@@ -22,6 +22,13 @@ class TestBuildExclusionSet:
         for builtin in ["node_modules", ".git", "__pycache__", ".venv"]:
             assert builtin in patterns
 
+    def test_argus_results_excluded_by_default(self):
+        """argus-results contains raw scanner output that repeated scans
+        would otherwise snowball-detect as findings (e.g. checkov flagging
+        the gitleaks raw JSON on every subsequent run). See issue #168-C."""
+        patterns = build_exclusion_set(scan_path="/nonexistent")
+        assert "argus-results" in patterns
+
     def test_adds_cli_excludes(self):
         patterns = build_exclusion_set(
             scan_path="/nonexistent",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -106,7 +106,7 @@ argus scan [-h] [--path PATH] [--config CONFIG]
 | `--no-spinner` | Disable animated spinner output | `false` |
 | `--no-update-check` | Skip the once-per-day check for a newer argus release. The check runs in the background during the scan (zero latency cost) and prints a soft notice at the end of the command when an upgrade is available. Also disabled by setting the ARGUS_NO_UPDATE_CHECK environment variable, which is the right move for CI / air-gapped environments. Override the PyPI URL via ARGUS_UPDATE_CHECK_URL for TestPyPI or private mirrors. | `false` |
 | `--no-timestamp` | Write output directly to --output-dir without a timestamped subdirectory. Useful in CI where a predictable output path is needed. | `false` |
-| `--output-vars` | Write scan result counts as key=value pairs to FILE. Useful in CI: cat FILE >> $GITHUB_OUTPUT. Keys: critical_count, high_count, medium_count, low_count, total_count, passed. |  |
+| `--output-vars` | Write scan result counts as key=value pairs to FILE. Useful in CI: cat FILE >> $GITHUB_OUTPUT. Keys: critical_count, high_count, medium_count, low_count, info_count, total_count, passed. |  |
 | `--exclude`, `-e` | Comma-separated paths or patterns to exclude from scanning. Added on top of .gitignore, .dockerignore, and built-in defaults. | `` |
 | `--no-default-excludes` | Drop built-in exclusions (node_modules, .git, ...) and .gitignore / .dockerignore patterns. Only --exclude and argus.yml exclude: take effect. Use when you explicitly want to scan what the defaults would normally skip. | `false` |
 | `--dry-run` | Resolve config and print the planned scanner invocations without executing them. Useful for verifying which per-scanner config files, paths, and excludes Argus will use. | `false` |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -261,7 +261,7 @@ argus mcp [-h]
 Generate a shell completion script for argus.
 
 Once installed, pressing <Tab> will complete:
-  - subcommands (scan, list, view, cache, ...)
+  - subcommands (scan, view, report, classify, cache, ...)
   - scanner and linter names (bandit, gitleaks, lint-yaml, ...)
   - common flags (--config, --scanners, --severity, ...)
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -319,8 +319,8 @@ Install:
   pip install 'argus-security[browser]'       # browser interface
 
 ```
-argus view [-h] [--interface {terminal,browser}] [--port PORT]
-                  [--no-open] [--check]
+argus view [-h] [--path PATH] [--interface {terminal,browser}]
+                  [--port PORT] [--no-open] [--check]
                   [INTERFACE|PATH] [PATH]
 ```
 
@@ -333,6 +333,7 @@ argus view [-h] [--interface {terminal,browser}] [--port PORT]
 
 | Flag | Description | Default |
 |------|-------------|---------|
+| `--path`, `-p` | Results directory or argus-results.json path. Equivalent to the positional form ``argus view <iface> <path>`` but robust to argparse's ordering quirks — use this when a flag-with-value (e.g. ``--port``) sits between the interface keyword and the path (issue #168-D5). |  |
 | `--interface`, `-i` | Interface to open: terminal \| browser (alternative to positional) (terminal, browser) |  |
 | `--port` | TCP port for the browser interface (default: 8080) | `8080` |
 | `--no-open` | Don't auto-open the default web browser after startup (browser interface only). By default, the browser opens when stdout is a TTY; CI and other non-interactive contexts already skip auto-open without this flag. | `false` |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,6 +1,6 @@
-# Argus CLI Reference (v1.0.0)
+# Argus CLI Reference (v1.0.1)
 
-> Auto-generated from argparse definitions on 2026-05-16.
+> Auto-generated from argparse definitions on 2026-05-17.
 > Do not edit manually — run `python -m scripts.ci.gen_cli_docs` to regenerate.
 
 Argus Security Scanner — comprehensive security scanning for your codebase
@@ -77,7 +77,7 @@ argus scan [-h] [--path PATH] [--config CONFIG]
                   [--sbom PATH] [--interface {terminal,browser}] [--fail-fast]
                   [--fail-on-scanner-error] [--timeout SECONDS]
                   [--no-parallel] [--allow-local-versions] [--no-cache]
-                  [--no-keep-raw] [--registry-password-stdin]
+                  [--keep-raw | --no-keep-raw] [--registry-password-stdin]
                   [--zap-auth-password-stdin] [--discover [PATH]]
                   [--image REF] [--scanners SCANNERS] [--target URL]
                   [--port PORT] [--env KEY=VALUE]
@@ -118,7 +118,7 @@ argus scan [-h] [--path PATH] [--config CONFIG]
 | `--no-parallel` | Run scanners sequentially instead of concurrently. | `false` |
 | `--allow-local-versions` | Allow local tool versions that differ from argus-pinned versions. Use in airgapped environments where tool updates are constrained. | `false` |
 | `--no-cache` | Disable DB cache volume mounts. Forces scanners to re-download vulnerability databases on every container run. | `false` |
-| `--no-keep-raw` | Do not persist raw per-scanner output files alongside the canonical argus-results.json. Source scans normally drop each scanner's results.json / *.sarif / stdout.txt under <output_dir>/raw/<scanner>/; container scans drop trivy-results.json / grype-results.json / syft-sbom.json under <output_dir>/raw/<image>/. Pass --no-keep-raw to skip that step in tight CI environments. The same effect is available via 'reporting.keep_raw: false' in argus.yml. | `false` |
+| `--keep-raw`, `--no-keep-raw` | Persist each scanner's raw output files (results.json / *.sarif / stdout.txt) under <output_dir>/raw/<scanner>/ alongside the canonical argus-results.json. Container scans drop trivy-results.json / grype-results.json / syft-sbom.json under <output_dir>/raw/<image>/. Default OFF — scanners like gitleaks write the literal matched secret bytes into raw output, so persisting raw by default turned argus-results into a secret-leak vector. The canonical argus-results.json is always written and is pattern-redacted. Pass --keep-raw for forensic / triage workflows that need the unredacted per-scanner artifacts. The same effect is available via 'reporting.keep_raw: true' in argus.yml. Use --no-keep-raw to explicitly override a config-file opt-in. |  |
 | `--registry-password-stdin` | Read the private-registry password from stdin and use it for any scanner that needs registry auth (container, zap with app_image_ref). Overrides registry_password / registry_password_env in argus.yml. | `false` |
 | `--zap-auth-password-stdin` | Read the ZAP web-app authentication password from stdin. Overrides scanners.zap.auth.password / password_env in argus.yml. | `false` |
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -34,7 +34,7 @@ If no config file is found, Argus uses default settings.
 Add the JSON Schema directive at the top of your config file for autocompletion and inline validation:
 
 ```yaml
-# yaml-language-server: $schema=https://raw.githubusercontent.com/huntridge-labs/argus/0.7.0/argus-config.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/huntridge-labs/argus/1.0.1/argus-config.schema.json
 version: "1.0"
 ```
 
@@ -512,7 +512,7 @@ Errors are fatal and abort the scan. Warnings are logged but the scan proceeds.
 ## Complete Example
 
 ```yaml
-# yaml-language-server: $schema=https://raw.githubusercontent.com/huntridge-labs/argus/0.7.0/argus-config.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/huntridge-labs/argus/1.0.1/argus-config.schema.json
 version: "1.0"
 
 scanners:

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -325,6 +325,7 @@ Controls how scan results are formatted and where they are written.
 | `formats` | array of strings | `["terminal"]` | Output formats to generate. |
 | `severity_threshold` | [severity](#severity-levels) | `none` | Global severity threshold. Findings at or above this level cause a non-zero exit code. |
 | `output_dir` | string | `"./argus-results"` | Directory for report files (SARIF, JSON, Markdown). |
+| `keep_raw` | boolean | `false` | Persist each scanner's raw output (results.json / *.sarif / stdout.txt) under `<output_dir>/raw/<scanner>/`. Default OFF because scanners like `gitleaks` write literal matched secret bytes into raw output — the canonical `argus-results.json` is always written and is pattern-redacted. Forensic / triage workflows that need unredacted per-scanner artifacts opt in. CLI `--keep-raw` / `--no-keep-raw` overrides this setting. |
 
 ### Report Formats
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -209,7 +209,7 @@ the Rekor transparency log.
 At pull time, argus runs:
 
 ```
-cosign verify ghcr.io/huntridge-labs/argus/scanner-bandit:0.7.0 \
+cosign verify ghcr.io/huntridge-labs/argus/scanner-bandit:1.0.1 \
   --certificate-identity-regexp '^https://github\.com/huntridge-labs/argus/\.github/workflows/release\.yml@' \
   --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
 ```

--- a/scripts/docsite/builder.py
+++ b/scripts/docsite/builder.py
@@ -20,6 +20,91 @@ from .pages import make_action_page, make_workflow_page
 from .parsers import parse_workflow_meta
 
 
+# Acronyms that ``.title()`` mangles ("Cli Reference", "Mcp"). The
+# title-casing pass uppercases anything in this set, otherwise
+# capitalizes (issue #167-4).
+_NAV_ACRONYMS = {
+    "ai", "ci", "cli", "dast", "iac", "json", "mcp", "pr", "sarif",
+    "sast", "sbom", "url", "yaml",
+}
+
+
+def _nav_title(stem: str) -> str:
+    """Convert a markdown filename stem into a nav label.
+
+    Examples:
+        cli-reference     → CLI Reference
+        mcp               → MCP
+        0.6.x-to-1.x      → 0.6.x → 1.x      (arrow for migration names)
+        config-reference  → Config Reference
+    """
+    parts = stem.replace("-", " ").split()
+    out: list[str] = []
+    for p in parts:
+        if p.lower() in _NAV_ACRONYMS:
+            out.append(p.upper())
+        elif any(ch.isdigit() for ch in p) and "." in p:
+            # Version-y tokens like 0.6.x, 1.x — preserve as-is.
+            out.append(p)
+        else:
+            out.append(p.capitalize())
+    title = " ".join(out)
+    # ``X to Y`` → ``X → Y`` for migration page names.
+    title = title.replace(" To ", " → ")
+    return title
+
+
+def _build_guides_nav(extra_pages: dict[str, str]) -> list[dict]:
+    """Build the Guides nav tree, grouping nested directories.
+
+    Top-level guides become flat entries. Files under a subdir (e.g.
+    ``migration/`` or ``troubleshooting/``) get a parent group so the
+    nav doesn't flatten ``migration/0.6.x-to-1.x.md`` into a single
+    lonely ``0.6.x → 1.x`` entry under Guides (issue #167-4).
+    """
+    flat: list[dict] = []
+    groups: dict[str, list[dict]] = {}
+    for rel, target in sorted(extra_pages.items()):
+        parts = Path(rel).parts
+        if len(parts) == 1:
+            flat.append({_nav_title(Path(rel).stem): target})
+        else:
+            subdir = parts[0]
+            groups.setdefault(subdir, []).append(
+                {_nav_title(Path(rel).stem): target}
+            )
+    nav = flat + [
+        {_nav_title(subdir): entries}
+        for subdir, entries in sorted(groups.items())
+    ]
+    return nav
+
+
+def _build_examples_extras_nav(
+    examples_out: Path,
+    skip_subdirs: tuple[str, ...] = ("ci",),
+) -> list[dict]:
+    """Walk the examples output and group orphan pages by their subdir.
+
+    The Examples nav was previously hand-wired to only include the
+    CI-platform pages; every page under examples/configs/,
+    examples/github-enterprise/, examples/workflows/ was reachable only
+    by URL (issue #167-5). This generates a sub-section per directory.
+    """
+    nav: list[dict] = []
+    for sub in sorted(p for p in examples_out.iterdir() if p.is_dir()):
+        if sub.name in skip_subdirs:
+            continue
+        entries: list[dict] = []
+        for md in sorted(sub.glob("*.md")):
+            entries.append({
+                _nav_title(md.stem): f"examples/{sub.name}/{md.name}"
+            })
+        if entries:
+            nav.append({_nav_title(sub.name): entries})
+    return nav
+
+
 # ─── Custom CSS ──────────────────────────────────────────────────────────────
 
 CUSTOM_CSS = """\
@@ -319,6 +404,18 @@ def build(repo_root: Path, output_dir: Path, *, ref: str | None = None) -> None:
             write(docs_out / "guides" / rel, content)
             extra_pages[str(rel)] = f"guides/{rel}"
 
+        # Copy docs/images/ to docs_out/images/ so guide pages can
+        # reference screenshots via the rewritten ``../images/<rest>``
+        # paths emitted by ``_to_docsite_path``. Without this, the TUI
+        # screenshots on view-terminal etc. fell through to GitHub
+        # blob URLs and rendered as broken <img>s (issue #167-1).
+        images_src = existing_docs_dir / "images"
+        if images_src.exists():
+            images_dst = docs_out / "images"
+            if images_dst.exists():
+                shutil.rmtree(images_dst)
+            shutil.copytree(images_src, images_dst)
+
     # ── Actions ──────────────────────────────────────────────────────────
     actions_out = docs_out / "actions"
     write(actions_out / "index.md", make_actions_index(actions_dir, version))
@@ -407,10 +504,7 @@ def build(repo_root: Path, output_dir: Path, *, ref: str | None = None) -> None:
 
     workflows_nav = _build_workflows_nav(workflows_dir)
 
-    guides_nav = [
-        {Path(k).stem.replace("-", " ").title(): v}
-        for k, v in sorted(extra_pages.items())
-    ]
+    guides_nav = _build_guides_nav(extra_pages)
 
     # Argus is a platform-agnostic Python SDK / CLI; CI integration is
     # one of many ways to invoke it, and GitHub Actions is one CI among
@@ -440,11 +534,30 @@ def build(repo_root: Path, output_dir: Path, *, ref: str | None = None) -> None:
         ci_nav: list = [{"GitHub Actions": github_actions_nav}]
         ci_nav.extend(ci_platform_nav_entries)
 
-        examples_nav = [
+        examples_nav: list[dict] = [
             {"Overview": "examples/index.md"},
             {"CI": ci_nav},
         ]
+        # Orphan example pages (configs/, github-enterprise/, workflows/)
+        # — previously reachable only by URL despite being generated
+        # into the site (issue #167-5).
+        examples_nav.extend(_build_examples_extras_nav(examples_out))
         nav.append({"Examples": examples_nav})
+
+    # Top-level policy files (Contributing, Code of Conduct, Security
+    # Policy) are written above as ``contributing.md`` /
+    # ``security.md`` / ``code_of_conduct.md`` but were never linked
+    # from the nav (issue #167-5).
+    about_nav: list[dict] = []
+    for filename, title in (
+        ("contributing.md", "Contributing"),
+        ("code_of_conduct.md", "Code of Conduct"),
+        ("security.md", "Security Policy"),
+    ):
+        if (docs_out / filename).exists():
+            about_nav.append({title: filename})
+    if about_nav:
+        nav.append({"About": about_nav})
 
     nav.append({"Changelog": "changelog.md"})
 

--- a/scripts/docsite/helpers.py
+++ b/scripts/docsite/helpers.py
@@ -43,11 +43,25 @@ def rewrite_repo_links(content: str, source_rel: str) -> str:
 
     Links that point to content hosted on the docsite (guide pages from
     ``docs/`` and action READMEs from ``.github/actions/``) are rewritten to
-    site-relative paths so they stay within the versioned docsite.  All other
+    page-relative paths so they stay within the versioned docsite. All other
     relative links are rewritten to absolute GitHub blob URLs so they still
     resolve.
+
+    The source page's docsite path is computed up-front so docsite-internal
+    links resolve relative to the rendered page's location (not relative to
+    docs_dir root) — without that, a link from ``guides/view-terminal.md``
+    to ``guides/cli-reference.md`` was being interpreted as
+    ``guides/guides/cli-reference.md`` and failing ``mkdocs --strict``.
     """
     source_dir = Path(source_rel).parent
+
+    # Compute the source page's docsite location for relative-link math.
+    # When the source has no docsite mapping (e.g. README.md in repo root)
+    # fall back to root-relative paths.
+    source_docsite = _to_docsite_path(source_rel)
+    source_docsite_dir = (
+        Path(source_docsite).parent if source_docsite else Path(".")
+    )
 
     def _rewrite(m: re.Match) -> str:
         prefix = m.group(1)   # [text](
@@ -75,11 +89,16 @@ def rewrite_repo_links(content: str, source_rel: str) -> str:
                 parts.append(p)
         clean = "/".join(parts)
 
-        # Rewrite links to docsite-hosted content as site-relative paths
-        # so they follow the user's selected version.
+        # Rewrite docsite-hosted targets to a path relative to the
+        # rendered source page. Mkdocs interprets unprefixed paths
+        # relative to the current page's directory, not docs_dir root.
         docsite_path = _to_docsite_path(clean)
         if docsite_path is not None:
-            return f"{prefix}{docsite_path}{anchor}{suffix}"
+            import os.path
+            target_relative = os.path.relpath(
+                docsite_path, start=str(source_docsite_dir),
+            )
+            return f"{prefix}{target_relative}{anchor}{suffix}"
 
         return f"{prefix}{config.GITHUB_BLOB}/{clean}{anchor}{suffix}"
 
@@ -92,19 +111,46 @@ def _to_docsite_path(repo_path: str) -> str | None:
     Returns ``None`` when the path doesn't correspond to a docsite page.
 
     Mappings:
-      ``docs/<name>.md``                    → ``guides/<name>/``
-      ``.github/actions/<name>/README.md``  → ``actions/<name>/``
+      ``docs/<name>.md``                    → ``guides/<name>.md``
+      ``docs/<sub>/<name>.md``              → ``guides/<sub>/<name>.md``
+      ``docs/images/<rest>``                → ``../images/<rest>`` (from guides)
+      ``.github/actions/<name>/README.md``  → ``actions/<name>.md``
+
+    Note: we emit ``.md`` rather than the bare-directory form
+    (``guides/<name>/``) so ``mkdocs build --strict`` can resolve and
+    validate the target. Material renders the same URL either way
+    (issue #167-6).
     """
-    # docs/*.md → guides/*/
+    # docs/images/... — image assets copied into docs_out/images/. Guide
+    # pages reference them as relative paths like ``images/...``; the
+    # rewriter resolves those to ``docs/images/...``. Return the
+    # docsite-root path; ``rewrite_repo_links`` then computes the
+    # correct ``../images/...`` relative to the source page's location
+    # (issue #167-1).
+    images_match = re.match(r'^docs/images/(.+)$', repo_path)
+    if images_match:
+        return f"images/{images_match.group(1)}"
+
+    # docs/<sub>/<name>.md → guides/<sub>/<name>.md (preserves nesting
+    # for ``migration/`` and ``troubleshooting/`` sub-trees). When the
+    # subdirectory is in ``EXCLUDED_GUIDE_DIRS`` (e.g. ``developer/``
+    # — internal-only pages that don't ship to the docsite), fall
+    # through so the rewriter sends the link to GitHub blob instead
+    # of producing a dead docsite-relative reference.
+    nested_match = re.match(r'^docs/([^/]+)/(.+)\.md$', repo_path)
+    if nested_match and nested_match.group(1) not in config.EXCLUDED_GUIDE_DIRS:
+        return f"guides/{nested_match.group(1)}/{nested_match.group(2)}.md"
+
+    # docs/*.md → guides/*.md (top-level guides)
     docs_match = re.match(r'^docs/([^/]+)\.md$', repo_path)
     if docs_match:
-        return f"guides/{docs_match.group(1)}/"
+        return f"guides/{docs_match.group(1)}.md"
 
-    # .github/actions/<name>/README.md → actions/<name>/
+    # .github/actions/<name>/README.md → actions/<name>.md
     action_match = re.match(
         r'^\.github/actions/([^/]+)/README\.md$', repo_path,
     )
     if action_match:
-        return f"actions/{action_match.group(1)}/"
+        return f"actions/{action_match.group(1)}.md"
 
     return None

--- a/scripts/docsite/tests/test_helpers.py
+++ b/scripts/docsite/tests/test_helpers.py
@@ -151,41 +151,58 @@ class TestRewriteRepoLinks:
     # ── Docsite path rewriting ───────────────────────────────────────────
 
     def test_rewrites_docs_link_to_guides(self):
+        # Issue #167-6: emit ``.md`` rather than the bare-directory form
+        # so ``mkdocs build --strict`` validates the target. The rewriter
+        # computes a relative path from the source's docsite location;
+        # README.md isn't mapped → source root → target path emitted as-is.
         content = "[scanners](docs/scanners.md)"
         result = rewrite_repo_links(content, "README.md")
-        assert result == "[scanners](guides/scanners/)"
+        assert result == "[scanners](guides/scanners.md)"
 
     def test_rewrites_action_readme_to_actions(self):
         content = "[ai](.github/actions/ai-summary/README.md)"
         result = rewrite_repo_links(content, "README.md")
-        assert result == "[ai](actions/ai-summary/)"
+        assert result == "[ai](actions/ai-summary.md)"
 
     def test_rewrites_docs_link_preserves_anchor(self):
         content = "[ctrl](docs/failure-control.md#thresholds)"
         result = rewrite_repo_links(content, "README.md")
-        assert result == "[ctrl](guides/failure-control/#thresholds)"
+        assert result == "[ctrl](guides/failure-control.md#thresholds)"
 
     def test_rewrites_nested_action_cross_reference(self):
+        # Source ``actions/scanner-bandit.md`` → target
+        # ``actions/scanner-codeql.md`` resolves to a sibling path.
         content = "[other](../scanner-codeql/README.md)"
         result = rewrite_repo_links(
             content, ".github/actions/scanner-bandit/README.md",
         )
-        assert result == "[other](actions/scanner-codeql/)"
+        assert result == "[other](scanner-codeql.md)"
 
     def test_does_not_rewrite_non_readme_action_file(self):
         content = "[script](.github/actions/ai-summary/scripts/gen.py)"
         result = rewrite_repo_links(content, "README.md")
         assert "https://github.com/org/repo/blob/main/" in result
 
-    def test_does_not_rewrite_nested_docs_path(self):
+    def test_excluded_nested_docs_falls_through_to_github(self, monkeypatch):
+        # docs/<excluded>/ subdirs aren't shipped to the docsite, so the
+        # link should fall through to a GitHub blob URL rather than
+        # producing a dead docsite-relative reference (issue #167-4).
+        monkeypatch.setattr(config, "EXCLUDED_GUIDE_DIRS", {"developer"})
         content = "[dev](docs/developer/setup.md)"
         result = rewrite_repo_links(content, "README.md")
-        assert "https://github.com/org/repo/blob/main/" in result
+        assert "https://github.com/org/repo/blob/main/docs/developer/setup.md" in result
+
+    def test_nested_docs_path_in_allowed_subdir_maps(self):
+        # ``docs/migration/`` and ``docs/troubleshooting/`` are not in
+        # EXCLUDED_GUIDE_DIRS, so links land inside the docsite (issue #167-4).
+        content = "[mig](docs/migration/0.6.x-to-1.x.md)"
+        result = rewrite_repo_links(content, "README.md")
+        assert result == "[mig](guides/migration/0.6.x-to-1.x.md)"
 
     def test_mixed_docsite_and_github_links(self):
         content = "[guide](docs/scanners.md) and [lic](LICENSE.md)"
         result = rewrite_repo_links(content, "README.md")
-        assert "guides/scanners/" in result
+        assert "guides/scanners.md" in result
         assert "https://github.com/org/repo/blob/main/LICENSE.md" in result
 
 
@@ -193,19 +210,32 @@ class TestToDocsitePath:
     """Tests for _to_docsite_path()."""
 
     def test_docs_md_to_guides(self):
-        assert _to_docsite_path("docs/scanners.md") == "guides/scanners/"
+        # Issue #167-6: emit ``.md`` form for mkdocs --strict validation.
+        assert _to_docsite_path("docs/scanners.md") == "guides/scanners.md"
 
     def test_action_readme_to_actions(self):
         assert (
             _to_docsite_path(".github/actions/ai-summary/README.md")
-            == "actions/ai-summary/"
+            == "actions/ai-summary.md"
         )
 
     def test_returns_none_for_non_docsite_path(self):
         assert _to_docsite_path("CHANGELOG.md") is None
 
-    def test_returns_none_for_nested_docs(self):
+    def test_excluded_nested_docs_returns_none(self, monkeypatch):
+        # When a subdirectory is in EXCLUDED_GUIDE_DIRS, those pages
+        # don't ship to the docsite, so the mapping returns None and
+        # the rewriter sends the link to GitHub blob (issue #167-4).
+        monkeypatch.setattr(config, "EXCLUDED_GUIDE_DIRS", {"developer"})
         assert _to_docsite_path("docs/developer/setup.md") is None
+
+    def test_nested_docs_in_allowed_subdir_maps(self):
+        # Allowed subdirs (migration, troubleshooting) map through with
+        # the subdirectory preserved (issue #167-4).
+        assert (
+            _to_docsite_path("docs/migration/0.6.x-to-1.x.md")
+            == "guides/migration/0.6.x-to-1.x.md"
+        )
 
     def test_returns_none_for_non_readme_action_file(self):
         assert _to_docsite_path(".github/actions/ai-summary/action.yml") is None


### PR DESCRIPTION
## Description
Resolves the three gauntlet issues filed after 1.0.1 shipped: #166 (CI workflows running on `chore(release):` commits), #167 (doc site audit), and #168 (1.0.1 end-to-end gauntlet — 15 items). 13 items close cleanly; 2 are deferred with rationale documented in commits and the #168 status comment.

## Changes Made
- [x] Added new scanner/workflow — `.github/workflows/ghcr-prune.yml` (already on the branch from the original gauntlet work)
- [x] Modified existing scanner/workflow
- [x] Updated documentation
- [x] Fixed bug
- [ ] Other

### Details
Across 18 commits, one logical fix per commit. By area:

**Security (high-priority)**
- Flip `reporting.keep_raw` default OFF — raw scanner output (e.g. gitleaks `Match`/`Secret`) no longer persists plaintext tokens to `argus-results/<ts>/raw/`. The canonical `argus-results.json` is always written and is pattern-redacted.
- Add `argus-results` to `_BUILTIN_EXCLUDES` so repeat scans don't snowball-detect their own prior raw output.

**Wheel correctness**
- `argus/init.py:_SCHEMA_VERSION` now derives from `argus.__version__` instead of a hardcoded `"0.7.0"`. Wider regex-bumper rules cover `argus-config.schema.json` URLs and `ghcr.io/.../scanner:<tag>` refs in docs.
- `cli-reference.md` auto-regenerates via the `after:bump` release-it hook.

**Reporters & validator**
- Markdown report + `--output-vars` now emit the Info row / `info_count` key (math reconciles with Total).
- Validator's accepted `reporting.formats` derived from `available_reporters()` at call time (no more rejecting `github`/`gitlab`/`junit` formats that `argus scan --format` accepts).
- Unknown scanner names in `argus.yml` error at validate time instead of silently passing.
- GitLab CC: de-dup'd `description` field when title and description carry the same content.
- JUnit XML: `failure[type]` is the rule id (exception-class-shaped) instead of the severity value.

**CI hygiene**
- `chore(release):` startsWith guard applied to 7 workflows that were running against bot release commits (#166).
- Container-pull failures categorized (#168-H); permanent failures (403, daemon-down, network) skip retry. Engine-level cache prevents pre-warm + inline pulls from both firing on permanent failures.

**CLI surface**
- `--quiet` actually mutes per-phase INFO logging (was a no-op).
- `--fail-on-scanner-error` no longer prints the "Pass --fail-on-scanner-error to fail" CTA when it's already on.
- `argus view` adds `--path / -p` flag as the argparse-safe escape hatch for the `view <interface> --flag value <path>` shape (#168-D5).
- `argus classify` exits non-zero when `git diff` itself fails (was masking CI gates).
- `argus report sarif` follows the `argus-results/latest` symlink by default.
- `argus collect` skips per-run timestamp dirs + the `latest` symlink so local layouts don't get mislabeled as scanners.
- `argus cache info` distinguishes `(not cached)` from `0 B (mount empty)` and explains the three likely causes.

**Scanners**
- Grype/Trivy raise `ScannerPreconditionError` (no more "trying local fallback" dance on missing `--sbom`).
- ClamAV writes its DB to `/tmp/clamav-db` via `freshclam --datadir`; `clamav` removed from `CACHE_MOUNTS` so the bind mount doesn't re-trigger the freshclam segfault.
- `argus init`-generated `argus.yml` includes a `yamllint disable-line` directive on the long `$schema` comment so the file passes its own lint-yaml default.

**MCP**
- `argus mcp serve` advertises the argus version on initialize instead of the FastMCP library version.

**Docsite**
- TUI screenshots render (copy `docs/images/` to `docs_out/images/`).
- Nav title casing handles acronyms (CLI, MCP, SAST, etc.) and migration page names (`0.6.x → 1.x`).
- Orphan example pages (`configs/`, `github-enterprise/`, `workflows/`) + top-level policy files wired into nav.
- `_to_docsite_path` emits `.md` form (not bare-directory URLs) and computes target paths relative to source. `mkdocs build --strict` now passes (down from 27 warnings).
- `cli-reference.md` regen wired into `after:bump`.

### Breaking changes
None at the SDK / CLI surface. Two internal contract changes worth noting in release notes:
- Reporter contract: `ScanSummary.fail_on_scanner_error_set` is new (defaults False). Custom reporters that pickled / serialized ScanSummary may need to handle the new field.
- JUnit `failure[type]` changed from severity value (`"high"`) to rule id (`"B102"`). External JUnit consumers that grouped on `type` will see different buckets.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results
Full suite passes via the pre-push hook:
```
3390 passed, 2 skipped, 7 deselected, 20 warnings in 29.40s
✅ All tests passed! Safe to push.
```

Coverage threshold (80%) enforced.

Per-fix test additions (highlights):
- `test_clamav_excluded_from_cache_mounts` — regression for #168-N
- `test_permanent_403_skips_second_pull` — regression for #168-H follow-up
- `test_view_argument_orderings_resolve_uniformly` — 8-row parametrize covering #168-D5
- `test_argus_results_excluded_by_default` — regression for #168-C
- `test_keep_raw_defaults_off` — regression for #168-B
- `TestUnknownScannerName` + `TestReporterRegistrySync` — #168-F
- `test_report_suppresses_cta_when_fail_on_scanner_error_set` — #168-D
- `TestClassifyPullError` — 7-case categorization for #168-H

## Security Considerations
- [ ] No security impact
- [x] Security enhancement
- [ ] Potential security implications

### Security Details
Two security-class fixes:
1. **Raw secret leak (#168-B)**: scanners like gitleaks were writing the literal matched secret bytes (`Match`, `Secret` JSON fields) into `argus-results/<ts>/raw/gitleaks/results.json` by default. Flipped `keep_raw` default to OFF; forensic / triage users opt in via `--keep-raw` or `reporting.keep_raw: true`. The canonical `argus-results.json` is always written and is pattern-redacted, so the common case (developer + CI) loses nothing.
2. **Self-scan snowball (#168-C)**: repeat scans were detecting their own prior raw output (e.g. checkov flagging the gitleaks raw JSON for Base64 high entropy). Adding `argus-results` to `_BUILTIN_EXCLUDES` stops the cascade and prevents on-disk secret material from growing linearly with scan count.

Cosign verification (release.yml workflow identity), digest-pinning, MCP version reporting — all behavioral fixes from prior commits remain intact.

## AI Context Updates (.ai/)
- [ ] `.ai/architecture.yaml` updated
- [ ] `.ai/workflows.yaml` updated
- [ ] `.ai/decisions.yaml` updated
- [ ] `.ai/errors.yaml` updated
- [x] N/A — None of the fixes change project structure, command surface, or design decisions at a level that needs `.ai/` mirroring. ADR-027 (build-once-promote release pipeline) was added in an earlier batch.

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (docs/cli-reference.md regenerated, docs/config-reference.md keep_raw row added, docs/security.md cosign example updated, docs/developer/SDK-ROADMAP.md follow-ups recorded)
- [ ] Changelog updated (release-it will generate on the next release)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Closes #166
Closes #167
Closes #168 (partial — 13/15 items; deferred items tracked in the issue thread)

## Deferred follow-ups
Two #168-I sub-items deferred to separate PRs:
- `argus scan lint-terraform` reports PASS on partial phase execution (needs phase-result merging refactor)
- `argus scan` with `container:` enabled but no `--image`/`--discover` silently 0-findings (needs auto-discover wiring or startup warn)

One #168-M follow-up: cache mounts actually persist per-scanner — needs running each tool and tracing where it writes its DB (per-scanner uid investigation).

Both classes are documented in the `fix(scanners)` and `fix(cache)` commit messages.

## Screenshots/Logs (if applicable)
Status table for all 15 items posted at https://github.com/huntridge-labs/argus/issues/168#issuecomment-4469339070