### PR TITLE
fix(supply-chain): treat empty scanner output as zero findings, not parse error

### DIFF
--- a/argus/scanners/supply_chain.py
+++ b/argus/scanners/supply_chain.py
@@ -131,7 +131,17 @@ class SupplyChainScanner:
         For explicit parsing, use parse_zizmor_results or
         parse_actionlint_results directly.
         """
-        data = json.loads(raw_output_path.read_text(encoding="utf-8", errors="replace"))
+        text = raw_output_path.read_text(encoding="utf-8", errors="replace").strip()
+        # Empty / whitespace-only output is the "no findings" case for
+        # both sub-tools (zizmor with a clean workflow set, actionlint
+        # short-circuited because no workflows exist). Without this
+        # guard ``json.loads('')`` raises ``Expecting value: line 1
+        # column 1`` and the engine surfaces it as a misleading
+        # "parser couldn't interpret it" warning when the scanner
+        # actually ran cleanly.
+        if not text:
+            return []
+        data = json.loads(text)
 
         # SARIF format (zizmor)
         if "$schema" in data or "runs" in data:
@@ -145,7 +155,10 @@ class SupplyChainScanner:
 
     def parse_zizmor_results(self, raw_output_path: Path) -> list[Finding]:
         """Parse zizmor SARIF output into findings."""
-        data = json.loads(raw_output_path.read_text(encoding="utf-8", errors="replace"))
+        text = raw_output_path.read_text(encoding="utf-8", errors="replace").strip()
+        if not text:
+            return []
+        data = json.loads(text)
         findings: list[Finding] = []
 
         for run in data.get("runs", []):
@@ -162,7 +175,10 @@ class SupplyChainScanner:
         self, raw_output_path: Path
     ) -> list[Finding]:
         """Parse actionlint JSON output into findings."""
-        data = json.loads(raw_output_path.read_text(encoding="utf-8", errors="replace"))
+        text = raw_output_path.read_text(encoding="utf-8", errors="replace").strip()
+        if not text:
+            return []
+        data = json.loads(text)
         if not isinstance(data, list):
             return []
 

--- a/argus/tests/scanners/test_supply_chain.py
+++ b/argus/tests/scanners/test_supply_chain.py
@@ -246,3 +246,52 @@ class TestSupplyChainContainerArgs:
         assert isinstance(args, list)
         assert len(args) == 1
         assert "zizmor" in args[0]
+
+
+# ───────────────────────────────────────────────
+# Empty / whitespace-only output handling
+# ───────────────────────────────────────────────
+#
+# When zizmor finds no issues on a clean workflow set, or actionlint
+# short-circuits because no workflow files exist, the sub-tool can
+# write an empty or whitespace-only file. Without the guard,
+# ``json.loads('')`` raises ``Expecting value: line 1 column 1`` and
+# the engine surfaces it as a misleading "parser couldn't interpret
+# it" warning when the scanner actually ran cleanly.
+
+
+class TestSupplyChainEmptyOutput:
+    """All three parse entry points must treat empty output as zero findings."""
+
+    def test_parse_results_empty_file_returns_no_findings(self, tmp_path):
+        empty = tmp_path / "supply-chain-results.json"
+        empty.write_text("")
+        assert SupplyChainScanner().parse_results(empty) == []
+
+    def test_parse_results_whitespace_only_returns_no_findings(self, tmp_path):
+        # ``json.loads('   \n')`` raises the same JSONDecodeError as the
+        # empty case — strip-then-check is what makes both safe.
+        ws = tmp_path / "supply-chain-results.json"
+        ws.write_text("   \n\n  \t  \n")
+        assert SupplyChainScanner().parse_results(ws) == []
+
+    def test_parse_zizmor_results_empty_file_returns_no_findings(self, tmp_path):
+        empty = tmp_path / "zizmor-results.json"
+        empty.write_text("")
+        assert SupplyChainScanner().parse_zizmor_results(empty) == []
+
+    def test_parse_actionlint_results_empty_file_returns_no_findings(self, tmp_path):
+        empty = tmp_path / "actionlint-results.json"
+        empty.write_text("")
+        assert SupplyChainScanner().parse_actionlint_results(empty) == []
+
+    def test_non_empty_malformed_json_still_raises(self, tmp_path):
+        # Regression guard: the empty-string guard must NOT swallow
+        # genuine parse failures. A non-empty file with garbage content
+        # is a real bug (truncated output, schema drift, etc.) and the
+        # engine's "scanner produced output but the parser couldn't
+        # interpret it" warning is the right response in that case.
+        bad = tmp_path / "supply-chain-results.json"
+        bad.write_text("{not-valid-json")
+        with pytest.raises(json.JSONDecodeError):
+            SupplyChainScanner().parse_results(bad)


### PR DESCRIPTION
## Description

When zizmor finds no issues on a clean workflow set, or actionlint short-circuits because no workflow files exist, the sub-tool writes an empty (or whitespace-only) file. `argus/scanners/supply_chain.py`'s three parse entry points all called `json.loads()` directly with no guard, so an empty file raised `json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)`. The engine catches that at `argus/core/engine.py::1295` and surfaces it as a misleading "scanner produced output but the parser couldn't interpret it" warning — even though the scanner actually ran cleanly and just had nothing to report.

This is the same shape as `argus/scanners/osv.py` already handles correctly at line 107; supply-chain was just missing the guard.

## Changes Made

- [x] Fixed bug

### Details

Three call sites in `argus/scanners/supply_chain.py` get a strip-and-check guard before `json.loads()`:

| Method | Line | Behavior |
|---|---|---|
| `parse_results` | 128 | Combined entry (auto-detects SARIF vs JSON-array) |
| `parse_zizmor_results` | 146 | SARIF format from zizmor |
| `parse_actionlint_results` | 161 | JSON-array format from actionlint |

All three now read, strip, and return `[]` cleanly when the file is empty or whitespace-only. Non-empty malformed input still raises `JSONDecodeError` — the engine's "parser couldn't interpret it" warning is the right response there (real schema drift, truncated output, etc.) and the empty-string guard mustn't swallow it.

Pattern mirrors `argus/scanners/osv.py::104-108`, which already handles this case the same way.

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed

### Test Results

```
$ python -m pytest argus/tests/scanners/test_supply_chain.py --no-cov -q
============================== 23 passed in 0.04s ==============================
```

Manual repro of the user-reported symptom (empty supply-chain output → `Expecting value: line 1 column 1`):

```
$ python -c "
from pathlib import Path; import tempfile
from argus.scanners.supply_chain import SupplyChainScanner
with tempfile.TemporaryDirectory() as d:
    p = Path(d) / 'empty.json'
    p.write_text('')
    print('findings:', SupplyChainScanner().parse_results(p))
"
findings: []                      # was: json.decoder.JSONDecodeError → engine warning
```

New tests in `TestSupplyChainEmptyOutput`:

- `test_parse_results_empty_file_returns_no_findings` — combined entry on a 0-byte file
- `test_parse_results_whitespace_only_returns_no_findings` — combined entry on `"   \n\n  \t  \n"`
- `test_parse_zizmor_results_empty_file_returns_no_findings` — SARIF entry directly
- `test_parse_actionlint_results_empty_file_returns_no_findings` — actionlint entry directly
- `test_non_empty_malformed_json_still_raises` — regression guard that genuine parse failures still surface

## Security Considerations

- [x] No security impact

The fix changes a false-positive warning into a correct "no findings" result. No new code path executes, no input is now trusted that wasn't trusted before, no scanner output bypasses validation. Malformed-but-non-empty output still raises, which is the correct behavior.

## AI Context Updates (.ai/)

- [x] N/A — internal scanner-parser change. No new components, decisions, workflows, or commands. The "Expecting value" warning pattern is generic enough that the existing engine-level error path in `.ai/errors.yaml` already covers the user-facing diagnostic; no new entry needed.

## Checklist

- [x] Code follows project style guidelines
- [x] All tests pass (23 in the directly-affected file)
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues

Reported by @eFAILution: supply-chain scanner output empty + argus warning "expected value line 1 column 1". This PR brings supply-chain's parsers to parity with osv.py's already-correct empty-output handling.