### PR TITLE
fix(update-check): suppress bogus "1.1.0 → 1.0.1" downgrade notice (closes #174)

### DIFF
--- a/argus/cli.py
+++ b/argus/cli.py
@@ -304,6 +304,34 @@ def _make_run_dir(base_dir: str) -> str:
     return str(run_dir)
 
 
+def _build_common_parent() -> argparse.ArgumentParser:
+    """Flags shared across every subcommand.
+
+    Currently just ``--no-update-check``. Per issue #174, users
+    invoked ``argus report --no-update-check`` and hit
+    ``unrecognized arguments: --no-update-check`` because the flag
+    was previously only on ``scan``. The update-check itself only
+    fires from scan paths today, but the flag should be accepted
+    everywhere so the suppression contract isn't subcommand-specific
+    (and so future subcommands that opt into the check don't need a
+    second round of UX cleanup).
+    """
+    parent = argparse.ArgumentParser(add_help=False)
+    parent.add_argument(
+        "--no-update-check",
+        action="store_true",
+        help="Skip the once-per-day check for a newer argus release. The "
+             "check runs in the background (zero latency cost) and prints "
+             "a soft notice at the end of the command when an upgrade is "
+             "available. Also disabled by setting the "
+             "ARGUS_NO_UPDATE_CHECK environment variable, which is the "
+             "right move for CI / air-gapped environments. Override the "
+             "PyPI URL via ARGUS_UPDATE_CHECK_URL for TestPyPI or "
+             "private mirrors.",
+    )
+    return parent
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build the top-level argument parser with scan and report subcommands."""
     parser = argparse.ArgumentParser(
@@ -319,16 +347,17 @@ def build_parser() -> argparse.ArgumentParser:
 
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
 
-    _build_init_parser(subparsers)
-    _build_scan_parser(subparsers)
-    _build_classify_parser(subparsers)
-    _build_collect_parser(subparsers)
-    _build_report_parser(subparsers)
-    _build_validate_parser(subparsers)
-    _build_mcp_parser(subparsers)
-    _build_completion_parser(subparsers)
-    _build_cache_parser(subparsers)
-    _build_view_parser(subparsers)
+    common = _build_common_parent()
+    _build_init_parser(subparsers, common)
+    _build_scan_parser(subparsers, common)
+    _build_classify_parser(subparsers, common)
+    _build_collect_parser(subparsers, common)
+    _build_report_parser(subparsers, common)
+    _build_validate_parser(subparsers, common)
+    _build_mcp_parser(subparsers, common)
+    _build_completion_parser(subparsers, common)
+    _build_cache_parser(subparsers, common)
+    _build_view_parser(subparsers, common)
 
     return parser
 
@@ -336,7 +365,7 @@ def build_parser() -> argparse.ArgumentParser:
 VIEW_INTERFACES = ("terminal", "browser")
 
 
-def _build_view_parser(subparsers: argparse._SubParsersAction) -> None:
+def _build_view_parser(subparsers: argparse._SubParsersAction, parent: argparse.ArgumentParser) -> None:
     """Add the 'view' subcommand — open a viewer on existing scan results.
 
     Replaces the old ``browse`` and ``serve`` commands with a single entry
@@ -346,6 +375,7 @@ def _build_view_parser(subparsers: argparse._SubParsersAction) -> None:
     """
     view_parser = subparsers.add_parser(
         "view",
+        parents=[parent],
         help="Open a viewer (terminal UI or browser) on existing scan results",
         description=(
             "Open a human-readable view of argus-results.json:\n"
@@ -598,10 +628,11 @@ def _launch_view(
     return EXIT_ERROR
 
 
-def _build_init_parser(subparsers: argparse._SubParsersAction) -> None:
+def _build_init_parser(subparsers: argparse._SubParsersAction, parent: argparse.ArgumentParser) -> None:
     """Add the 'init' subcommand for project initialization."""
     init_parser = subparsers.add_parser(
         "init",
+        parents=[parent],
         help="Initialize argus.yml for the current project",
         description=(
             "Detect your project's languages, frameworks, and infrastructure,\n"
@@ -634,10 +665,11 @@ def cmd_init(args: argparse.Namespace) -> int:
     )
 
 
-def _build_scan_parser(subparsers: argparse._SubParsersAction) -> None:
+def _build_scan_parser(subparsers: argparse._SubParsersAction, parent: argparse.ArgumentParser) -> None:
     """Add the 'scan' subcommand."""
     scan_parser = subparsers.add_parser(
         "scan",
+        parents=[parent],
         help="Run security scanners against a target path or container images",
         description=(
             "Run one or more security scanners and generate results.\n\n"
@@ -725,18 +757,6 @@ def _build_scan_parser(subparsers: argparse._SubParsersAction) -> None:
         "--no-spinner",
         action="store_true",
         help="Disable animated spinner output",
-    )
-    scan_parser.add_argument(
-        "--no-update-check",
-        action="store_true",
-        help="Skip the once-per-day check for a newer argus release. The "
-             "check runs in the background during the scan (zero latency "
-             "cost) and prints a soft notice at the end of the command "
-             "when an upgrade is available. Also disabled by setting the "
-             "ARGUS_NO_UPDATE_CHECK environment variable, which is the "
-             "right move for CI / air-gapped environments. Override the "
-             "PyPI URL via ARGUS_UPDATE_CHECK_URL for TestPyPI or "
-             "private mirrors.",
     )
     scan_parser.add_argument(
         "--no-timestamp",
@@ -944,10 +964,11 @@ def _build_scan_parser(subparsers: argparse._SubParsersAction) -> None:
     )
 
 
-def _build_classify_parser(subparsers: argparse._SubParsersAction) -> None:
+def _build_classify_parser(subparsers: argparse._SubParsersAction, parent: argparse.ArgumentParser) -> None:
     """Add the 'classify' subcommand for SCN change classification."""
     classify_parser = subparsers.add_parser(
         "classify",
+        parents=[parent],
         help="Classify IaC changes for compliance reporting (FedRAMP SCN)",
         description=(
             "Analyze infrastructure-as-code changes between two git refs\n"
@@ -1114,10 +1135,11 @@ def cmd_classify(args: argparse.Namespace) -> int:
     return EXIT_SUCCESS
 
 
-def _build_collect_parser(subparsers: argparse._SubParsersAction) -> None:
+def _build_collect_parser(subparsers: argparse._SubParsersAction, parent: argparse.ArgumentParser) -> None:
     """Add the 'collect' subcommand for aggregating multi-job results."""
     collect_parser = subparsers.add_parser(
         "collect",
+        parents=[parent],
         help="Collect and merge results from parallel CI scanner jobs",
         description=(
             "Aggregate per-scanner results into a unified audit package.\n\n"
@@ -1147,10 +1169,11 @@ def _build_collect_parser(subparsers: argparse._SubParsersAction) -> None:
     )
 
 
-def _build_validate_parser(subparsers: argparse._SubParsersAction) -> None:
+def _build_validate_parser(subparsers: argparse._SubParsersAction, parent: argparse.ArgumentParser) -> None:
     """Add the 'validate' subcommand for config validation."""
     validate_parser = subparsers.add_parser(
         "validate",
+        parents=[parent],
         help="Validate an argus.yml configuration file",
         description=(
             "Check an argus.yml config file for errors and warnings.\n"
@@ -1183,10 +1206,11 @@ def _build_validate_parser(subparsers: argparse._SubParsersAction) -> None:
     )
 
 
-def _build_mcp_parser(subparsers: argparse._SubParsersAction) -> None:
+def _build_mcp_parser(subparsers: argparse._SubParsersAction, parent: argparse.ArgumentParser) -> None:
     """Add the 'mcp' subcommand to start the MCP server."""
     subparsers.add_parser(
         "mcp",
+        parents=[parent],
         help="Start the MCP server for AI assistant integration",
         description=(
             "Start the Argus MCP (Model Context Protocol) server.\n\n"
@@ -1201,10 +1225,11 @@ def _build_mcp_parser(subparsers: argparse._SubParsersAction) -> None:
     )
 
 
-def _build_completion_parser(subparsers: argparse._SubParsersAction) -> None:
+def _build_completion_parser(subparsers: argparse._SubParsersAction, parent: argparse.ArgumentParser) -> None:
     """Add the 'completion' subcommand for shell completion scripts."""
     completion_parser = subparsers.add_parser(
         "completion",
+        parents=[parent],
         help="Generate shell completion script",
         description=(
             "Generate a shell completion script for argus.\n\n"
@@ -1229,14 +1254,15 @@ def _build_completion_parser(subparsers: argparse._SubParsersAction) -> None:
     )
 
 
-def _build_cache_parser(subparsers: argparse._SubParsersAction) -> None:
+def _build_cache_parser(subparsers: argparse._SubParsersAction, parent: argparse.ArgumentParser) -> None:
     """Add the 'cache' subcommand for managing scanner DB caches."""
     cache_parser = subparsers.add_parser(
         "cache",
+        parents=[parent],
         help="Manage scanner database caches",
         description=(
             "Manage cached vulnerability databases used by container-based scanners.\n\n"
-            "Argus caches scanner databases (Trivy, Grype, ClamAV, etc.) in the system\n"
+            "Argus caches scanner databases (Trivy, Grype, Checkov, etc.) in the system\n"
             "temp directory so container runs don't re-download hundreds of MB each time.\n"
             "The cache persists across runs within a session but is cleaned on reboot.\n\n"
             "Cache location: $TMPDIR/argus-cache (override with ARGUS_CACHE_DIR)\n"
@@ -1256,10 +1282,11 @@ def _build_cache_parser(subparsers: argparse._SubParsersAction) -> None:
     )
 
 
-def _build_report_parser(subparsers: argparse._SubParsersAction) -> None:
+def _build_report_parser(subparsers: argparse._SubParsersAction, parent: argparse.ArgumentParser) -> None:
     """Add the 'report' subcommand."""
     report_parser = subparsers.add_parser(
         "report",
+        parents=[parent],
         help="Generate reports from existing scan results",
         description="Generate formatted reports from previously captured scan results.",
     )

--- a/argus/tests/test_update_check.py
+++ b/argus/tests/test_update_check.py
@@ -152,6 +152,9 @@ class TestCachedLatestVersion:
             "latest_version": "0.9.0",
         }))
         monkeypatch.setattr(update_check, "_cache_path", lambda: cache_path)
+        # Pin installed version <= cached_latest so the new staleness
+        # guard (issue #174-1.1.a) doesn't trip and force a refetch.
+        monkeypatch.setattr(update_check, "__version__", "0.8.0")
 
         with patch("argus.update_check.fetch_latest_version") as mock_fetch:
             result = update_check.cached_latest_version()
@@ -201,6 +204,58 @@ class TestCachedLatestVersion:
             result = update_check.cached_latest_version()
         assert result == "0.9.0"
 
+    def test_cache_invalidated_when_installed_newer_than_cached(
+        self, tmp_path, monkeypatch,
+    ):
+        """Regression for issue #174-1.1.a.
+
+        After ``pip install --upgrade argus-security==1.1.0`` the cache
+        from the prior 1.0.1 install still says ``latest_version:
+        1.0.1``. Without this check the helper would happily return
+        "1.0.1" as latest, and the caller would emit a "1.1.0 → 1.0.1"
+        downgrade notice forever. The fix: when installed > cached
+        latest, treat the cache as stale and refetch.
+        """
+        cache_path = tmp_path / "argus" / "update-check.json"
+        cache_path.parent.mkdir()
+        cache_path.write_text(json.dumps({
+            "checked_at": datetime.now(timezone.utc).isoformat(),
+            "latest_version": "1.0.1",
+        }))
+        monkeypatch.setattr(update_check, "_cache_path", lambda: cache_path)
+        monkeypatch.setattr(update_check, "__version__", "1.1.0")
+
+        with patch(
+            "argus.update_check.fetch_latest_version",
+            return_value="1.1.0",
+        ) as mock_fetch:
+            result = update_check.cached_latest_version()
+            mock_fetch.assert_called_once()
+        # Refetched the real latest; cache was rewritten with it.
+        assert result == "1.1.0"
+        new_cache = json.loads(cache_path.read_text())
+        assert new_cache["latest_version"] == "1.1.0"
+
+    def test_cache_returned_when_cached_newer_than_installed(
+        self, tmp_path, monkeypatch,
+    ):
+        """Inverse of the invalidation case: when the cache says a
+        newer version IS available (normal upgrade-pending state),
+        return it without refetching."""
+        cache_path = tmp_path / "argus" / "update-check.json"
+        cache_path.parent.mkdir()
+        cache_path.write_text(json.dumps({
+            "checked_at": datetime.now(timezone.utc).isoformat(),
+            "latest_version": "1.2.0",
+        }))
+        monkeypatch.setattr(update_check, "_cache_path", lambda: cache_path)
+        monkeypatch.setattr(update_check, "__version__", "1.1.0")
+
+        with patch("argus.update_check.fetch_latest_version") as mock_fetch:
+            result = update_check.cached_latest_version()
+            mock_fetch.assert_not_called()
+        assert result == "1.2.0"
+
 
 # ──────────────────────────────────────────────────────────────────
 # Version comparison + notice formatting                           #
@@ -217,6 +272,42 @@ class TestIsNewer:
 
     def test_older_returns_false(self):
         assert update_check.is_newer("0.8.0", "0.7.2") is False
+
+    def test_unparseable_latest_returns_false(self):
+        """Regression for issue #174-1.1.c.
+
+        The previous fallback used ``latest != current`` which would
+        return True for *any* mismatch — including a downgrade or a
+        garbage version string. With the fail-closed fallback the
+        helper suppresses the notice when it can't compute a real
+        ordering.
+        """
+        assert update_check.is_newer("1.0.0", "not-a-version") is False
+
+    def test_packaging_missing_returns_false(self, monkeypatch):
+        """Regression for issue #174-1.1.b.
+
+        Originally claimed that ``packaging`` was a "transitive dep
+        of pip+setuptools" and the missing-import branch was
+        "theoretical." A fresh ``python -m venv`` does NOT bundle
+        packaging, and the prior fallback (``latest != current``)
+        misfired in exactly that environment, producing the
+        "1.1.0 → 1.0.1" downgrade notice users reported. The new
+        behavior is fail-closed: no notice when we can't compute.
+        """
+        import builtins
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "packaging.version" or name.startswith("packaging."):
+                raise ImportError("simulated missing packaging")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        # With the old behavior this would return True (latest != current);
+        # the fixed behavior fails closed and returns False.
+        assert update_check.is_newer("1.1.0", "1.0.1") is False
+        assert update_check.is_newer("0.7.2", "0.8.0") is False
 
 
 class TestFormatNotice:

--- a/argus/update_check.py
+++ b/argus/update_check.py
@@ -151,10 +151,20 @@ def cached_latest_version() -> Optional[str]:
 
     Returns ``None`` only when both the cache miss AND the network
     fetch fail.
+
+    Also invalidates the cache when the locally installed version is
+    already newer than the cached ``latest_version`` — the cache was
+    written by an earlier install and survived a ``pip install
+    --upgrade``. Without this, post-upgrade users see a bogus
+    "1.1.0 → 1.0.1" downgrade notice forever (issue #174-1.1.a).
     """
     cache = _read_cache()
     if cache and _cache_is_fresh(cache):
-        return cache.get("latest_version")
+        cached_latest = cache.get("latest_version")
+        # Cache is stale via upgrade when installed > cached_latest.
+        # Fall through to a fresh fetch in that case.
+        if cached_latest and not is_newer(cached_latest, __version__):
+            return cached_latest
 
     latest = fetch_latest_version()
     if latest:
@@ -163,18 +173,27 @@ def cached_latest_version() -> Optional[str]:
 
 
 def is_newer(current: str, latest: str) -> bool:
-    """``True`` when *latest* > *current*. Falls back to inequality on parse failure."""
+    """``True`` when *latest* > *current*.
+
+    Fails closed on parse failure or missing ``packaging``. A notice
+    that erroneously says "1.0.1 → 1.0.1" is annoying but harmless;
+    a notice that says "1.1.0 → 1.0.1" actively misleads — the prior
+    ``latest != current`` fallback triggered for downgrades too
+    (issue #174-1.1.c). When we can't compute a real ordering we
+    suppress the notice rather than risk a wrong-direction arrow.
+    """
     try:
         from packaging.version import parse, InvalidVersion
         try:
             return parse(latest) > parse(current)
         except InvalidVersion:
-            return latest != current
+            return False
     except ImportError:
-        # ``packaging`` is a transitive dep of pip+setuptools; this
-        # branch is mostly theoretical but keeps the helper robust on
-        # exotic minimal environments.
-        return latest != current
+        # ``packaging`` is declared as a hard dependency in
+        # pyproject.toml ([project].dependencies); this fallback only
+        # fires on exotic minimal environments where someone bypassed
+        # dependency resolution. Fail closed (issue #174-1.1.b).
+        return False
 
 
 def format_notice(current: str, latest: str) -> str:

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -43,13 +43,14 @@ Examples:
   argus init --no-detect    # generate with defaults only
 
 ```
-argus init [-h] [--force] [--no-detect]
+argus init [-h] [--no-update-check] [--force] [--no-detect]
 ```
 
 **Options:**
 
 | Flag | Description | Default |
 |------|-------------|---------|
+| `--no-update-check` | Skip the once-per-day check for a newer argus release. The check runs in the background (zero latency cost) and prints a soft notice at the end of the command when an upgrade is available. Also disabled by setting the ARGUS_NO_UPDATE_CHECK environment variable, which is the right move for CI / air-gapped environments. Override the PyPI URL via ARGUS_UPDATE_CHECK_URL for TestPyPI or private mirrors. | `false` |
 | `--force` | Overwrite an existing argus.yml file | `false` |
 | `--no-detect` | Skip auto-detection and generate a config with defaults only | `false` |
 
@@ -67,14 +68,14 @@ For container image scanning:
   argus scan container --discover docker/
 
 ```
-argus scan [-h] [--path PATH] [--config CONFIG]
+argus scan [-h] [--no-update-check] [--path PATH] [--config CONFIG]
                   [--output-dir OUTPUT_DIR]
                   [--severity-threshold {critical,high,medium,low,none}]
                   [--format {terminal,markdown,sarif,json,github,gitlab,junit}]
                   [--list] [--verbose] [--debug] [--quiet] [--no-spinner]
-                  [--no-update-check] [--no-timestamp] [--output-vars FILE]
-                  [--exclude PATTERNS] [--no-default-excludes] [--dry-run]
-                  [--sbom PATH] [--interface {terminal,browser}] [--fail-fast]
+                  [--no-timestamp] [--output-vars FILE] [--exclude PATTERNS]
+                  [--no-default-excludes] [--dry-run] [--sbom PATH]
+                  [--interface {terminal,browser}] [--fail-fast]
                   [--fail-on-scanner-error] [--timeout SECONDS]
                   [--no-parallel] [--allow-local-versions] [--no-cache]
                   [--keep-raw | --no-keep-raw] [--registry-password-stdin]
@@ -94,6 +95,7 @@ argus scan [-h] [--path PATH] [--config CONFIG]
 
 | Flag | Description | Default |
 |------|-------------|---------|
+| `--no-update-check` | Skip the once-per-day check for a newer argus release. The check runs in the background (zero latency cost) and prints a soft notice at the end of the command when an upgrade is available. Also disabled by setting the ARGUS_NO_UPDATE_CHECK environment variable, which is the right move for CI / air-gapped environments. Override the PyPI URL via ARGUS_UPDATE_CHECK_URL for TestPyPI or private mirrors. | `false` |
 | `--path`, `-p` | Path to scan (default: current directory) | `.` |
 | `--config`, `-c` | Path to argus.yml config file |  |
 | `--output-dir`, `-o` | Output directory for results (default: ./argus-results) |  |
@@ -104,7 +106,6 @@ argus scan [-h] [--path PATH] [--config CONFIG]
 | `--debug` | Full firehose: subprocess output, vulnerability-DB updates, every engine log line. Use when troubleshooting; the default phase-aware progress is enough for normal scans. | `false` |
 | `--quiet`, `-q` | Suppress per-phase progress lines. The spinner still draws (use --no-spinner to suppress that too). Final summary still prints. Compose with --no-spinner for fully silent CI exit-code-only mode. | `false` |
 | `--no-spinner` | Disable animated spinner output | `false` |
-| `--no-update-check` | Skip the once-per-day check for a newer argus release. The check runs in the background during the scan (zero latency cost) and prints a soft notice at the end of the command when an upgrade is available. Also disabled by setting the ARGUS_NO_UPDATE_CHECK environment variable, which is the right move for CI / air-gapped environments. Override the PyPI URL via ARGUS_UPDATE_CHECK_URL for TestPyPI or private mirrors. | `false` |
 | `--no-timestamp` | Write output directly to --output-dir without a timestamped subdirectory. Useful in CI where a predictable output path is needed. | `false` |
 | `--output-vars` | Write scan result counts as key=value pairs to FILE. Useful in CI: cat FILE >> $GITHUB_OUTPUT. Keys: critical_count, high_count, medium_count, low_count, info_count, total_count, passed. |  |
 | `--exclude`, `-e` | Comma-separated paths or patterns to exclude from scanning. Added on top of .gitignore, .dockerignore, and built-in defaults. | `` |
@@ -152,8 +153,8 @@ Examples:
   argus classify --format json                # JSON output
 
 ```
-argus classify [-h] [--base BASE] [--head HEAD] [--config CONFIG]
-                      [--format {terminal,markdown,json}]
+argus classify [-h] [--no-update-check] [--base BASE] [--head HEAD]
+                      [--config CONFIG] [--format {terminal,markdown,json}]
                       [--output-dir OUTPUT_DIR] [--output-vars FILE]
                       [--enable-ai] [--verbose]
 ```
@@ -162,6 +163,7 @@ argus classify [-h] [--base BASE] [--head HEAD] [--config CONFIG]
 
 | Flag | Description | Default |
 |------|-------------|---------|
+| `--no-update-check` | Skip the once-per-day check for a newer argus release. The check runs in the background (zero latency cost) and prints a soft notice at the end of the command when an upgrade is available. Also disabled by setting the ARGUS_NO_UPDATE_CHECK environment variable, which is the right move for CI / air-gapped environments. Override the PyPI URL via ARGUS_UPDATE_CHECK_URL for TestPyPI or private mirrors. | `false` |
 | `--base` | Base git ref for comparison (default: main) | `main` |
 | `--head` | Head git ref for comparison (default: HEAD) | `HEAD` |
 | `--config`, `-c` | Path to SCN configuration/profile file |  |
@@ -185,7 +187,9 @@ Example:
   argus collect ./downloaded-artifacts/ -o ./argus-audit-package/
 
 ```
-argus collect [-h] [--output-dir OUTPUT_DIR] [--verbose] input_dir
+argus collect [-h] [--no-update-check] [--output-dir OUTPUT_DIR]
+                     [--verbose]
+                     input_dir
 ```
 
 **Arguments:**
@@ -196,6 +200,7 @@ argus collect [-h] [--output-dir OUTPUT_DIR] [--verbose] input_dir
 
 | Flag | Description | Default |
 |------|-------------|---------|
+| `--no-update-check` | Skip the once-per-day check for a newer argus release. The check runs in the background (zero latency cost) and prints a soft notice at the end of the command when an upgrade is available. Also disabled by setting the ARGUS_NO_UPDATE_CHECK environment variable, which is the right move for CI / air-gapped environments. Override the PyPI URL via ARGUS_UPDATE_CHECK_URL for TestPyPI or private mirrors. | `false` |
 | `--output-dir`, `-o` | Output directory for the combined audit package (default: ./argus-audit-package) | `./argus-audit-package` |
 | `--verbose`, `-v` | Enable verbose output | `false` |
 
@@ -204,8 +209,8 @@ argus collect [-h] [--output-dir OUTPUT_DIR] [--verbose] input_dir
 Generate formatted reports from previously captured scan results.
 
 ```
-argus report [-h] [--results-dir RESULTS_DIR] [--output-dir OUTPUT_DIR]
-                    [--verbose]
+argus report [-h] [--no-update-check] [--results-dir RESULTS_DIR]
+                    [--output-dir OUTPUT_DIR] [--verbose]
                     {terminal,markdown,sarif,json,github,gitlab,junit}
 ```
 
@@ -217,6 +222,7 @@ argus report [-h] [--results-dir RESULTS_DIR] [--output-dir OUTPUT_DIR]
 
 | Flag | Description | Default |
 |------|-------------|---------|
+| `--no-update-check` | Skip the once-per-day check for a newer argus release. The check runs in the background (zero latency cost) and prints a soft notice at the end of the command when an upgrade is available. Also disabled by setting the ARGUS_NO_UPDATE_CHECK environment variable, which is the right move for CI / air-gapped environments. Override the PyPI URL via ARGUS_UPDATE_CHECK_URL for TestPyPI or private mirrors. | `false` |
 | `--results-dir`, `-r` | Directory containing scan results JSON (default: ./argus-results) | `./argus-results` |
 | `--output-dir`, `-o` | Output directory for generated reports (default: same as results-dir) |  |
 | `--verbose`, `-v` | Enable verbose output | `false` |
@@ -227,14 +233,15 @@ Check an argus.yml config file for errors and warnings.
 Catches typos, invalid values, and unknown keys before scanning.
 
 ```
-argus validate [-h] [--config CONFIG] [--check-tools] [--strict]
-                      [--report-issue]
+argus validate [-h] [--no-update-check] [--config CONFIG]
+                      [--check-tools] [--strict] [--report-issue]
 ```
 
 **Options:**
 
 | Flag | Description | Default |
 |------|-------------|---------|
+| `--no-update-check` | Skip the once-per-day check for a newer argus release. The check runs in the background (zero latency cost) and prints a soft notice at the end of the command when an upgrade is available. Also disabled by setting the ARGUS_NO_UPDATE_CHECK environment variable, which is the right move for CI / air-gapped environments. Override the PyPI URL via ARGUS_UPDATE_CHECK_URL for TestPyPI or private mirrors. | `false` |
 | `--config`, `-c` | Path to argus.yml config file (default: auto-detect) |  |
 | `--check-tools` | Also check scanner tool availability (local + Docker) | `false` |
 | `--strict` | Treat warnings as errors (exit non-zero). Useful in CI. | `false` |
@@ -253,8 +260,14 @@ Setup in Claude Code:
     "argus": {"command": "argus", "args": ["mcp"]}
 
 ```
-argus mcp [-h]
+argus mcp [-h] [--no-update-check]
 ```
+
+**Options:**
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--no-update-check` | Skip the once-per-day check for a newer argus release. The check runs in the background (zero latency cost) and prints a soft notice at the end of the command when an upgrade is available. Also disabled by setting the ARGUS_NO_UPDATE_CHECK environment variable, which is the right move for CI / air-gapped environments. Override the PyPI URL via ARGUS_UPDATE_CHECK_URL for TestPyPI or private mirrors. | `false` |
 
 ### `argus completion`
 
@@ -276,18 +289,24 @@ Completions are generated from the live scanner registry, so
 newly added scanners appear after re-running this command.
 
 ```
-argus completion [-h] {bash,zsh}
+argus completion [-h] [--no-update-check] {bash,zsh}
 ```
 
 **Arguments:**
 
 - `shell` — Shell type to generate completions for (choices: bash, zsh)
 
+**Options:**
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--no-update-check` | Skip the once-per-day check for a newer argus release. The check runs in the background (zero latency cost) and prints a soft notice at the end of the command when an upgrade is available. Also disabled by setting the ARGUS_NO_UPDATE_CHECK environment variable, which is the right move for CI / air-gapped environments. Override the PyPI URL via ARGUS_UPDATE_CHECK_URL for TestPyPI or private mirrors. | `false` |
+
 ### `argus cache`
 
 Manage cached vulnerability databases used by container-based scanners.
 
-Argus caches scanner databases (Trivy, Grype, ClamAV, etc.) in the system
+Argus caches scanner databases (Trivy, Grype, Checkov, etc.) in the system
 temp directory so container runs don't re-download hundreds of MB each time.
 The cache persists across runs within a session but is cleaned on reboot.
 
@@ -295,8 +314,14 @@ Cache location: $TMPDIR/argus-cache (override with ARGUS_CACHE_DIR)
 For persistent caching: export ARGUS_CACHE_DIR=~/.argus/cache
 
 ```
-argus cache [-h] {info,clean} ...
+argus cache [-h] [--no-update-check] {info,clean} ...
 ```
+
+**Options:**
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--no-update-check` | Skip the once-per-day check for a newer argus release. The check runs in the background (zero latency cost) and prints a soft notice at the end of the command when an upgrade is available. Also disabled by setting the ARGUS_NO_UPDATE_CHECK environment variable, which is the right move for CI / air-gapped environments. Override the PyPI URL via ARGUS_UPDATE_CHECK_URL for TestPyPI or private mirrors. | `false` |
 
 ### `argus view`
 
@@ -319,8 +344,9 @@ Install:
   pip install 'argus-security[browser]'       # browser interface
 
 ```
-argus view [-h] [--path PATH] [--interface {terminal,browser}]
-                  [--port PORT] [--no-open] [--check]
+argus view [-h] [--no-update-check] [--path PATH]
+                  [--interface {terminal,browser}] [--port PORT] [--no-open]
+                  [--check]
                   [INTERFACE|PATH] [PATH]
 ```
 
@@ -333,6 +359,7 @@ argus view [-h] [--path PATH] [--interface {terminal,browser}]
 
 | Flag | Description | Default |
 |------|-------------|---------|
+| `--no-update-check` | Skip the once-per-day check for a newer argus release. The check runs in the background (zero latency cost) and prints a soft notice at the end of the command when an upgrade is available. Also disabled by setting the ARGUS_NO_UPDATE_CHECK environment variable, which is the right move for CI / air-gapped environments. Override the PyPI URL via ARGUS_UPDATE_CHECK_URL for TestPyPI or private mirrors. | `false` |
 | `--path`, `-p` | Results directory or argus-results.json path. Equivalent to the positional form ``argus view <iface> <path>`` but robust to argparse's ordering quirks — use this when a flag-with-value (e.g. ``--port``) sits between the interface keyword and the path (issue #168-D5). |  |
 | `--interface`, `-i` | Interface to open: terminal \| browser (alternative to positional) (terminal, browser) |  |
 | `--port` | TCP port for the browser interface (default: 8080) | `8080` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,13 @@ dependencies = [
     # backend instead.
     "yamllint>=1.35",   # lint-yaml
     "flake8>=7.0",      # lint-python
+    # PEP 440 version comparison for the daily update-check. Without
+    # this, the ``is_newer`` helper falls through to a closed-fail
+    # branch and the upgrade notice never fires — which is correct
+    # but unhelpful. Previously assumed to be a transitive dep of
+    # pip+setuptools; that's not true on minimal venvs and led to
+    # the post-upgrade "1.1.0 → 1.0.1" downgrade notice (issue #174).
+    "packaging>=21",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Description
Closes #174.

The 1.1.0 gauntlet surfaced three layered bugs in ``update_check`` that together produce a wrong-direction "1.1.0 → 1.0.1" upgrade notice on every scan in any environment where (a) the cache survived a ``pip install --upgrade`` and (b) ``packaging`` isn't in the runtime venv. Plus two minor follow-ups: the ``argus cache --help`` text still listed ClamAV (removed from CACHE_MOUNTS in #168-N), and ``--no-update-check`` was a ``scan``-only flag that the issue rightly points out should work from every subcommand.

## Changes Made
- [x] Fixed bug
- [x] Other: lifted ``--no-update-check`` to a shared parent parser; declared ``packaging`` as a hard dependency

### Details

**Three layered fixes for the downgrade notice** (any one suppresses it, all three together make it impossible by construction):

1. **``pyproject.toml``** — declare ``packaging>=21`` as a hard dependency. Previously assumed transitive via pip+setuptools — false on fresh ``python -m venv``. (#174-1.1.b)
2. **``argus/update_check.py:is_newer``** — fail closed when version parsing fails or ``packaging`` is missing. The prior fallback ``latest != current`` returned True for downgrades too. (#174-1.1.c)
3. **``argus/update_check.py:cached_latest_version``** — invalidate the cache when the locally installed version is newer than ``cached_latest_version``. The cache was keyed only on timestamp freshness so it survived a ``pip install --upgrade``. (#174-1.1.a)

**Minor follow-ups:**

4. **``argus cache --help``** — drop the stale "ClamAV" mention from the description (clamav was removed from ``CACHE_MOUNTS`` in #168-N to fix the freshclam-write-conflict bug). Replaced with Checkov which is actually in the mount set.
5. **``--no-update-check`` is now accepted on every subcommand.** Added ``_build_common_parent()`` to ``cli.py``; every ``_build_<cmd>_parser`` inherits the flag via ``parents=[common]``. ``argus report --no-update-check`` (and any future subcommand) now works without "unrecognized arguments". Backwards compatible — ``argus scan --no-update-check`` still works.

No scanner protocol changes. No new optional deps. ``packaging`` is already pulled in transitively by ``flake8`` and ``yamllint`` so the install graph doesn't widen.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed

### Test Results
- New regression tests in ``argus/tests/test_update_check.py``:
  - ``test_cache_invalidated_when_installed_newer_than_cached`` (#174-1.1.a)
  - ``test_cache_returned_when_cached_newer_than_installed`` (the inverse — sanity check)
  - ``test_unparseable_latest_returns_false`` (#174-1.1.c)
  - ``test_packaging_missing_returns_false`` (#174-1.1.b) — monkey-patches ``builtins.__import__`` to simulate the missing-``packaging`` venv
  - ``test_uses_fresh_cache`` updated to pin ``__version__`` <= ``cached_latest`` so the new staleness guard doesn't fire
- ``docs/cli-reference.md`` regenerated via ``python -m scripts.ci.check_cli_docs --fix`` because every subcommand now advertises ``--no-update-check``.
- Local pytest: 3416 passed, 2 skipped. The 3 pre-existing browser-viewer failures on main (``test_export_hrefs_preserve_filters_and_sort``, ``test_invalid_severity_surfaces_quiet_hint``, ``test_renders_all_entries_with_no_filters``) are unrelated to this branch.
- Manual repro from the issue:
  ```
  /tmp/v/bin/argus report markdown --no-update-check    # accepted (was: error)
  argus scan --help | grep no-update-check              # still present
  argus report --help | grep no-update-check            # newly present
  ```

## Security Considerations
- [x] No security impact

### Security Details
N/A — UX fix only. The update-check helper already runs in a daemon thread with air-gap-friendly silent failure on network errors; this PR doesn't change that contract.

## AI Context Updates (.ai/)
- [x] N/A - No .ai/ updates needed (no components, scanners, or workflows changed; only fixes to existing CLI surface)

## Checklist
- [x] Code follows project style guidelines
- [x] All tests pass (modulo 3 pre-existing main-branch flakes in viewers/browser)
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**