### PR TITLE
feat(execution): per-upstream registry mirrors via registry_map (closes #178)

### DIFF
--- a/argus-config.schema.json
+++ b/argus-config.schema.json
@@ -162,7 +162,14 @@
         },
         "registry": {
           "type": "string",
-          "description": "Override the default container registry for private or air-gapped environments (e.g. 'registry.internal.corp/argus')."
+          "description": "Override the default container registry for private or air-gapped environments (e.g. 'registry.internal.corp/argus'). Flat host-swap \u2014 every image gets rewritten to '<registry>/<original-path>'. For setups where each proxy cache tracks a single upstream (Harbor / Artifactory / ECR), use 'registry_map' instead."
+        },
+        "registry_map": {
+          "type": "object",
+          "description": "Per-upstream registry mirrors. Keys are the upstream host (e.g. 'docker.io', 'ghcr.io', 'quay.io'); values are the mirror prefix to swap in. Wins over 'registry' on conflict. Unmapped upstreams fall through to 'registry' (if set) or the original reference. Recommended over 'registry' for Harbor / Artifactory / ECR proxy caches, which mirror a single upstream per project.",
+          "additionalProperties": {
+            "type": "string"
+          }
         },
         "pull_policy": {
           "type": "string",

--- a/argus/core/config.py
+++ b/argus/core/config.py
@@ -33,7 +33,20 @@ class ExecutionConfig:
     """
 
     backend: str = "auto"  # auto | local | docker
-    registry: str = ""  # override for private registries
+    # Single-mirror override (legacy). Every image gets rewritten to
+    # ``<registry>/<original-path>``. Adequate when one mirror proxies
+    # *every* upstream argus uses (Docker Hub + GHCR). For setups where
+    # each proxy cache tracks a single upstream — the default shape of
+    # Harbor / Artifactory / ECR — use ``registry_map`` instead.
+    registry: str = ""
+    # Per-upstream registry mirrors. Keyed by the upstream host the
+    # image originates from (``docker.io``, ``ghcr.io``, etc.); value
+    # is the mirror prefix to swap in. Resolves correctly across
+    # argus's mixed image set (Docker Hub + GHCR) without forcing
+    # users to populate a single Harbor project from two upstreams
+    # manually. ``registry_map`` wins on conflict with the flat
+    # ``registry`` setting (issue #178).
+    registry_map: dict = field(default_factory=dict)
     pull_policy: str = "if-not-present"  # always | if-not-present | never
     # Pre-warm container images in the background before scanning.
     # Off-by-default would penalise the common case (most users have
@@ -281,9 +294,16 @@ def _parse_execution_config(raw: dict | None) -> ExecutionConfig:
     if not isinstance(raw, dict):
         return ExecutionConfig()
 
+    raw_map = raw.get("registry_map") or {}
+    if not isinstance(raw_map, dict):
+        raw_map = {}
+    # Coerce values to strings so the engine can rely on a clean
+    # ``str -> str`` mapping without re-validating at each call site.
+    registry_map = {str(k): str(v) for k, v in raw_map.items() if v}
     return ExecutionConfig(
         backend=raw.get("backend", "auto"),
         registry=raw.get("registry", ""),
+        registry_map=registry_map,
         pull_policy=raw.get("pull_policy", "if-not-present"),
         prewarm_images=bool(raw.get("prewarm_images", True)),
         prewarm_workers=int(raw.get("prewarm_workers", 4)),

--- a/argus/core/engine.py
+++ b/argus/core/engine.py
@@ -36,6 +36,31 @@ class ScannerPreconditionError(RuntimeError):
     """
 
 
+def _split_upstream(image: str) -> tuple[str, str]:
+    """Split a container image reference into ``(upstream_host, path)``.
+
+    Docker's reference grammar treats the first slash-segment as a host
+    only when it contains a ``.`` or ``:`` (or equals ``localhost``);
+    otherwise the reference is treated as a bare Docker Hub repository.
+    The same heuristic drives both the legacy ``execution.registry``
+    rewrite and the per-upstream ``execution.registry_map`` lookup, so
+    both code paths agree on what ""upstream"" means for a given
+    reference (issue #178).
+
+    Examples:
+      ``aquasec/trivy:0.70.0``         -> (``docker.io``, ``aquasec/trivy:0.70.0``)
+      ``docker.io/aquasec/trivy:tag``  -> (``docker.io``, ``aquasec/trivy:tag``)
+      ``ghcr.io/google/osv-scanner@sha256:…`` ->
+                                       (``ghcr.io``, ``google/osv-scanner@sha256:…``)
+      ``quay.io/foo/bar:tag``          -> (``quay.io``, ``foo/bar:tag``)
+      ``localhost:5000/dev/img``       -> (``localhost:5000``, ``dev/img``)
+    """
+    first, sep, rest = image.partition("/")
+    if sep and ("." in first or ":" in first or first == "localhost"):
+        return first, rest
+    return "docker.io", image
+
+
 def _classify_pull_error(stderr: str) -> tuple[str, bool]:
     """Classify a docker/podman ``pull`` failure for human-readable
     logging and retry policy.
@@ -852,10 +877,43 @@ class ArgusEngine:
         return result.returncode == 0
 
     def _resolve_image(self, scanner) -> str:
-        """Resolve the full container image reference, applying registry override."""
+        """Resolve the full container image reference, applying registry override.
+
+        Resolution order (issue #178):
+
+        1. ``execution.registry_map`` — per-upstream mirror table. The
+           image's normalised upstream host (``docker.io`` for bare-name
+           references, otherwise the leading host segment) is looked up
+           in the map; on hit, the host is swapped for the mirror and
+           the path under it is preserved verbatim. Matches how Harbor /
+           Artifactory / ECR proxy-cache projects actually mirror
+           single upstreams.
+        2. ``execution.registry`` — flat single-mirror rewrite. Kept for
+           backwards compatibility and for shops with a single registry
+           proxying every upstream.
+        3. Original image reference, unchanged.
+
+        Tag and ``@sha256:`` digest pin always travel with the path so
+        content-addressable verification still gates the pull.
+        """
         image = getattr(scanner, "container_image", "")
         if not image:
             return ""
+
+        registry_map = getattr(self.config.execution, "registry_map", {}) or {}
+        if registry_map:
+            upstream, path = _split_upstream(image)
+            mirror = registry_map.get(upstream)
+            if mirror:
+                rewritten = f"{mirror.rstrip('/')}/{path}"
+                logger.debug(
+                    "Registry map: %s → %s (via %s)", image, rewritten, upstream,
+                )
+                return rewritten
+            # No map entry for this upstream — fall through to the legacy
+            # flat-registry path. A partial map (only ``docker.io`` set)
+            # therefore leaves GHCR pulls alone instead of silently
+            # double-rewriting them.
 
         registry = self.config.execution.registry
         if registry:

--- a/argus/core/schema.py
+++ b/argus/core/schema.py
@@ -108,6 +108,7 @@ _REPORTING_KEYS = {"formats", "severity_threshold", "output_dir"}
 _EXECUTION_KEYS = {
     "backend",
     "registry",
+    "registry_map",
     "pull_policy",
     "prewarm_images",
     "prewarm_workers",
@@ -545,6 +546,30 @@ def _validate_execution(path: str, data: Any) -> list[ConfigError]:
             f"Must be a boolean (true/false), got "
             f"{type(data['verify_image_signatures']).__name__}",
         ))
+
+    # Per-upstream registry mirrors — must be a mapping of str → str.
+    # Keys are upstream hosts (``docker.io``, ``ghcr.io``, …); values
+    # are mirror prefixes. Issue #178.
+    if "registry_map" in data:
+        rm = data["registry_map"]
+        if not isinstance(rm, dict):
+            errors.append(ConfigError(
+                f"{path}.registry_map",
+                f"Must be a mapping (upstream host -> mirror), got "
+                f"{type(rm).__name__}",
+            ))
+        else:
+            for k, v in rm.items():
+                if not isinstance(k, str) or not k:
+                    errors.append(ConfigError(
+                        f"{path}.registry_map",
+                        f"Keys must be non-empty strings, got {k!r}",
+                    ))
+                if not isinstance(v, str) or not v:
+                    errors.append(ConfigError(
+                        f"{path}.registry_map.{k}",
+                        f"Mirror must be a non-empty string, got {v!r}",
+                    ))
 
     return errors
 

--- a/argus/tests/test_engine.py
+++ b/argus/tests/test_engine.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from argus.core.config import ArgusConfig, ScannerConfig
-from argus.core.engine import ArgusEngine
+from argus.core.engine import ArgusEngine, _split_upstream
 from argus.core.models import Finding, ScanResult, Severity, ScanSummary
 
 
@@ -189,14 +189,64 @@ class TestArgusEngine:
         assert summary.results[0].total_count == 0
 
 
+class TestSplitUpstream:
+    """Pin the host-parsing heuristic that drives ``registry_map``
+    routing (issue #178). Mirrors Docker's reference grammar — the
+    first slash-segment is treated as a host only when it contains a
+    ``.`` / ``:`` or equals ``localhost``; otherwise the reference is
+    bare-name Docker Hub."""
+
+    def test_bare_name_routes_to_docker_io(self):
+        assert _split_upstream("aquasec/trivy:0.70.0") == (
+            "docker.io", "aquasec/trivy:0.70.0",
+        )
+
+    def test_explicit_docker_io_host_stripped(self):
+        assert _split_upstream("docker.io/aquasec/trivy:0.70.0") == (
+            "docker.io", "aquasec/trivy:0.70.0",
+        )
+
+    def test_ghcr_host_recognised(self):
+        assert _split_upstream("ghcr.io/google/osv-scanner:v2.3.6") == (
+            "ghcr.io", "google/osv-scanner:v2.3.6",
+        )
+
+    def test_digest_pin_travels_with_path(self):
+        # The digest must stay attached to the path for the rewritten
+        # reference to keep content-addressable verification.
+        upstream, path = _split_upstream(
+            "ghcr.io/google/osv-scanner:v2.3.6@sha256:deadbeef",
+        )
+        assert upstream == "ghcr.io"
+        assert path.endswith("@sha256:deadbeef")
+
+    def test_quay_io_routed_as_host(self):
+        assert _split_upstream("quay.io/foo/bar:tag") == (
+            "quay.io", "foo/bar:tag",
+        )
+
+    def test_localhost_with_port_recognised(self):
+        # ``localhost:5000/...`` is a common dev-loop registry shape
+        # — Docker's grammar special-cases ``localhost`` (no dots) so
+        # we match.
+        assert _split_upstream("localhost:5000/dev/img:latest") == (
+            "localhost:5000", "dev/img:latest",
+        )
+
+    def test_single_segment_treated_as_docker_io(self):
+        # No slash at all — ``redis:7`` is a Docker Hub library image.
+        assert _split_upstream("redis:7") == ("docker.io", "redis:7")
+
+
 class TestDockerExecutionBackend:
     """Test Docker execution fallback logic."""
 
-    def _make_engine(self, backend="auto", registry=""):
+    def _make_engine(self, backend="auto", registry="", registry_map=None):
         data = {
             "execution": {
                 "backend": backend,
                 "registry": registry,
+                "registry_map": registry_map or {},
             },
         }
         return ArgusEngine(ArgusConfig.from_dict(data))
@@ -318,6 +368,125 @@ class TestDockerExecutionBackend:
         engine = self._make_engine()
         scanner = MockScanner("container", container_image="")
         assert engine._resolve_image(scanner) == ""
+
+    # ──────────────────────────────────────────────────────────────
+    # registry_map — per-upstream mirroring (issue #178)
+    # ──────────────────────────────────────────────────────────────
+
+    def test_registry_map_routes_docker_hub_image(self):
+        """A bare-name Docker Hub image (``aquasec/trivy:tag``) resolves
+        through the ``docker.io`` mirror entry. The path under the
+        mirror preserves the upstream repo layout — matches how Harbor
+        proxy-cache projects actually mirror."""
+        engine = self._make_engine(registry_map={
+            "docker.io": "harbor.example.com/dockerhub-cache",
+            "ghcr.io": "harbor.example.com/ghcr-cache",
+        })
+        scanner = MockScanner("trivy", container_image="aquasec/trivy:0.70.0")
+        assert engine._resolve_image(scanner) == (
+            "harbor.example.com/dockerhub-cache/aquasec/trivy:0.70.0"
+        )
+
+    def test_registry_map_routes_ghcr_image_with_digest(self):
+        """GHCR image with ``@sha256:`` digest pin routes through the
+        ``ghcr.io`` mirror entry. The digest stays attached to the
+        rewritten path so content verification still gates the pull —
+        the same property that makes the existing flat-rewrite safe."""
+        engine = self._make_engine(registry_map={
+            "ghcr.io": "harbor.example.com/ghcr-cache",
+        })
+        scanner = MockScanner(
+            "osv",
+            container_image="ghcr.io/google/osv-scanner:v2.3.6@sha256:abc123",
+        )
+        assert engine._resolve_image(scanner) == (
+            "harbor.example.com/ghcr-cache/google/osv-scanner:v2.3.6@sha256:abc123"
+        )
+
+    def test_registry_map_unmapped_upstream_falls_back_to_legacy_registry(self):
+        """Partial map (``docker.io`` only) + legacy ``registry`` set
+        should mirror Docker Hub via the map and rewrite everything
+        else via the legacy flat-registry path. Closes the migration
+        gap for users moving from ``registry`` to ``registry_map``."""
+        engine = self._make_engine(
+            registry="harbor.example.com/fallback",
+            registry_map={
+                "docker.io": "harbor.example.com/dockerhub-cache",
+            },
+        )
+        # docker.io image routes through the map.
+        dh_scanner = MockScanner("trivy", container_image="aquasec/trivy:tag")
+        assert engine._resolve_image(dh_scanner) == (
+            "harbor.example.com/dockerhub-cache/aquasec/trivy:tag"
+        )
+        # ghcr.io image is NOT in the map — falls through to legacy.
+        ghcr_scanner = MockScanner(
+            "osv", container_image="ghcr.io/google/osv-scanner:v2.3.6",
+        )
+        assert engine._resolve_image(ghcr_scanner) == (
+            "harbor.example.com/fallback/google/osv-scanner:v2.3.6"
+        )
+
+    def test_registry_map_unmapped_with_no_legacy_leaves_image_untouched(self):
+        """``registry_map`` without a matching upstream and no legacy
+        ``registry`` returns the original reference. A partial map
+        must NOT silently break unmapped upstreams — issue #178."""
+        engine = self._make_engine(registry_map={
+            "docker.io": "harbor.example.com/dockerhub-cache",
+        })
+        scanner = MockScanner(
+            "osv", container_image="ghcr.io/google/osv-scanner:v2.3.6",
+        )
+        assert engine._resolve_image(scanner) == (
+            "ghcr.io/google/osv-scanner:v2.3.6"
+        )
+
+    def test_registry_map_wins_over_legacy_registry(self):
+        """Both ``registry`` and ``registry_map`` set, and the image's
+        upstream IS in the map → map wins. Existing single-mirror
+        users adopting ``registry_map`` for one upstream don't see
+        their legacy setting double-apply."""
+        engine = self._make_engine(
+            registry="harbor.example.com/legacy",
+            registry_map={
+                "ghcr.io": "harbor.example.com/ghcr-cache",
+            },
+        )
+        scanner = MockScanner(
+            "osv", container_image="ghcr.io/google/osv-scanner:v2.3.6",
+        )
+        assert engine._resolve_image(scanner) == (
+            "harbor.example.com/ghcr-cache/google/osv-scanner:v2.3.6"
+        )
+
+    def test_registry_map_handles_explicit_docker_io_host(self):
+        """``docker.io/aquasec/trivy:tag`` (explicit host) routes the
+        same way as the bare-name shorthand. Argus's pinned images use
+        bare-name, but third-party tooling sometimes writes the
+        explicit form."""
+        engine = self._make_engine(registry_map={
+            "docker.io": "harbor.example.com/dockerhub-cache",
+        })
+        scanner = MockScanner(
+            "trivy", container_image="docker.io/aquasec/trivy:0.70.0",
+        )
+        assert engine._resolve_image(scanner) == (
+            "harbor.example.com/dockerhub-cache/aquasec/trivy:0.70.0"
+        )
+
+    def test_registry_map_trailing_slash_on_mirror_normalised(self):
+        """A user-provided mirror with a trailing slash must not
+        produce a double-slash path — Docker tolerates it but Harbor
+        and a few other registries reject the malformed ref."""
+        engine = self._make_engine(registry_map={
+            "ghcr.io": "harbor.example.com/ghcr-cache/",
+        })
+        scanner = MockScanner(
+            "osv", container_image="ghcr.io/google/osv-scanner:v2.3.6",
+        )
+        assert engine._resolve_image(scanner) == (
+            "harbor.example.com/ghcr-cache/google/osv-scanner:v2.3.6"
+        )
 
     def test_docker_backend_no_image_raises(self):
         engine = self._make_engine(backend="docker")

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -359,7 +359,8 @@ Controls how scanner tools are executed — locally, in containers, or auto-dete
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
 | `backend` | string | `"auto"` | Execution backend: `auto`, `local`, or `docker`. |
-| `registry` | string | | Override the default container registry (e.g. `registry.internal.corp/argus`). |
+| `registry` | string | | Override the default container registry (e.g. `registry.internal.corp/argus`). Flat host-swap — every image gets rewritten to `<registry>/<original-path>`. For per-upstream mirrors (Harbor / Artifactory / ECR proxy caches), use `registry_map` instead. |
+| `registry_map` | map[string→string] | `{}` | Per-upstream registry mirrors, keyed by upstream host (`docker.io`, `ghcr.io`, `quay.io`, etc.). Wins over `registry` for any matching upstream; unmapped upstreams fall through to `registry` (if set) or the original reference. Recommended for proxy-cache setups where each project mirrors a single upstream. See [Container scanning → Per-upstream mirrors](troubleshooting/docker.md#image-pull-failures-registry-auth-rate-limits-air-gapped-ghes). |
 | `pull_policy` | string | `"if-not-present"` | Container image pull policy: `always`, `if-not-present`, or `never`. |
 | `prewarm_images` | boolean | `true` | Pull container images in the background during scan startup so scanners with cached images don't wait on the registry. Disable on metered connections. |
 | `prewarm_workers` | integer | `4` | Concurrency cap for the pre-warm thread pool. Lower for stricter registry rate-limits; higher only with first-class network. |

--- a/docs/troubleshooting/docker.md
+++ b/docs/troubleshooting/docker.md
@@ -226,6 +226,36 @@ preserves the original `<repo>/<image>:<tag>` shape, just swaps the registry
 host. See **GHES with private container registry** below for the full mirror
 playbook.
 
+**Fix — Harbor / Artifactory / ECR (per-upstream proxy caches).** The flat
+`execution.registry` setting assumes one mirror that proxies *every* upstream
+Argus uses. Proxy-cache projects on Harbor / Artifactory / ECR mirror a
+**single** upstream registry per project — so a `dockerhub-cache` project
+catches Argus's 9 Docker Hub images but can't serve the 7 GHCR ones (or
+vice versa). Use `execution.registry_map` to point each upstream at its
+corresponding mirror:
+
+```yaml
+execution:
+  registry_map:
+    docker.io: harbor.internal.corp/dockerhub-cache
+    ghcr.io:   harbor.internal.corp/ghcr-cache
+  pull_policy: if-not-present
+```
+
+Resolution rules:
+
+- The upstream host is the first slash-segment when it contains a `.` /
+  `:` (or equals `localhost`); otherwise the reference is treated as
+  bare-name `docker.io`.
+- The path under the mirror host preserves the upstream path verbatim
+  (e.g. `ghcr.io/google/osv-scanner:tag` → `<ghcr-mirror>/google/osv-scanner:tag`),
+  matching how Harbor proxy-caches lay out replicated content.
+- A partial map leaves unmapped upstreams alone — they fall through to
+  the legacy `execution.registry` setting (if set), then to the
+  original reference unchanged.
+- The `@sha256:` digest pin travels with the rewritten reference, so
+  content-addressable pull verification still gates the bytes.
+
 ---
 
 ## Network proxies inside the container


### PR DESCRIPTION
## Description
Closes #178. Unblocks air-gapped / proxy-cache setups where each Harbor / Artifactory / ECR project mirrors a single upstream registry.

The flat ``execution.registry`` setting assumes one mirror proxies every upstream Argus uses (docker.io + ghcr.io). That's not how proxy-cache projects actually work — each project tracks one upstream. A ``dockerhub-cache`` Harbor project catches Argus's 9 Docker Hub images but can't serve the 7 GHCR ones, because the proxy cache simply doesn't talk to GHCR. Reproduced live with a real user: gitleaks pulled cleanly, ``osv`` and ``opengrep`` 404'd from the dockerhub-cache and fell back to local execution.

## Changes Made
- [x] New feature
- [x] Updated documentation

### Details

**New YAML shape:**

```yaml
execution:
  registry_map:
    docker.io: harbor.internal.corp/dockerhub-cache
    ghcr.io:   harbor.internal.corp/ghcr-cache
```

**Resolution order** in ``argus/core/engine.py:_resolve_image``:

1. **``registry_map``** — split the image into ``(upstream, path)`` via the Docker reference grammar; look up upstream in the map. On hit, swap host and preserve the path verbatim (matches Harbor proxy-cache layout). Digest pin travels with the path so content verification still gates the pull.
2. **``registry``** (legacy flat-rewrite) — fallback for unmapped upstreams and for users who haven't migrated. **No behavior change for existing single-mirror setups.**
3. Original image unchanged.

The host-detection heuristic is a new module-level helper ``argus.core.engine._split_upstream`` — mirrors Docker's grammar (first slash-segment is a host only when it contains ``.`` / ``:`` or equals ``localhost``; otherwise bare-name ``docker.io``). Pinned in its own ``TestSplitUpstream`` test class so the parsing contract is exercised independently of engine routing.

**Files touched:**

| File | Change |
|------|--------|
| ``argus/core/config.py`` | ``ExecutionConfig.registry_map: dict`` + parser coerces to ``str -> str`` |
| ``argus/core/engine.py`` | ``_split_upstream`` helper + ``_resolve_image`` consults map first |
| ``argus/core/schema.py`` | ``registry_map`` added to ``_EXECUTION_KEYS`` + shape validation (must be ``str -> str``) |
| ``argus-config.schema.json`` | ``executionConfig.registry_map`` JSON Schema property |
| ``argus/tests/test_engine.py`` | ``TestSplitUpstream`` (7) + 7 new ``TestDockerExecutionBackend`` cases |
| ``docs/troubleshooting/docker.md`` | ""Per-upstream proxy caches"" subsection with Harbor recipe |
| ``docs/config-reference.md`` | ``registry_map`` row in the execution table |

No breaking changes; ``execution.registry`` continues to work exactly as before.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed

### Test Results

**New regression coverage** (14 new tests, all green):

``TestSplitUpstream``:
- ``test_bare_name_routes_to_docker_io``
- ``test_explicit_docker_io_host_stripped``
- ``test_ghcr_host_recognised``
- ``test_digest_pin_travels_with_path``
- ``test_quay_io_routed_as_host``
- ``test_localhost_with_port_recognised``
- ``test_single_segment_treated_as_docker_io``

``TestDockerExecutionBackend`` (additions):
- ``test_registry_map_routes_docker_hub_image``
- ``test_registry_map_routes_ghcr_image_with_digest``
- ``test_registry_map_unmapped_upstream_falls_back_to_legacy_registry``
- ``test_registry_map_unmapped_with_no_legacy_leaves_image_untouched``
- ``test_registry_map_wins_over_legacy_registry``
- ``test_registry_map_handles_explicit_docker_io_host``
- ``test_registry_map_trailing_slash_on_mirror_normalised``

**Manual validation:**

```yaml
# argus.yml
execution:
  registry_map:
    docker.io: harbor.example.com/dockerhub-cache
    ghcr.io: harbor.example.com/ghcr-cache
```

```
$ argus validate
✅ valid

# Bad shape (list instead of map):
$ argus validate
❌ [ERROR] execution.registry_map: Must be a mapping (upstream host -> mirror), got list
```

**Full suite:** 3427 passed, 2 skipped. The 3 known pre-existing browser-viewer failures (``test_export_hrefs_preserve_filters_and_sort``, ``test_invalid_severity_surfaces_quiet_hint``, ``test_renders_all_entries_with_no_filters``) are unrelated to this branch.

## Security Considerations
- [x] Security enhancement (defensive)

### Security Details
The ``@sha256:`` digest pin travels with the rewritten reference, so content-addressable pull verification still gates the bytes against the same hash regardless of which mirror serves them. A malicious mirror substituting different content would fail the runtime's content check just as with the current flat-rewrite. Schema-level shape validation (must be ``str -> str``) prevents config-injection patterns like passing arbitrary structures into the mirror lookup.

## AI Context Updates (.ai/)
- [x] N/A — config field addition, no architectural / workflow / decision-level change

## Checklist
- [x] Code follows project style guidelines
- [x] All tests pass (modulo 3 pre-existing main-branch flakes in viewers/browser)
- [x] Documentation updated (config-reference.md + troubleshooting/docker.md)
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**