### PR TITLE
fix(config): reject duplicate keys in argus.yml at load time (closes #177)

### DIFF
--- a/.ai/errors.yaml
+++ b/.ai/errors.yaml
@@ -119,6 +119,49 @@ error_patterns:
           how: "fail_on_severity: critical reduces findings count"
 
   # ==============================================================================
+  # CONFIGURATION ERRORS
+  # ==============================================================================
+
+  - pattern: "Invalid YAML.*found duplicate key"
+    category: configuration
+    context: |
+      argus.yml has the same mapping key defined twice (e.g. two
+      ``execution:`` blocks, or ``enabled`` listed twice under one
+      scanner). PyYAML's default loader silently keeps the last
+      value; argus's strict loader rejects the file at load time
+      so the user's earlier settings can't be silently dropped.
+
+    root_cause: |
+      A YAML mapping can only legally have each key once. When the
+      same key appears twice at the same nesting level — at the
+      top of argus.yml, inside ``scanners.<name>``, anywhere — the
+      second occurrence overrides the first. Pre-fix behavior:
+      validation passed, scan silently used only the second
+      definition. Post-fix behavior: argus.core.config's
+      StrictSafeLoader raises a YAMLError naming the duplicated
+      key and the line of the second occurrence.
+
+    solution:
+      steps:
+        - "Open the file at the line named in the error message"
+        - "Merge the two blocks into one — choose which value should win, write it once"
+        - "Re-run ``argus validate`` to confirm"
+      example: |
+        # WRONG — silently drops the registry setting
+        execution:
+          registry: registry.internal.corp/argus
+          backend: docker
+        execution:
+          backend: docker
+
+        # RIGHT — single block
+        execution:
+          registry: registry.internal.corp/argus
+          backend: docker
+
+    reference: "argus/core/config.py::StrictSafeLoader"
+
+  # ==============================================================================
   # CONTAINER SCANNING ERRORS
   # ==============================================================================
 

--- a/argus/cli.py
+++ b/argus/cli.py
@@ -1527,8 +1527,9 @@ def _load_container_config(args: argparse.Namespace) -> dict:
     if config_path:
         try:
             import yaml
+            from argus.core.config import load_strict_yaml
             with open(config_path, "r", encoding="utf-8") as fh:
-                file_config = yaml.safe_load(fh) or {}
+                file_config = load_strict_yaml(fh) or {}
         except FileNotFoundError as exc:
             raise ValueError(f"Config file not found: {config_path}") from exc
         except yaml.YAMLError as exc:
@@ -3170,7 +3171,8 @@ def cmd_validate(args: argparse.Namespace) -> int:
         return EXIT_ERROR
 
     try:
-        data = yaml.safe_load(raw_text)
+        from argus.core.config import load_strict_yaml
+        data = load_strict_yaml(raw_text)
     except yaml.YAMLError as exc:
         print(f"Invalid YAML in {config_path}: {exc}", file=sys.stderr)
         return EXIT_ERROR

--- a/argus/core/config.py
+++ b/argus/core/config.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional
+from typing import Optional, IO, Union
 
 import yaml
 
@@ -10,6 +10,78 @@ from .models import Severity
 
 
 _DEFAULT_CONFIG_NAMES = ["argus.yml", "argus.yaml", ".argus.yml", ".argus.yaml"]
+
+
+class StrictSafeLoader(yaml.SafeLoader):
+    """``yaml.SafeLoader`` that rejects duplicate mapping keys.
+
+    PyYAML's default mapping constructor silently keeps only the last
+    value when a key is duplicated. For argus.yml that means a
+    second ``execution:`` block (or any other accidental
+    duplication, at any nesting level) overwrites the user's earlier
+    settings — the schema validator never sees the conflict and
+    happily reports the config valid.
+
+    This loader catches the duplication at parse time so the user
+    gets a clear error naming the duplicated key and the line where
+    the second occurrence sits. Same constructor override applies
+    at every nesting level because PyYAML calls
+    ``construct_mapping`` for every mapping node it encounters,
+    not just the root.
+    """
+
+
+def _construct_mapping_strict(loader: yaml.SafeLoader, node, deep: bool = False) -> dict:
+    """Mapping constructor that raises on the second occurrence of a key.
+
+    Line numbers are 1-indexed in the error so they match what the
+    user sees in their editor; PyYAML's internal ``start_mark.line``
+    is 0-indexed.
+    """
+    if not isinstance(node, yaml.MappingNode):
+        raise yaml.constructor.ConstructorError(
+            None, None,
+            f"expected a mapping node, but found {node.id}",
+            node.start_mark,
+        )
+    mapping: dict = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        try:
+            hash(key)
+        except TypeError as exc:
+            raise yaml.constructor.ConstructorError(
+                "while constructing a mapping", node.start_mark,
+                f"found unhashable key ({exc})", key_node.start_mark,
+            )
+        if key in mapping:
+            raise yaml.constructor.ConstructorError(
+                "while constructing a mapping", node.start_mark,
+                f"found duplicate key {key!r} "
+                f"(line {key_node.start_mark.line + 1}, "
+                f"column {key_node.start_mark.column + 1})",
+                key_node.start_mark,
+            )
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+StrictSafeLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    _construct_mapping_strict,
+)
+
+
+def load_strict_yaml(stream: Union[str, IO]) -> object:
+    """Parse YAML with duplicate-key detection.
+
+    Drop-in replacement for ``yaml.safe_load`` that uses
+    ``StrictSafeLoader``. Raises ``yaml.constructor.ConstructorError``
+    when a duplicate mapping key is encountered at any nesting level;
+    callers that already catch ``yaml.YAMLError`` (the base class)
+    pick up the new failure mode for free with no try/except changes.
+    """
+    return yaml.load(stream, Loader=StrictSafeLoader)
 
 
 @dataclass
