### PR TITLE
fix(container): honor execution.registry/registry_map for sub-scanner image pulls (closes #186)

### DIFF
--- a/argus/cli.py
+++ b/argus/cli.py
@@ -1560,6 +1560,23 @@ def _load_container_config(args: argparse.Namespace) -> dict:
         if isinstance(reporting_section, dict) and "keep_raw" in reporting_section:
             config["_reporting_keep_raw"] = bool(reporting_section["keep_raw"])
 
+        # Plumb ``execution.registry`` and ``execution.registry_map``
+        # through to the container engine so the Trivy/Grype/Syft sub-
+        # scanner image pulls honor the operator's mirror policy. Same
+        # synthetic-key pattern as ``_reporting_keep_raw`` above.
+        # Without this, the source-scan path correctly routes through
+        # ArgusEngine._resolve_image but ``argus scan container`` pulls
+        # raw upstream refs regardless of config (#186).
+        execution_section = file_config.get("execution", {})
+        if isinstance(execution_section, dict):
+            if execution_section.get("registry"):
+                config["_execution_registry"] = str(execution_section["registry"])
+            raw_map = execution_section.get("registry_map") or {}
+            if isinstance(raw_map, dict) and raw_map:
+                config["_execution_registry_map"] = {
+                    str(k): str(v) for k, v in raw_map.items() if v
+                }
+
         # Back-compat: registry credentials are documented under
         # ``scanners.container.*`` in argus.example.yml and were the
         # only home for them before container-scan grew first-class

--- a/argus/container/scanner.py
+++ b/argus/container/scanner.py
@@ -267,6 +267,35 @@ def _redact_cmd_for_log(cmd: list[str]) -> str:
             safe.append(token)
     return " ".join(safe)
 
+
+def _resolve_sub_scanner_image(image_ref: str, config: dict | None) -> str:
+    """Apply ``execution.registry`` / ``execution.registry_map`` rewrites
+    to a sub-scanner image reference (Trivy / Grype / Syft).
+
+    The source-scan engine already routes through
+    ``ArgusEngine._resolve_image`` for the same effect, but the
+    container-scan path used to pull raw upstream refs regardless of
+    config. This helper reads the synthetic keys
+    ``_execution_registry`` / ``_execution_registry_map`` stashed by
+    ``argus.cli._load_container_config`` and delegates to the shared
+    pure-function resolver — same algorithm, same logging shape,
+    same back-compat fallthrough.
+
+    Returns the original ``image_ref`` unchanged when no mirror config
+    is in play, so the no-mirror case sees zero behavior change.
+    Issue #186.
+    """
+    if not image_ref or not config:
+        return image_ref
+    from argus.core.engine import resolve_image_ref
+
+    return resolve_image_ref(
+        image_ref,
+        registry=config.get("_execution_registry"),
+        registry_map=config.get("_execution_registry_map"),
+    )
+
+
 # Shared parser instance — reuses ContainerScanner's parsing logic
 _parser = ContainerScanner()
 
@@ -702,7 +731,7 @@ def _run_trivy(
         from argus import container_runtime
         from argus.containers import get_image
 
-        image = get_image("trivy")
+        image = _resolve_sub_scanner_image(get_image("trivy"), config)
         if not image or not container_runtime.is_available():
             logger.warning("trivy not available (local or container) — skipping")
             return []
@@ -721,7 +750,7 @@ def _run_trivy(
         from argus.containers import get_image
 
         rt = container_runtime.runtime_cmd()
-        image = get_image("trivy")
+        image = _resolve_sub_scanner_image(get_image("trivy"), config)
 
         # Mount docker.sock when scanning local images so trivy can
         # see images on the host daemon
@@ -811,7 +840,7 @@ def _run_grype(
         from argus import container_runtime
         from argus.containers import get_image
 
-        image = get_image("grype")
+        image = _resolve_sub_scanner_image(get_image("grype"), config)
         if not image or not container_runtime.is_available():
             logger.warning("grype not available (local or container) — skipping")
             return []
@@ -856,7 +885,7 @@ def _run_grype(
         from argus.containers import get_image
 
         rt = container_runtime.runtime_cmd()
-        image = get_image("grype")
+        image = _resolve_sub_scanner_image(get_image("grype"), config)
 
         # Mount docker.sock when scanning local images
         vol_args = _container_vol_args(tmp_path, "grype", mount_docker_sock=local)
@@ -941,7 +970,7 @@ def _run_syft(
         from argus import container_runtime
         from argus.containers import get_image
 
-        image = get_image("syft")
+        image = _resolve_sub_scanner_image(get_image("syft"), config)
         if not image or not container_runtime.is_available():
             logger.debug("syft not available (local or container) — skipping SBOM")
             return

--- a/argus/core/engine.py
+++ b/argus/core/engine.py
@@ -61,6 +61,62 @@ def _split_upstream(image: str) -> tuple[str, str]:
     return "docker.io", image
 
 
+def resolve_image_ref(
+    image: str,
+    registry: str | None = None,
+    registry_map: dict | None = None,
+) -> str:
+    """Apply ``execution.registry`` / ``execution.registry_map`` rewrites
+    to a container image reference. Pure function — shared by the
+    source-scan engine and the container-scan runners (issue #186).
+
+    Resolution order:
+
+    1. ``registry_map`` — per-upstream mirror table. The image's
+       normalised upstream host (``docker.io`` for bare-name refs,
+       otherwise the leading host segment) is looked up in the map;
+       on hit, the host is swapped for the mirror and the path under
+       it is preserved verbatim. Matches how Harbor / Artifactory /
+       ECR proxy-cache projects actually mirror single upstreams.
+    2. ``registry`` — flat single-mirror rewrite. Kept for
+       back-compat and for shops with one registry proxying every
+       upstream.
+    3. Original image reference, unchanged.
+
+    Tag and ``@sha256:`` digest pin always travel with the path so
+    content-addressable verification still gates the pull. Empty
+    ``image`` returns ``""`` unchanged so callers can pre-flight
+    optional refs without branching.
+    """
+    if not image:
+        return ""
+
+    if registry_map:
+        upstream, path = _split_upstream(image)
+        mirror = registry_map.get(upstream)
+        if mirror:
+            rewritten = f"{mirror.rstrip('/')}/{path}"
+            logger.debug(
+                "Registry map: %s → %s (via %s)", image, rewritten, upstream,
+            )
+            return rewritten
+        # No map entry for this upstream — fall through to the legacy
+        # flat-registry path. A partial map (only ``docker.io`` set)
+        # therefore leaves GHCR pulls alone instead of silently
+        # double-rewriting them.
+
+    if registry:
+        parts = image.split("/", 1)
+        if len(parts) == 2 and ("." in parts[0] or ":" in parts[0]):
+            rewritten = f"{registry}/{parts[1]}"
+        else:
+            rewritten = f"{registry}/{image}"
+        logger.debug("Registry override: %s → %s", image, rewritten)
+        return rewritten
+
+    return image
+
+
 def _classify_pull_error(stderr: str) -> tuple[str, bool]:
     """Classify a docker/podman ``pull`` failure for human-readable
     logging and retry policy.
@@ -877,54 +933,19 @@ class ArgusEngine:
         return result.returncode == 0
 
     def _resolve_image(self, scanner) -> str:
-        """Resolve the full container image reference, applying registry override.
+        """Resolve the full container image reference for a Scanner instance.
 
-        Resolution order (issue #178):
-
-        1. ``execution.registry_map`` — per-upstream mirror table. The
-           image's normalised upstream host (``docker.io`` for bare-name
-           references, otherwise the leading host segment) is looked up
-           in the map; on hit, the host is swapped for the mirror and
-           the path under it is preserved verbatim. Matches how Harbor /
-           Artifactory / ECR proxy-cache projects actually mirror
-           single upstreams.
-        2. ``execution.registry`` — flat single-mirror rewrite. Kept for
-           backwards compatibility and for shops with a single registry
-           proxying every upstream.
-        3. Original image reference, unchanged.
-
-        Tag and ``@sha256:`` digest pin always travel with the path so
-        content-addressable verification still gates the pull.
+        Thin wrapper around the module-level ``resolve_image_ref``
+        helper — see its docstring for the resolution order. Reads
+        ``container_image`` from the scanner attribute and applies the
+        ``execution.registry`` / ``execution.registry_map`` config from
+        this engine's ArgusConfig.
         """
-        image = getattr(scanner, "container_image", "")
-        if not image:
-            return ""
-
-        registry_map = getattr(self.config.execution, "registry_map", {}) or {}
-        if registry_map:
-            upstream, path = _split_upstream(image)
-            mirror = registry_map.get(upstream)
-            if mirror:
-                rewritten = f"{mirror.rstrip('/')}/{path}"
-                logger.debug(
-                    "Registry map: %s → %s (via %s)", image, rewritten, upstream,
-                )
-                return rewritten
-            # No map entry for this upstream — fall through to the legacy
-            # flat-registry path. A partial map (only ``docker.io`` set)
-            # therefore leaves GHCR pulls alone instead of silently
-            # double-rewriting them.
-
-        registry = self.config.execution.registry
-        if registry:
-            parts = image.split("/", 1)
-            if len(parts) == 2 and ("." in parts[0] or ":" in parts[0]):
-                image = f"{registry}/{parts[1]}"
-            else:
-                image = f"{registry}/{image}"
-            logger.debug("Registry override: %s", image)
-
-        return image
+        return resolve_image_ref(
+            getattr(scanner, "container_image", ""),
+            registry=self.config.execution.registry,
+            registry_map=getattr(self.config.execution, "registry_map", None),
+        )
 
     def _run_in_container(
         self, scanner, path: str, config: dict | None

--- a/argus/tests/test_cli_container.py
+++ b/argus/tests/test_cli_container.py
@@ -485,3 +485,86 @@ containers:
         config = _load_container_config(args)
         assert config["registry_username"] == "alice"
         assert config["registry_password"] == "s3cret"
+
+
+# =====================================================================
+# _load_container_config: plumbs execution.registry / registry_map (#186)
+# =====================================================================
+#
+# The source-scan path routes scanner-image pulls through the engine's
+# resolver, which reads ``execution.registry`` / ``execution.registry_map``
+# off ArgusConfig. The container-scan path doesn't see ArgusConfig at
+# all — it consumes the dict ``_load_container_config`` builds. Without
+# explicit plumbing, the operator's mirror policy was silently ignored
+# for every ``argus scan container`` invocation against a config with a
+# mirror. The fix stashes both fields under synthetic underscore keys
+# the same way ``_reporting_keep_raw`` is stashed.
+
+
+class TestLoadContainerConfigPlumbsExecutionRegistry:
+    """``execution.registry`` / ``registry_map`` reach the container config dict."""
+
+    def _write_config(self, tmp_path, body: str):
+        cfg = tmp_path / "argus.yml"
+        cfg.write_text(body)
+        return argparse.Namespace(
+            config=str(cfg),
+            images=None,
+            discover=None,
+            scanners=None,
+        )
+
+    def test_flat_registry_stashed_under_synthetic_key(self, tmp_path):
+        args = self._write_config(tmp_path, """
+execution:
+  registry: harbor.internal.corp/argus
+containers:
+  images:
+    - image: registry.example.com/app@sha256:abcd
+""")
+        config = _load_container_config(args)
+        assert config["_execution_registry"] == "harbor.internal.corp/argus"
+
+    def test_registry_map_stashed_under_synthetic_key(self, tmp_path):
+        args = self._write_config(tmp_path, """
+execution:
+  registry_map:
+    docker.io: harbor.internal.corp/dockerhub-cache
+    ghcr.io:   harbor.internal.corp/ghcr-cache
+containers:
+  images:
+    - image: registry.example.com/app@sha256:abcd
+""")
+        config = _load_container_config(args)
+        assert config["_execution_registry_map"] == {
+            "docker.io": "harbor.internal.corp/dockerhub-cache",
+            "ghcr.io":   "harbor.internal.corp/ghcr-cache",
+        }
+
+    def test_no_execution_block_no_synthetic_keys(self, tmp_path):
+        # Sanity: configs without an execution block stay clean — no
+        # synthetic empty values, no surprise dict entries that could
+        # confuse downstream lookups.
+        args = self._write_config(tmp_path, """
+containers:
+  images:
+    - image: registry.example.com/app@sha256:abcd
+""")
+        config = _load_container_config(args)
+        assert "_execution_registry" not in config
+        assert "_execution_registry_map" not in config
+
+    def test_empty_registry_map_not_stashed(self, tmp_path):
+        # An empty map (or one with only blank values) is functionally
+        # the same as no map — don't stash it. Avoids triggering the
+        # resolver's "map-is-set" branch on what is effectively a
+        # default config.
+        args = self._write_config(tmp_path, """
+execution:
+  registry_map: {}
+containers:
+  images:
+    - image: registry.example.com/app@sha256:abcd
+""")
+        config = _load_container_config(args)
+        assert "_execution_registry_map" not in config

--- a/argus/tests/test_container_scanner_runners.py
+++ b/argus/tests/test_container_scanner_runners.py
@@ -1308,3 +1308,177 @@ class TestRegistryAuthEnvWithImageRef:
         env = _registry_auth_env(config, image_ref=None)
         assert env["TRIVY_USERNAME"] == "alice"
         assert "ironbank-user" not in env.values()
+
+
+# ───────────────────────────────────────────────
+# execution.registry / registry_map plumbing (#186)
+# ───────────────────────────────────────────────
+#
+# The source-scan path routes scanner-image pulls through
+# ArgusEngine._resolve_image, which reads execution.registry /
+# registry_map from ArgusConfig. The container-scan path consumes a
+# dict (not ArgusConfig) and used to pull raw upstream refs regardless
+# of the operator's mirror policy. Fix: _load_container_config stashes
+# the execution.* values under synthetic underscore keys, and the
+# runners call _resolve_sub_scanner_image at every get_image() →
+# pull_image() site.
+
+
+class TestResolveSubScannerImage:
+    """Helper-level checks for the container-side resolver wrapper."""
+
+    def test_returns_unchanged_when_no_config(self):
+        from argus.container.scanner import _resolve_sub_scanner_image
+        assert _resolve_sub_scanner_image(
+            "aquasec/trivy:0.70.0", None,
+        ) == "aquasec/trivy:0.70.0"
+        assert _resolve_sub_scanner_image("aquasec/trivy:0.70.0", {}) == "aquasec/trivy:0.70.0"
+
+    def test_returns_unchanged_when_no_synthetic_keys_set(self):
+        # A config with creds / scanners / images but no
+        # _execution_registry* must NOT rewrite — back-compat guard
+        # for every operator that hasn't set up a mirror.
+        from argus.container.scanner import _resolve_sub_scanner_image
+        assert _resolve_sub_scanner_image(
+            "aquasec/trivy:0.70.0",
+            {"registry_username_env": "FOO", "images": []},
+        ) == "aquasec/trivy:0.70.0"
+
+    def test_applies_registry_map(self):
+        from argus.container.scanner import _resolve_sub_scanner_image
+        rewritten = _resolve_sub_scanner_image(
+            "aquasec/trivy:0.70.0",
+            {"_execution_registry_map": {"docker.io": "harbor.corp/dockerhub-cache"}},
+        )
+        assert rewritten == "harbor.corp/dockerhub-cache/aquasec/trivy:0.70.0"
+
+    def test_falls_back_to_flat_registry(self):
+        from argus.container.scanner import _resolve_sub_scanner_image
+        rewritten = _resolve_sub_scanner_image(
+            "ghcr.io/google/osv-scanner:v2.3.6",
+            {
+                "_execution_registry_map": {"docker.io": "harbor.corp/dockerhub-cache"},
+                "_execution_registry": "harbor.corp/argus",
+            },
+        )
+        # ghcr.io has no map entry → flat ``_execution_registry`` wins.
+        assert rewritten == "harbor.corp/argus/google/osv-scanner:v2.3.6"
+
+
+class TestRunTrivyUsesResolvedImage:
+    """The ``docker run`` cmd argv carries the mirror-rewritten image."""
+
+    def test_trivy_docker_run_uses_mapped_mirror(self, tmp_path, monkeypatch):
+        _force_container_path(monkeypatch, "trivy")
+        intercepted: list[list[str]] = []
+
+        def fake_run(cmd, **_kwargs):
+            intercepted.append(list(cmd))
+            (tmp_path / "trivy-results.json").write_text('{"Results": []}')
+            return _completed(returncode=0)
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+
+        # ``_force_container_path`` mocks get_image to return
+        # ``fake/trivy:test`` — a bare-name docker.io shape. The map
+        # routes docker.io to harbor.corp/dockerhub-cache, so the cmd
+        # should reference the mirror path.
+        _run_trivy(
+            "registry.example.com/myapp@sha256:" + "a" * 64,
+            tmp_path, local=False,
+            config={
+                "_execution_registry_map": {
+                    "docker.io": "harbor.corp/dockerhub-cache",
+                },
+            },
+        )
+
+        # DB pre-warm + scan = 2 invocations. BOTH must use the
+        # rewritten image — pulling the DB from upstream when the
+        # operator has a mirror configured would defeat the mirror.
+        assert len(intercepted) == 2
+        for cmd in intercepted:
+            joined = " ".join(cmd)
+            assert "harbor.corp/dockerhub-cache/fake/trivy:test" in joined
+            # The bare upstream form must NOT appear as the image
+            # positional — that's the pre-fix bug shape.
+            assert "fake/trivy:test " not in joined.replace(
+                "harbor.corp/dockerhub-cache/fake/trivy:test", "",
+            )
+
+    def test_trivy_unchanged_when_no_mirror_config(self, tmp_path, monkeypatch):
+        # Critical back-compat: configs without any execution.* synthetic
+        # key see the original ``fake/trivy:test`` ref unchanged.
+        _force_container_path(monkeypatch, "trivy")
+        intercepted: list[list[str]] = []
+
+        def fake_run(cmd, **_kwargs):
+            intercepted.append(list(cmd))
+            (tmp_path / "trivy-results.json").write_text('{"Results": []}')
+            return _completed(returncode=0)
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+        _run_trivy(
+            "library/nginx:latest",
+            tmp_path, local=False, config=None,
+        )
+
+        for cmd in intercepted:
+            joined = " ".join(cmd)
+            assert "fake/trivy:test" in joined
+            assert "harbor" not in joined  # no rewrite occurred
+
+
+class TestRunGrypeUsesResolvedImage:
+    """Grype's docker-run cmd honors the mirror config the same way Trivy does."""
+
+    def test_grype_docker_run_uses_mapped_mirror(self, tmp_path, monkeypatch):
+        _force_container_path(monkeypatch, "grype")
+        intercepted: list[list[str]] = []
+
+        def fake_run(cmd, **_kwargs):
+            intercepted.append(list(cmd))
+            (tmp_path / "grype-results.json").write_text('{"matches": []}')
+            return _completed(returncode=0)
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+        _run_grype(
+            "registry.example.com/myapp@sha256:" + "a" * 64,
+            tmp_path, local=False,
+            config={
+                "_execution_registry_map": {
+                    "docker.io": "harbor.corp/dockerhub-cache",
+                },
+            },
+        )
+
+        # DB update + scan = 2 invocations. Both use rewritten image.
+        assert len(intercepted) == 2
+        for cmd in intercepted:
+            assert "harbor.corp/dockerhub-cache/fake/grype:test" in " ".join(cmd)
+
+
+class TestRunSyftUsesResolvedImage:
+    """Syft's docker-run cmd honors the mirror config."""
+
+    def test_syft_docker_run_uses_mapped_mirror(self, tmp_path, monkeypatch):
+        _force_container_path(monkeypatch, "syft")
+        intercepted: list[list[str]] = []
+
+        def fake_run(cmd, **_kwargs):
+            intercepted.append(list(cmd))
+            return _completed(returncode=0)
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+        _run_syft(
+            "registry.example.com/myapp@sha256:" + "a" * 64,
+            tmp_path, local=False,
+            config={
+                "_execution_registry_map": {
+                    "docker.io": "harbor.corp/dockerhub-cache",
+                },
+            },
+        )
+
+        assert len(intercepted) == 1
+        assert "harbor.corp/dockerhub-cache/fake/syft:test" in " ".join(intercepted[0])

--- a/argus/tests/test_engine.py
+++ b/argus/tests/test_engine.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from argus.core.config import ArgusConfig, ScannerConfig
-from argus.core.engine import ArgusEngine, _split_upstream
+from argus.core.engine import ArgusEngine, _split_upstream, resolve_image_ref
 from argus.core.models import Finding, ScanResult, Severity, ScanSummary
 
 
@@ -236,6 +236,96 @@ class TestSplitUpstream:
     def test_single_segment_treated_as_docker_io(self):
         # No slash at all — ``redis:7`` is a Docker Hub library image.
         assert _split_upstream("redis:7") == ("docker.io", "redis:7")
+
+
+class TestResolveImageRef:
+    """Pure-function checks for ``resolve_image_ref`` — the shared
+    helper used by both the source-scan engine wrapper
+    (``ArgusEngine._resolve_image``) and the container-scan path
+    (``container/scanner.py::_resolve_sub_scanner_image``).
+    Issue #186."""
+
+    def test_no_registry_no_map_returns_image_unchanged(self):
+        # Zero config = zero rewrite. Critical back-compat guard —
+        # every config without execution.registry / registry_map must
+        # see identical pull behavior post-fix.
+        assert resolve_image_ref("aquasec/trivy:0.70.0") == "aquasec/trivy:0.70.0"
+
+    def test_empty_image_returns_empty(self):
+        # The wrapper passes ``getattr(scanner, 'container_image', '')``
+        # — orchestrator scanners (like the container scanner itself)
+        # leave it empty intentionally. Helper must not crash.
+        assert resolve_image_ref("", registry="harbor.corp/argus") == ""
+
+    def test_flat_registry_rewrites_bare_name(self):
+        assert resolve_image_ref(
+            "aquasec/trivy:0.70.0",
+            registry="harbor.corp/argus",
+        ) == "harbor.corp/argus/aquasec/trivy:0.70.0"
+
+    def test_flat_registry_rewrites_host_segment(self):
+        # Host segment is detected by ``.`` or ``:`` in the first
+        # slash-segment — replace it with the configured registry.
+        assert resolve_image_ref(
+            "ghcr.io/google/osv-scanner:v2.3.6",
+            registry="harbor.corp/argus",
+        ) == "harbor.corp/argus/google/osv-scanner:v2.3.6"
+
+    def test_registry_map_routes_docker_hub_image(self):
+        # Bare-name image normalises to docker.io and gets the
+        # docker.io mirror entry.
+        assert resolve_image_ref(
+            "aquasec/trivy:0.70.0",
+            registry_map={
+                "docker.io": "harbor.corp/dockerhub-cache",
+                "ghcr.io":   "harbor.corp/ghcr-cache",
+            },
+        ) == "harbor.corp/dockerhub-cache/aquasec/trivy:0.70.0"
+
+    def test_registry_map_routes_ghcr_image_with_digest(self):
+        # Digest pin travels with the rewritten path — content-
+        # addressable pull still verifies the same bytes.
+        assert resolve_image_ref(
+            "ghcr.io/google/osv-scanner@sha256:" + "a" * 64,
+            registry_map={"ghcr.io": "harbor.corp/ghcr-cache"},
+        ) == "harbor.corp/ghcr-cache/google/osv-scanner@sha256:" + "a" * 64
+
+    def test_partial_map_falls_through_to_flat_registry(self):
+        # docker.io is mapped → rewrites. ghcr.io is NOT mapped but
+        # the flat ``registry`` is set → falls through to the legacy
+        # flat-rewrite path. Partial maps with a flat fallback are
+        # the realistic shape for mixed proxy setups.
+        registry_map = {"docker.io": "harbor.corp/dockerhub-cache"}
+        flat = "harbor.corp/argus"
+
+        # docker.io match → map wins
+        assert resolve_image_ref(
+            "aquasec/trivy:0.70.0",
+            registry=flat, registry_map=registry_map,
+        ) == "harbor.corp/dockerhub-cache/aquasec/trivy:0.70.0"
+
+        # ghcr.io has no map entry → flat fallback
+        assert resolve_image_ref(
+            "ghcr.io/google/osv-scanner:v2.3.6",
+            registry=flat, registry_map=registry_map,
+        ) == "harbor.corp/argus/google/osv-scanner:v2.3.6"
+
+    def test_partial_map_no_flat_leaves_unmapped_unchanged(self):
+        # docker.io mapped, ghcr.io not mapped, NO flat registry →
+        # ghcr.io image must NOT silently double-rewrite. Falls all
+        # the way through to original.
+        assert resolve_image_ref(
+            "ghcr.io/google/osv-scanner:v2.3.6",
+            registry_map={"docker.io": "harbor.corp/dockerhub-cache"},
+        ) == "ghcr.io/google/osv-scanner:v2.3.6"
+
+    def test_mirror_trailing_slash_normalized(self):
+        # Operator-friendly: a trailing slash in the mirror config
+        # mustn't produce a double-slash in the rewritten ref.
+        assert resolve_image_ref(
+            "aquasec/trivy:0.70.0",
+            registry_map={"docker.io": "harbor.corp/dockerhub-cache/"},
+        ) == "harbor.corp/dockerhub-cache/aquasec/trivy:0.70.0"
 
 
 class TestDockerExecutionBackend:


### PR DESCRIPTION
## Description

`argus scan container` pulled the Trivy / Grype / Syft sub-scanner images **without** consulting `execution.registry` or `execution.registry_map`, even though the source-scan path already routed through `ArgusEngine._resolve_image`. Behind a corporate mirror or air-gapped registry, those pulls hit upstream Docker Hub / GHCR directly and defied the operator's mirror policy.

## Changes Made

- [x] Fixed bug

### Details

Two compounding gaps explained in #186:

1. **`argus/container/scanner.py`** called `argus.containers.get_image()` and pulled the raw reference (5 call sites across `_run_trivy`, `_run_grype`, `_run_syft`).
2. **`argus/cli.py::_load_container_config`** only read `containers:` from argus.yml — `execution.registry` / `execution.registry_map` never made it into the dict `ContainerEngine` passes to `scan_image`.

| File | Change |
|---|---|
| `argus/core/engine.py` | Extracted `ArgusEngine._resolve_image` into module-level pure helper `resolve_image_ref(image, registry, registry_map)`. The class method becomes a thin wrapper. Same algorithm, same logging shape. |
| `argus/cli.py` | `_load_container_config` stashes `execution.registry` and `execution.registry_map` under synthetic keys `_execution_registry` / `_execution_registry_map` (same pattern as the existing `_reporting_keep_raw`). |
| `argus/container/scanner.py` | New `_resolve_sub_scanner_image(image_ref, config)` helper reads the synthetic keys and delegates to `resolve_image_ref`. All five `get_image(...)` sites now route through it before pull or `docker run` cmd construction. |

Returns the original image unchanged when no mirror config is in play — back-compat is guarded explicitly in tests.

## Testing

- [x] Unit tests added/updated

### Test Results

```
$ python -m pytest argus/tests/test_engine.py argus/tests/test_cli_container.py \
                   argus/tests/test_container_scanner_runners.py \
                   argus/tests/test_container_scanner.py --no-cov -q
============================= 280 passed in 12.82s =============================
```

New tests:

- **`test_engine.py::TestResolveImageRef`** — 9 pure-function cases: bare-name `docker.io` routing, `ghcr.io` with `@sha256:` digest pin, partial-map flat fallthrough, partial-map no-flat = no rewrite, trailing-slash mirror normalization.
- **`test_cli_container.py::TestLoadContainerConfigPlumbsExecutionRegistry`** — 4 cases: flat registry stashed under synthetic key, map stashed verbatim, no-execution-block = no synthetic keys, empty-map = no stash.
- **`test_container_scanner_runners.py`** — 7 cases across `TestResolveSubScannerImage` (pure helper, including the back-compat no-mirror case) plus runner-integration tests `TestRunTrivyUsesResolvedImage` / `TestRunGrypeUsesResolvedImage` / `TestRunSyftUsesResolvedImage` that capture the constructed `docker run` argv and assert the rewritten image appears (and the bare upstream form does not).

The existing `TestDockerExecutionBackend` tests for `_resolve_image` on the engine wrapper continue to pass unchanged — proves the refactor keeps the source-scan path's resolution behavior identical.

## Security Considerations

- [x] No security impact

The fix routes additional pulls through the same mirror config the operator already trusts for their source-scan flow. Empty / missing mirror config sees zero behavior change. The `@sha256:` digest pin travels with the rewritten reference, so content-addressable verification still gates the pull.

## AI Context Updates (.ai/)

- [x] N/A — this fix doesn't add a new component, decision, workflow, or error pattern. It closes a parity gap between the source-scan and container-scan code paths; the existing `execution.registry` / `execution.registry_map` semantics documented under [ADR-027 / docs/troubleshooting/docker.md](../docs/troubleshooting/docker.md) now apply uniformly to both paths.

## Checklist

- [x] Code follows project style guidelines
- [x] All tests pass (280 across the directly-affected files)
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues

Closes #186.