### PR TITLE
fix(security): mitigate dogfood-scan findings (bandit B103/B310, lodash OSV)

### DIFF
--- a/argus.yml
+++ b/argus.yml
@@ -28,6 +28,9 @@ scanners:
   osv:
     enabled: true
     exclude: "tests/fixtures"
+    # Accepted-with-rationale advisories live in osv-scanner.toml.
+    # Each entry carries a reason and an ignoreUntil review date.
+    config_file: "osv-scanner.toml"
 
   supply-chain:
     enabled: true

--- a/argus/core/engine.py
+++ b/argus/core/engine.py
@@ -973,7 +973,7 @@ class ArgusEngine:
             # this guard exists for). Calling ``chmod 0o777`` there is
             # at best a no-op and at worst confusing in stack traces.
             if platform.system() != "Windows":
-                os.chmod(output_dir, 0o777)
+                os.chmod(output_dir, 0o777)  # nosec B103 — see comment above
 
             docker_cmd = [
                 self._runtime, "run", "--rm",

--- a/argus/dast/runner.py
+++ b/argus/dast/runner.py
@@ -156,7 +156,9 @@ def _probe_health(host: str, port: int, timeout: int = 60) -> bool:
             with socket.create_connection((host, port), timeout=2):
                 # TCP connected — try HTTP to confirm the app is ready
                 try:
-                    resp = urllib.request.urlopen(
+                    # B310: scheme is the hardcoded literal "http://"; the
+                    # host/port pair is the user-supplied DAST target, not a URL.
+                    resp = urllib.request.urlopen(  # nosec B310
                         f"http://{host}:{port}/", timeout=3,
                     )
                     if resp.status < 500:

--- a/argus/preflight/issue_reporter.py
+++ b/argus/preflight/issue_reporter.py
@@ -105,7 +105,9 @@ class GitHubIssueReporter:
 
         req = urllib.request.Request(url, data=body, headers=headers, method=method)
         try:
-            with urllib.request.urlopen(req, timeout=15) as resp:
+            # B310: url is built from CIContext.api_base (CI-env, trusted)
+            # plus an internal path literal; no file:// reachable.
+            with urllib.request.urlopen(req, timeout=15) as resp:  # nosec B310
                 return json.loads(resp.read().decode())
         except (urllib.error.URLError, json.JSONDecodeError, OSError) as exc:
             logger.warning("GitHub API %s %s failed: %s", method, path, exc)
@@ -183,7 +185,9 @@ class GitLabIssueReporter:
 
         req = urllib.request.Request(url, data=body, headers=headers, method=method)
         try:
-            with urllib.request.urlopen(req, timeout=15) as resp:
+            # B310: url is built from CIContext.api_base (CI-env, trusted)
+            # plus an internal path literal; no file:// reachable.
+            with urllib.request.urlopen(req, timeout=15) as resp:  # nosec B310
                 return json.loads(resp.read().decode())
         except (urllib.error.URLError, json.JSONDecodeError, OSError) as exc:
             logger.warning("GitLab API %s %s failed: %s", method, path, exc)

--- a/argus/tests/viewers/terminal/test_mouse_actions.py
+++ b/argus/tests/viewers/terminal/test_mouse_actions.py
@@ -575,6 +575,27 @@ class TestVerifyRemoteUrl:
         # the user can act on it.
         assert "error" in message.lower() or "dns" in message.lower()
 
+    def test_rejects_non_http_schemes(self, monkeypatch):
+        # Defense-in-depth: callers in this module construct URLs as
+        # hardcoded ``https://`` strings, but the ``url`` parameter is
+        # still a plain str. A future caller mistakenly handing this
+        # function a ``file://`` URL must NOT turn the HEAD probe into
+        # a local-file disclosure gadget (bandit B310). The scheme
+        # check must fire BEFORE urlopen is reached.
+        import urllib.request as urllib_request
+
+        from argus.viewers.terminal import mouse_actions
+
+        def _should_not_be_called(req, timeout=None):
+            raise AssertionError("urlopen called with non-http(s) scheme")
+
+        monkeypatch.setattr(urllib_request, "urlopen", _should_not_be_called)
+
+        for bad in ("file:///etc/passwd", "ftp://x.test", "gopher://x.test"):
+            ok, message = mouse_actions.verify_remote_url(bad)
+            assert ok is False, f"scheme {bad!r} should be rejected"
+            assert "scheme" in message.lower()
+
 
 class TestGitFileStatus:
     """``git_file_status`` is best-effort — it should never crash, and

--- a/argus/update_check.py
+++ b/argus/update_check.py
@@ -136,7 +136,9 @@ def fetch_latest_version() -> Optional[str]:
             url,
             headers={"User-Agent": f"argus-security/{__version__}"},
         )
-        with urlopen(req, timeout=HTTP_TIMEOUT) as resp:
+        # B310: url is the hardcoded PyPI endpoint, or an env-var override
+        # the user explicitly set. No file:// reachable.
+        with urlopen(req, timeout=HTTP_TIMEOUT) as resp:  # nosec B310
             data = json.loads(resp.read().decode("utf-8"))
         version = data.get("info", {}).get("version")
         return version if isinstance(version, str) else None

--- a/argus/viewers/terminal/mouse_actions.py
+++ b/argus/viewers/terminal/mouse_actions.py
@@ -387,6 +387,13 @@ def verify_remote_url(url: str, timeout: float = 2.0) -> tuple[bool, str]:
     """
     if not url:
         return False, "empty URL"
+    # Defense in depth: callers construct URLs via the hardcoded https://
+    # builders in this module (cve_url, advisory_url_for_id, …), but
+    # ``url`` is still a plain str. Reject anything that isn't http(s) so
+    # an unexpected caller can't turn this HEAD probe into a file://
+    # disclosure gadget (bandit B310).
+    if not url.lower().startswith(("http://", "https://")):
+        return False, "unsupported URL scheme"
     import urllib.error
     import urllib.request
     try:
@@ -394,7 +401,8 @@ def verify_remote_url(url: str, timeout: float = 2.0) -> tuple[bool, str]:
             url, method="HEAD",
             headers={"User-Agent": "argus-view-terminal"},
         )
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
+        # B310: scheme is enforced above; only http(s) reach this call.
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # nosec B310
             status = getattr(resp, "status", None) or resp.getcode()
             if 200 <= status < 400:
                 return True, f"HTTP {status}"

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,21 @@
+# osv-scanner ignore list — argus dev-only transitive deps with no
+# upstream fix available. Each entry must carry a rationale and an
+# ``until`` review date; re-evaluate during the next release cycle.
+#
+# Format: https://google.github.io/osv-scanner/configuration/
+
+[[IgnoredVulns]]
+id = "GHSA-r5fr-rjxr-66jc"
+reason = """
+lodash@4.17.21 _.template code injection (CVE-2026-4800). Pulled in
+transitively by dev-only release tooling: release-it plugins,
+commitizen, and inquirer prompts. None of those call sites pass our
+content through _.template — the gadget is unreachable in our build.
+Lodash 4.17.21 is the last upstream release (2021) so no fix version
+exists. Argus ships no JavaScript at runtime; the only attack surface
+is "anyone running `npm run release` against a hostile changelog
+template," which is the same trust boundary as running the release
+itself. Re-evaluate when release-it / commitizen drop their lodash
+dependency.
+"""
+ignoreUntil = 2026-11-17


### PR DESCRIPTION
## Description
A local ``argus scan`` of this repo (severity threshold: ``high``) reached ``Status: FAIL`` on two highs and five mediums that don't reflect real exposure. This PR mitigates each so a dogfood scan reaches ``PASS`` without lowering the bar.

## Changes Made
- [x] Fixed bug
- [x] Security enhancement (scheme allowlist in ``verify_remote_url``)
- [x] Other: scan-config + nosec annotations with rationale

### Details
**bandit B103 — ``argus/core/engine.py:976``** (high → suppressed)
``chmod 0o777`` on a ``tempfile.TemporaryDirectory()`` output_dir. The block already documents (20-line comment) why this is safe: random-named host-only path, scoped to one scan, torn down at end of with-block, fixes the macOS uid-mismatch silent-failure mode. Added ``# nosec B103`` referencing the rationale comment.

**bandit B310 — 5 ``urllib.request.urlopen`` sites** (medium → suppressed)
Bandit's concern is "urlopen accepts ``file://``". Each site's actual URL provenance:
- ``argus/dast/runner.py:159`` — hardcoded ``"http://"`` literal
- ``argus/preflight/issue_reporter.py:108,186`` — ``CIContext.api_base`` (env-derived, trusted)
- ``argus/update_check.py:139`` — hardcoded PyPI URL or env override
- ``argus/viewers/terminal/mouse_actions.py:397`` — **promoted to actual fix**: ``verify_remote_url`` now rejects any scheme that isn't ``http(s)://`` *before* ``urlopen`` is reached. Defense-in-depth, not just an annotation.

**osv GHSA-r5fr-rjxr-66jc — ``lodash@4.17.21`` ``_.template`` code injection** (high → suppressed via osv-scanner.toml)
Pulled in transitively by dev-only release tooling: ``@j-ulrich/release-it-regex-bumper``, ``commitizen``, ``inquirer``. Lodash 4.17.21 is the last upstream release (2021) — no fix version exists. Argus ships no JavaScript at runtime; the gadget is unreachable in our build. Added ``osv-scanner.toml`` with reason + ``ignoreUntil = 2026-11-17`` review date, and wired it into ``argus.yml`` via ``osv.config_file``.

No breaking changes; no scanner protocol changes.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed

### Test Results
- New test ``TestVerifyRemoteUrl::test_rejects_non_http_schemes`` — monkey-patches ``urlopen`` to assert it is *never called* for ``file://``, ``ftp://``, ``gopher://``. Proves the scheme check fires before ``urlopen``.
- Local pytest: 3414 passed, 2 skipped, 3 pre-existing browser-viewer failures on main unrelated to this branch.
- Local TOML parse of ``osv-scanner.toml`` confirms it loads cleanly (``tomllib.loads``).

## Security Considerations
- [x] Security enhancement

### Security Details
- ``verify_remote_url`` now enforces an http(s) scheme allowlist. Before this PR, a future caller mistakenly passing ``file:///etc/passwd`` could turn the HEAD probe into a local-file-existence oracle. The new check rejects with ``"unsupported URL scheme"`` before any URL parsing.
- Every ``# nosec`` annotation carries inline rationale referencing the actual URL provenance, not a generic "trust me" comment.
- ``osv-scanner.toml`` ignore is dated (``ignoreUntil = 2026-11-17``) so the scanner re-flags the lodash advisory if release-it / commitizen haven't dropped lodash by then.

## AI Context Updates (.ai/)
- [x] N/A - No .ai/ updates needed (no commands, components, or workflows changed)

## Checklist
- [x] Code follows project style guidelines
- [x] All tests pass (modulo 3 pre-existing main-branch flakes in viewers/browser)
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**