### PR TITLE
chore(deps): bump clamav and eslint digests to track upstream republishes

### DIFF
--- a/argus/containers.py
+++ b/argus/containers.py
@@ -30,7 +30,7 @@ OFFICIAL_IMAGES = {
     "grype": "anchore/grype:v0.112.0@sha256:391bfda62888fb4e98ff5c4c81598f7431a3c1eac3f8519d69d1ff00df247c1d",
     "syft": "anchore/syft:v1.44.0@sha256:86fde6445b483d902fe011dd9f68c4987dd94e07da1e9edc004e3c2422650de6",
     "gitleaks": "zricethezav/gitleaks:v8.30.1@sha256:c00b6bd0aeb3071cbcb79009cb16a60dd9e0a7c60e2be9ab65d25e6bc8abbb7f",
-    "clamav": "clamav/clamav:1.5@sha256:de10aee284800529bbdad5c45648afa81ab7cd45a14bc6d5ef7432496fef7b5c",
+    "clamav": "clamav/clamav:1.5@sha256:f7954ca7ca13f0ebc301bb8a8b492a88db793192c48763a0b9a2ffb64dcf4bee",
     "checkov": "bridgecrew/checkov:3.2.526@sha256:93a910a5854dce9b9935c18e96574162dec7ef2f07b819fd6af19f2e16ea306c",
     "osv-scanner": "ghcr.io/google/osv-scanner:v2.3.6@sha256:2e07e642463100474fc5e214b66e6beccbd6bfa63dd3fbf047b3f755e78a6cfe",
     "zap": "ghcr.io/zaproxy/zaproxy:2.17.0@sha256:8770b23f9e8b49038f413cb2b10c58c901e5b6717be221a22b1bcab5c9771b8a",
@@ -44,7 +44,7 @@ OFFICIAL_IMAGES = {
     # SHA + ``:latest`` + ``:edge``, not semver, so the ``:latest`` tag
     # is mutable — the digest pin below is the content-hash gate that
     # protects us between Renovate-driven bumps.
-    "eslint": "pipelinecomponents/eslint:latest@sha256:e75c7b8e8948ae0575a4239bd916f4b1610331f41a633a71cc1ffab1af562034",
+    "eslint": "pipelinecomponents/eslint:latest@sha256:0927aae5ab372691f2ba100ad56bd026b297b263c2fa19287547c33ee74013dd",
 }
 
 # Custom images built and published by Argus to ghcr.io/huntridge-labs/argus/


### PR DESCRIPTION
## Description

The previously pinned `clamav/clamav:1.5` and `pipelinecomponents/eslint:latest` digests in `argus/containers.py` are no longer resolvable on Docker Hub — both publishers re-tagged the same tag with new bytes. This broke `scripts/ci/check_container_images.py` and is blocking the **Unit Tests (Python 3.13)** CI job on every open PR against `main` as of 2026-05-25.

This is the second time clamav has done this (see [`700f91d`](https://github.com/huntridge-labs/argus/commit/700f91d)); for `pipelinecomponents/eslint:latest`, mutability is by design (per the comment at `containers.py:42-47` — Renovate keeps the digest current on a 7-day lag, but a hard republish in the window leaves the pin dangling until the next bump).

## Changes Made

- [x] Fixed bug

### Details

| Image | Old digest (no longer resolvable) | New digest (current index) |
|---|---|---|
| `clamav/clamav:1.5` | `sha256:de10aee2...fef7b5c` | `sha256:f7954ca7ca13f0ebc301bb8a8b492a88db793192c48763a0b9a2ffb64dcf4bee` |
| `pipelinecomponents/eslint:latest` | `sha256:e75c7b8e...f562034` | `sha256:0927aae5ab372691f2ba100ad56bd026b297b263c2fa19287547c33ee74013dd` |

Both new digests resolved via `docker buildx imagetools inspect <tag>` against Docker Hub, picking up the top-level OCI/Docker manifest list digest (matches the format of the existing pins).

Mirrors the one-line shape of `700f91d` exactly — only the digest segment of the tag-and-digest reference changes.

## Testing

- [x] Manual testing performed

### Test Results

Confirmed both new digest pins resolve against the live registry:

```
$ docker buildx imagetools inspect clamav/clamav:1.5@sha256:f7954ca7...dcf4bee
Name:      docker.io/clamav/clamav:1.5@sha256:f7954ca7...dcf4bee
MediaType: application/vnd.oci.image.index.v1+json
Digest:    sha256:f7954ca7...dcf4bee

$ docker buildx imagetools inspect pipelinecomponents/eslint:latest@sha256:0927aae5...4013dd
Name:      docker.io/pipelinecomponents/eslint:latest@sha256:0927aae5...4013dd
MediaType: application/vnd.docker.distribution.manifest.list.v2+json
Digest:    sha256:0927aae5...4013dd
```

Full pre-push test suite: **3486 passed, 2 skipped, 7 deselected** (no test-side impact — these are runtime image references consumed by `check_container_images.py`, not by any unit test).

## Security Considerations

- [x] No security impact

Digest pinning continues to provide content-addressable verification — the new pins are the current top-level index digests for the same tags the project has trusted all along. No widening of trust, no new images.

## AI Context Updates (.ai/)

- [x] N/A — internal digest refresh. No new components, decisions, workflows, or error patterns. The same operational pattern as the existing 700f91d commit.

## Checklist

- [x] Code follows project style guidelines
- [x] All tests pass (3486 in pre-push)
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues

Unblocks open PRs #184, #185, #187, #194 — all four had previously-green CI flipped to failure by the upstream republish of these two tags. They will re-pass once rebased onto this fix.