@@ -140,11 +212,10 @@ class ArgusConfig:
         """
         try:
             from argus.init import detect_project, generate_config
-            import yaml as _yaml
 
             signals = detect_project(Path("."))
             config_text = generate_config(signals)
-            data = _yaml.safe_load(config_text)
+            data = load_strict_yaml(config_text)
             if isinstance(data, dict):
                 return cls.from_dict(data)
         except Exception:
@@ -188,8 +259,16 @@ class ArgusConfig:
     @classmethod
     def _load_file(cls, path: Path) -> "ArgusConfig":
         """Read, validate, and parse a YAML config file."""
-        with open(path, "r", encoding="utf-8") as fh:
-            data = yaml.safe_load(fh)
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                data = load_strict_yaml(fh)
+        except yaml.YAMLError as exc:
+            # Covers ConstructorError raised by load_strict_yaml on
+            # duplicate keys plus any other PyYAML parse failure. Wrap
+            # in ValueError so the caller's existing
+            # "invalid argus config" handling path catches it,
+            # without a bare PyYAML traceback leaking to the user.
+            raise ValueError(f"Invalid YAML in {path}: {exc}") from exc
         if not isinstance(data, dict):
             return cls()
 

--- a/argus/tests/test_config.py
+++ b/argus/tests/test_config.py
@@ -240,3 +240,113 @@ class TestExecutionConfig:
         config = ArgusConfig.load(config_file)
         assert config.execution.backend == "local"
         assert config.execution.pull_policy == "never"
+
+
+# ───────────────────────────────────────────────
+# Strict YAML loader — duplicate-key detection (#177)
+# ───────────────────────────────────────────────
+#
+# PyYAML's default mapping constructor silently keeps the last value
+# when a key is duplicated. For argus.yml that means a second
+# ``execution:`` block (or any other accidental duplication at any
+# nesting level) overwrites the user's earlier settings — the schema
+# validator never sees the conflict and reports the config valid.
+# load_strict_yaml catches the duplication at parse time.
+
+
+class TestStrictYamlLoaderRejectsDuplicateKeys:
+    """``load_strict_yaml`` raises a YAMLError on any duplicate key."""
+
+    def test_top_level_duplicate_raises(self):
+        from argus.core.config import load_strict_yaml
+        import yaml
+
+        text = (
+            "version: \"1.0\"\n"
+            "execution:\n"
+            "  registry: registry.internal.corp/argus\n"
+            "  backend: docker\n"
+            "execution:\n"
+            "  backend: docker\n"
+        )
+        with pytest.raises(yaml.YAMLError) as excinfo:
+            load_strict_yaml(text)
+        # Message must name the duplicated key + the line of the
+        # second occurrence so the user can find it in their editor.
+        msg = str(excinfo.value)
+        assert "duplicate key 'execution'" in msg
+        assert "line 5" in msg
+
+    def test_nested_duplicate_raises(self):
+        # The same constructor override applies at every nesting
+        # level — PyYAML calls construct_mapping for every mapping
+        # node, not just the root.
+        from argus.core.config import load_strict_yaml
+        import yaml
+
+        text = (
+            "scanners:\n"
+            "  bandit:\n"
+            "    enabled: true\n"
+            "    enabled: false\n"
+        )
+        with pytest.raises(yaml.YAMLError) as excinfo:
+            load_strict_yaml(text)
+        msg = str(excinfo.value)
+        assert "duplicate key 'enabled'" in msg
+        assert "line 4" in msg
+
+    def test_unique_keys_load_normally(self):
+        # Regression guard: the strict loader must NOT change behavior
+        # for well-formed config — same dict the default safe_load
+        # would have produced.
+        from argus.core.config import load_strict_yaml
+
+        text = (
+            "version: \"1.0\"\n"
+            "scanners:\n"
+            "  bandit:\n"
+            "    enabled: true\n"
+            "  gitleaks:\n"
+            "    enabled: false\n"
+            "execution:\n"
+            "  backend: docker\n"
+        )
+        data = load_strict_yaml(text)
+        assert data["version"] == "1.0"
+        assert data["scanners"]["bandit"]["enabled"] is True
+        assert data["scanners"]["gitleaks"]["enabled"] is False
+        assert data["execution"]["backend"] == "docker"
+
+    def test_argus_config_load_surfaces_duplicate_as_value_error(
+        self, tmp_path,
+    ):
+        # End-to-end: ArgusConfig.load wraps the YAMLError in a clean
+        # ValueError that names the file so the user can pin the
+        # error without seeing a PyYAML traceback.
+        config_file = tmp_path / "argus.yml"
+        config_file.write_text(
+            "version: \"1.0\"\n"
+            "execution:\n"
+            "  backend: docker\n"
+            "execution:\n"
+            "  backend: local\n"
+        )
+        with pytest.raises(ValueError) as excinfo:
+            ArgusConfig.load(config_file)
+        msg = str(excinfo.value)
+        assert "Invalid YAML" in msg
+        assert str(config_file) in msg
+        assert "duplicate key 'execution'" in msg
+
+    def test_unhashable_key_is_reported_not_silently_ignored(self):
+        # Defensive guard for an exotic case: a mapping key that
+        # isn't hashable (e.g. a flow-style list used as a key) would
+        # crash the default constructor with a confusing TypeError.
+        # The strict loader reports it as a normal YAML error.
+        from argus.core.config import load_strict_yaml
+        import yaml
+
+        text = "? [a, b]\n: value\n"
+        with pytest.raises(yaml.YAMLError):
+            load_strict_yaml(text)


### PR DESCRIPTION
## Description

PyYAML's default mapping constructor silently keeps the last value when a mapping key is duplicated. argus.yml was loaded via plain `yaml.safe_load`, so a second `execution:` block (or any duplicated nested key like a repeated `enabled:` under one scanner) silently overwrote the user's earlier settings — and because the schema validator only saw the post-merge dict, it had no way to flag the conflict. The validator's whole job is to surface this kind of thing.

## Changes Made

- [x] Fixed bug

### Details

New `argus.core.config.StrictSafeLoader` subclasses `yaml.SafeLoader` and overrides the mapping constructor to raise `yaml.constructor.ConstructorError` when the same key appears twice in a mapping. Because PyYAML calls `construct_mapping` for every mapping node, the override applies at any nesting depth without recursion bookkeeping — top-level `execution:` duplicates AND nested `scanners.bandit.enabled` duplicates both get caught.

A public `load_strict_yaml(stream)` helper wraps `yaml.load(..., Loader=StrictSafeLoader)` as a drop-in replacement for `yaml.safe_load`. Plumbed at all four call sites that read `argus.yml`-shaped YAML:

| Call site | Path |
|---|---|
| Explicit config-file load | `argus/core/config.py::ArgusConfig._load_file` |
| Auto-detected/generated config | `argus/core/config.py::ArgusConfig._auto_detect_config` |
| Container subcommand config | `argus/cli.py::_load_container_config` |
| `argus validate` subcommand | `argus/cli.py::cmd_validate` |

`ConstructorError` is a subclass of `yaml.YAMLError`, so the three call sites that already wrap the load in `except yaml.YAMLError` (container subcommand, validate subcommand) pick up the new failure mode with no try/except changes. `_load_file` had no error handling at all (would have crashed with a bare PyYAML traceback); added a clean `ValueError` wrapper that includes the file path so the caller's "Invalid argus config" path catches it.

**Note on JSON-Schema validation:** argus already validates against a schema (`argus-config.schema.json` + `argus/core/schema.py::validate_config`). That layer can't see duplicates because PyYAML collapses them before the validator sees the dict — strict YAML loading is the only layer where the duplication is observable. Schema validation continues handling structural shape; the strict loader handles parser-level integrity. Complementary, not substitutes.

**Breaking changes:** an argus.yml that was previously silently dropping a duplicated block will now fail at load time. That's the intended behavior — the silent drop was the bug — but anyone with an existing config that happens to have a duplicate (which would have been silently mis-applied) will need to merge their blocks before the next scan.

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed

### Test Results

```
$ python -m pytest argus/tests/test_config.py argus/tests/test_cli.py argus/tests/test_cli_container.py argus/tests/test_container_scanner_runners.py argus/tests/test_container_scanner.py --no-cov -q
============================= 272 passed in 10.97s =============================

$ python -m pytest argus/tests/ --no-cov -q --ignore=argus/tests/test_e2e_container_scan.py --ignore=argus/tests/test_e2e_dast.py
2047 passed across the SDK; 8 pre-existing failures in test_mcp_architecture_resource.py + 3 in viewers/browser, all unrelated to this PR
```

Manual repro of the user-reported scenario:

```
$ argus validate --config /tmp/dup-keys.yml
Invalid YAML in /tmp/dup-keys.yml: while constructing a mapping
  in "<unicode string>", line 1, column 1:
    version: "1.0"
    ^
found duplicate key 'execution' (line 11, column 1)
  in "<unicode string>", line 11, column 1:
    execution:
    ^
exit=2
```

New tests in `argus/tests/test_config.py::TestStrictYamlLoaderRejectsDuplicateKeys`:
- `test_top_level_duplicate_raises` — two `execution:` keys → YAMLError naming the key + line of the second occurrence
- `test_nested_duplicate_raises` — `enabled: true` then `enabled: false` under one scanner → caught
- `test_unique_keys_load_normally` — regression guard that well-formed config still parses identically
- `test_argus_config_load_surfaces_duplicate_as_value_error` — end-to-end: `ArgusConfig.load` wraps the YAMLError in a clean ValueError naming the file
- `test_unhashable_key_is_reported_not_silently_ignored` — defensive guard for the exotic flow-style-list-as-key case

## Security Considerations

- [x] Security enhancement (validation strictness)

### Security Details

Pre-fix behavior was a silent-failure class: an operator copy-pasted a registry override into a second `execution:` block, the second block (without the override) silently won, and the resulting scan pulled from the wrong registry without ever telling them. The fix surfaces the misconfiguration before any scan runs.

## AI Context Updates (.ai/)

- [x] `.ai/errors.yaml` updated — new `Invalid YAML.*found duplicate key` pattern with the wrong-vs-right config example, mapped to the StrictSafeLoader as the reference.

Other `.ai/` files don't need changes: this is a validator-tightening fix, not an architectural decision, new component, or new workflow.

## Checklist

- [x] Code follows project style guidelines
- [x] All tests pass (272 in directly-affected files, 2047 across the SDK)
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues

Closes #177.