### PR TITLE
feat(validate): add --deep flag for live config validation

### DIFF
--- a/argus/cli.py
+++ b/argus/cli.py
@@ -1208,6 +1208,15 @@ def _build_validate_parser(subparsers: argparse._SubParsersAction, parent: argpa
         ),
     )
     validate_parser.add_argument(
+        "--verbose", "-v",
+        action="store_true",
+        default=False,
+        help=(
+            "Show full image references including the 64-character @sha256 "
+            "digest. Default truncates digests for readability."
+        ),
+    )
+    validate_parser.add_argument(
         "--strict",
         action="store_true",
         default=False,
@@ -3296,23 +3305,38 @@ def cmd_validate(args: argparse.Namespace) -> int:
                 print(f"     - {ref}")
 
     # Tool readiness check. --deep implies --check-tools so the user
-    # gets the full live picture from one flag.
+    # gets the full live picture from one flag. The unified table also
+    # subsumes the separate Registry-reachability section when --deep
+    # is requested — scanner image refs only appear once, beside their
+    # owning scanner, rather than in two duplicate tables.
     deep = getattr(args, "deep", False)
+    verbose = getattr(args, "verbose", False)
     check_tools = getattr(args, "check_tools", False) or deep
+    execution = data.get("execution", {}) if isinstance(data.get("execution"), dict) else {}
     unavailable = []
     tool_statuses = []
+    probe_failures = 0
     if check_tools and enabled_names:
-        registry = data.get("execution", {}).get("registry", "")
-        unavailable, tool_statuses = _check_tool_readiness(enabled_names, backend, registry)
+        registry = execution.get("registry") or ""
+        registry_map = execution.get("registry_map") or {}
+        unavailable, tool_statuses, probe_failures = _render_scanner_table(
+            enabled_names,
+            backend=backend,
+            registry=registry,
+            registry_map=registry_map,
+            probe=deep,
+            verbose=verbose,
+        )
         if unavailable and strict:
             print(f"\n❌ {len(unavailable)} scanner(s) unavailable (--strict)")
 
-    # Deep checks — registry reachability + on-disk paths. Each probe
-    # is independent and reports its own pass/fail; counts aggregate
-    # into ``deep_failures`` for the exit-code calculation below.
-    deep_failures = 0
+    # Deep checks — `containers.images` (separate from scanner images)
+    # plus on-disk paths. The scanner-image reachability check ran
+    # above as part of the unified table; this only handles the
+    # additional surfaces the table didn't cover.
+    deep_failures = probe_failures
     if deep:
-        deep_failures = _run_deep_checks(data)
+        deep_failures += _run_deep_checks(data, verbose=verbose)
 
     # Living issue reporting (runs before exit so the issue captures full state)
     if report_issue:
@@ -3350,30 +3374,38 @@ def cmd_validate(args: argparse.Namespace) -> int:
     return EXIT_SUCCESS
 
 
-def _run_deep_checks(data: dict) -> int:
-    """Run deep validation probes and print results.
+def _run_deep_checks(data: dict, *, verbose: bool = False) -> int:
+    """Run deep validation probes for surfaces the unified scanner
+    table doesn't already cover.
 
-    Returns the count of `status="fail"` results across all probes,
-    which the caller folds into the validate exit code. Pure detection
-    lives in ``argus.preflight.deep_checks``; this wrapper formats the
-    output specific to ``argus validate --deep``.
+    Scanner-tool image reachability has already been printed inline
+    next to each scanner in ``_render_scanner_table``. This function
+    handles the two remaining surfaces:
+
+    * ``containers.images`` — explicit images the operator wants to
+      scan. Distinct from scanner-tool images; rendered as its own
+      section so the operator can tell which mirror policy applies
+      to *their* container fleet vs the scanner internals.
+    * On-disk paths — search_paths, output_dirs, per-scanner excludes.
+      Fast, no network.
+
+    Returns the count of ``status="fail"`` results, folded into the
+    validate exit code by the caller.
     """
     from argus.preflight.deep_checks import (
         check_paths,
         check_registry_reachability,
+        short_ref,
     )
 
     execution = data.get("execution", {}) if isinstance(data.get("execution"), dict) else {}
     registry = execution.get("registry") or ""
     registry_map = execution.get("registry_map") or {}
 
-    # Source of truth for "what images would this config touch": the
-    # explicit containers.images block plus the scanner tool images
-    # already cataloged in argus.containers (Trivy, Grype, etc., used
-    # when the engine container-runs a scanner). The user cares about
-    # the first set the most; we include the second when relevant
-    # scanners are enabled so the operator's mirror policy is verified
-    # end-to-end.
+    # containers.images — explicit operator-specified images. Scanner
+    # images are NOT included here; they're printed by the unified
+    # scanner table above. Keeping the two sets separate prevents the
+    # operator from having to mentally diff "my images vs internal".
     container_images: list[str] = []
     containers_cfg = data.get("containers")
     if isinstance(containers_cfg, dict):
@@ -3383,41 +3415,35 @@ def _run_deep_checks(data: dict) -> int:
             elif isinstance(entry, str):
                 container_images.append(entry)
 
-    scanner_images: list[str] = []
-    enabled_scanners = []
-    scanners_cfg = data.get("scanners", {}) or {}
-    if isinstance(scanners_cfg, dict):
-        for name, cfg in scanners_cfg.items():
-            if isinstance(cfg, dict) and not cfg.get("enabled", True):
-                continue
-            enabled_scanners.append(name)
-    if enabled_scanners:
-        from argus.containers import get_image
-        seen = set()
-        for name in enabled_scanners:
-            ref = get_image(name)
-            if ref and ref not in seen:
-                scanner_images.append(ref)
-                seen.add(ref)
-
     total_failures = 0
 
-    if registry or registry_map or container_images or scanner_images:
-        all_images = container_images + scanner_images
-        if all_images:
-            print("\n   Registry reachability:")
-            results = check_registry_reachability(
-                all_images,
-                registry=registry,
-                registry_map=registry_map,
+    if container_images:
+        import threading
+        print(f"\n   Container images (from containers.images):")
+        print(f"     ⏳ probing {len(container_images)} image(s) in parallel…")
+        print_lock = threading.Lock()
+        start_time = time.monotonic()
+
+        def on_progress(idx: int, result) -> None:
+            elapsed = time.monotonic() - start_time
+            icon = {"ok": "✅", "fail": "❌", "skip": "⏭️ ", "warn": "⚠️ "}.get(
+                result.status, "?"
             )
-            icon = {"ok": "✅", "fail": "❌", "skip": "⏭️ ", "warn": "⚠️ "}
-            for r in results:
-                print(f"     {icon.get(r.status, '?')} {r.name}")
-                if r.status != "ok":
-                    print(f"         {r.message}")
-                if r.status == "fail":
-                    total_failures += 1
+            display = short_ref(result.name, verbose=verbose)
+            with print_lock:
+                print(f"     {icon} {display}  ({elapsed:.1f}s)")
+                if result.status == "fail":
+                    print(f"         {result.message}")
+                elif result.status == "skip" and "install Docker" in result.message:
+                    print(f"         {result.message}")
+
+        results = check_registry_reachability(
+            container_images,
+            registry=registry,
+            registry_map=registry_map,
+            progress=on_progress,
+        )
+        total_failures += sum(1 for r in results if r.status == "fail")
 
     # Paths are always probed under --deep (cheap, no network).
     path_results = check_paths(data)
@@ -3436,47 +3462,121 @@ def _run_deep_checks(data: dict) -> int:
     return total_failures
 
 
-def _check_tool_readiness(
-    enabled_names: list[str], backend: str, registry: str = ""
-) -> tuple[list[str], list]:
-    """Check whether enabled scanners can actually run.
+def _render_scanner_table(
+    enabled_names: list[str],
+    *,
+    backend: str,
+    registry: str = "",
+    registry_map: dict | None = None,
+    probe: bool = False,
+    verbose: bool = False,
+) -> tuple[list[str], list, int]:
+    """Render the unified per-scanner readiness + reachability table.
 
-    Returns (unavailable_names, tool_statuses). Pure detection lives in
-    `argus.preflight.tool_check`; this wrapper handles the detailed
-    per-scanner output specific to `argus validate --check-tools`.
+    Replaces the older split between "Tool readiness" and "Registry
+    reachability" sections. Each enabled scanner gets exactly one row
+    showing its provisioning mode (local | container | unavailable),
+    the rewritten image ref when applicable, and — under ``probe=True``
+    — the live ``docker manifest inspect`` status for container-mode
+    scanners. Local scanners and unavailable scanners print
+    immediately. Container-mode rows are dispatched to a thread pool
+    and printed in finish-order so the user sees activity instead of
+    a 15-second silent block.
+
+    Returns ``(unavailable_names, tool_statuses, probe_failure_count)``.
+    The first two preserve the prior ``_check_tool_readiness`` shape so
+    `_report_issue` and `--strict` accounting keep working unchanged.
     """
-    from argus.scanners import SCANNER_REGISTRY
+    import threading
+    from argus.preflight.deep_checks import (
+        check_registry_reachability,
+        short_ref,
+    )
     from argus.preflight.tool_check import (
         check_scanner_readiness,
         container_runtime_available,
         unavailable_names,
     )
+    from argus.scanners import SCANNER_REGISTRY
 
     statuses = check_scanner_readiness(enabled_names, backend=backend, registry=registry)
 
     if registry:
         print(f"\n   Registry: {registry}")
-    print("\n   Tool readiness:")
-    for status in statuses:
+    if registry_map:
+        print(f"   Registry map: {len(registry_map)} upstream(s)")
+    print("\n   Scanners:")
+
+    # Print local + unavailable rows immediately. Stash container-mode
+    # rows for the parallel probe pass.
+    name_col = max((len(s.name) for s in statuses), default=0) + 2
+    container_rows: list[tuple[int, str, str, list[str]]] = []  # (orig_idx, image_ref, name, net_deps)
+    for idx, status in enumerate(statuses):
         name = status.name
         cls = SCANNER_REGISTRY.get(name)
         if cls is None:
-            print(f"     {name}: ⚠️  unknown scanner (not in registry)")
-        elif status.available and status.method == "local":
-            print(f"     {name}: ✅ installed locally")
+            print(f"     ⚠️  {name:<{name_col}} unknown scanner (not in registry)")
+            continue
+        if status.available and status.method == "local":
+            print(f"     ✅ {name:<{name_col}} local")
+            for dep in status.network_deps:
+                print(f"            ℹ️  Requires network: {dep}")
         elif status.available and status.method == "container":
-            print(f"     {name}: 🐳 will use container ({status.image})")
+            container_rows.append((idx, status.image, name, list(status.network_deps)))
         else:
             install_cmd = cls().install_command() or "see docs"
             if backend == "local":
-                print(f"     {name}: ❌ not found (install: {install_cmd})")
+                print(f"     ❌ {name:<{name_col}} not found (install: {install_cmd})")
             elif not container_runtime_available():
-                print(f"     {name}: ❌ not found, Docker not available (install: {install_cmd})")
+                print(f"     ❌ {name:<{name_col}} not found, no container runtime (install: {install_cmd})")
             else:
-                print(f"     {name}: ❌ not found, no container image (install: {install_cmd})")
+                print(f"     ❌ {name:<{name_col}} not found, no container image (install: {install_cmd})")
 
-        for dep in status.network_deps:
-            print(f"             ℹ️  Requires network: {dep}")
+    probe_failures = 0
+
+    if container_rows and not probe:
+        # --check-tools alone: show container assignments without
+        # probing. Same format as the probe path so the table reads
+        # consistently across modes.
+        for _, image, name, net_deps in container_rows:
+            print(f"     🐳 {name:<{name_col}} {short_ref(image, verbose=verbose)}")
+            for dep in net_deps:
+                print(f"            ℹ️  Requires network: {dep}")
+    elif container_rows and probe:
+        # --deep: probe each container image concurrently. Print rows
+        # as probes complete so the user sees activity (~3s wall-clock
+        # for ~6 images vs ~15s sequential).
+        images_to_probe = [row[1] for row in container_rows]
+        print(f"     ⏳ probing {len(images_to_probe)} container image(s) in parallel…")
+
+        row_by_idx = {i: row for i, row in enumerate(container_rows)}
+        print_lock = threading.Lock()
+        start_time = time.monotonic()
+        per_start: dict[int, float] = {i: start_time for i in range(len(images_to_probe))}
+
+        def on_progress(probe_idx: int, result) -> None:
+            orig_idx, _image, name, net_deps = row_by_idx[probe_idx]
+            elapsed = time.monotonic() - per_start[probe_idx]
+            icon = {"ok": "✅", "fail": "❌", "skip": "⏭️ ", "warn": "⚠️ "}.get(
+                result.status, "?"
+            )
+            display = short_ref(result.name, verbose=verbose)
+            with print_lock:
+                print(f"     🐳 {name:<{name_col}} {icon} {display}  ({elapsed:.1f}s)")
+                if result.status == "fail":
+                    print(f"            {result.message}")
+                elif result.status == "skip" and "install Docker" in result.message:
+                    print(f"            {result.message}")
+                for dep in net_deps:
+                    print(f"            ℹ️  Requires network: {dep}")
+
+        results = check_registry_reachability(
+            images_to_probe,
+            registry=registry,
+            registry_map=registry_map or {},
+            progress=on_progress,
+        )
+        probe_failures = sum(1 for r in results if r.status == "fail")
 
     if not container_runtime_available() and backend != "local":
         print(
@@ -3487,7 +3587,7 @@ def _check_tool_readiness(
             "      Install Docker, Podman, or nerdctl — or set execution.backend: local in argus.yml"
         )
 
-    return unavailable_names(statuses), statuses
+    return unavailable_names(statuses), statuses, probe_failures
 
 
 def _report_issue(

--- a/argus/cli.py
+++ b/argus/cli.py
@@ -1186,10 +1186,26 @@ def _build_validate_parser(subparsers: argparse._SubParsersAction, parent: argpa
         help="Path to argus.yml config file (default: auto-detect)",
     )
     validate_parser.add_argument(
+        "--schema",
+        action="store_true",
+        default=False,
+        help="Run schema validation only (default behavior; explicit form for scripting).",
+    )
+    validate_parser.add_argument(
         "--check-tools",
         action="store_true",
         default=False,
         help="Also check scanner tool availability (local + Docker)",
+    )
+    validate_parser.add_argument(
+        "--deep",
+        action="store_true",
+        default=False,
+        help=(
+            "Live validation of config settings: scanner tools, registry / "
+            "registry_map reachability, and on-disk paths. Implies --check-tools. "
+            "Requires Docker on PATH for registry probes."
+        ),
     )
     validate_parser.add_argument(
         "--strict",
@@ -3279,14 +3295,24 @@ def cmd_validate(args: argparse.Namespace) -> int:
                 ref = entry.get("image") or entry.get("dockerfile") or "<unknown>"
                 print(f"     - {ref}")
 
-    # Tool readiness check
+    # Tool readiness check. --deep implies --check-tools so the user
+    # gets the full live picture from one flag.
+    deep = getattr(args, "deep", False)
+    check_tools = getattr(args, "check_tools", False) or deep
     unavailable = []
     tool_statuses = []
-    if getattr(args, "check_tools", False) and enabled_names:
+    if check_tools and enabled_names:
         registry = data.get("execution", {}).get("registry", "")
         unavailable, tool_statuses = _check_tool_readiness(enabled_names, backend, registry)
         if unavailable and strict:
             print(f"\n❌ {len(unavailable)} scanner(s) unavailable (--strict)")
+
+    # Deep checks — registry reachability + on-disk paths. Each probe
+    # is independent and reports its own pass/fail; counts aggregate
+    # into ``deep_failures`` for the exit-code calculation below.
+    deep_failures = 0
+    if deep:
+        deep_failures = _run_deep_checks(data)
 
     # Living issue reporting (runs before exit so the issue captures full state)
     if report_issue:
@@ -3299,13 +3325,115 @@ def cmd_validate(args: argparse.Namespace) -> int:
             strict=strict,
         )
 
+    # Conditional --deep hint. Only printed when:
+    #  - schema validation passed (no fatal errors)
+    #  - --deep wasn't already requested
+    #  - the config has options --deep would actually exercise
+    # Keeps the default `argus validate` quiet on minimal configs.
+    if not fatal and not deep:
+        from argus.preflight.deep_hints import compute_deep_hints
+
+        hints = compute_deep_hints(data)
+        if hints:
+            print("\n   Live checks available (run with --deep):")
+            for h in hints:
+                print(f"     - {h}")
+
     if fatal:
         return EXIT_ERROR
     if strict and warnings:
         return EXIT_ERROR
     if unavailable and strict:
         return EXIT_ERROR
+    if deep_failures:
+        return EXIT_ERROR
     return EXIT_SUCCESS
+
+
+def _run_deep_checks(data: dict) -> int:
+    """Run deep validation probes and print results.
+
+    Returns the count of `status="fail"` results across all probes,
+    which the caller folds into the validate exit code. Pure detection
+    lives in ``argus.preflight.deep_checks``; this wrapper formats the
+    output specific to ``argus validate --deep``.
+    """
+    from argus.preflight.deep_checks import (
+        check_paths,
+        check_registry_reachability,
+    )
+
+    execution = data.get("execution", {}) if isinstance(data.get("execution"), dict) else {}
+    registry = execution.get("registry") or ""
+    registry_map = execution.get("registry_map") or {}
+
+    # Source of truth for "what images would this config touch": the
+    # explicit containers.images block plus the scanner tool images
+    # already cataloged in argus.containers (Trivy, Grype, etc., used
+    # when the engine container-runs a scanner). The user cares about
+    # the first set the most; we include the second when relevant
+    # scanners are enabled so the operator's mirror policy is verified
+    # end-to-end.
+    container_images: list[str] = []
+    containers_cfg = data.get("containers")
+    if isinstance(containers_cfg, dict):
+        for entry in containers_cfg.get("images") or []:
+            if isinstance(entry, dict) and isinstance(entry.get("image"), str):
+                container_images.append(entry["image"])
+            elif isinstance(entry, str):
+                container_images.append(entry)
+
+    scanner_images: list[str] = []
+    enabled_scanners = []
+    scanners_cfg = data.get("scanners", {}) or {}
+    if isinstance(scanners_cfg, dict):
+        for name, cfg in scanners_cfg.items():
+            if isinstance(cfg, dict) and not cfg.get("enabled", True):
+                continue
+            enabled_scanners.append(name)
+    if enabled_scanners:
+        from argus.containers import get_image
+        seen = set()
+        for name in enabled_scanners:
+            ref = get_image(name)
+            if ref and ref not in seen:
+                scanner_images.append(ref)
+                seen.add(ref)
+
+    total_failures = 0
+
+    if registry or registry_map or container_images or scanner_images:
+        all_images = container_images + scanner_images
+        if all_images:
+            print("\n   Registry reachability:")
+            results = check_registry_reachability(
+                all_images,
+                registry=registry,
+                registry_map=registry_map,
+            )
+            icon = {"ok": "✅", "fail": "❌", "skip": "⏭️ ", "warn": "⚠️ "}
+            for r in results:
+                print(f"     {icon.get(r.status, '?')} {r.name}")
+                if r.status != "ok":
+                    print(f"         {r.message}")
+                if r.status == "fail":
+                    total_failures += 1
+
+    # Paths are always probed under --deep (cheap, no network).
+    path_results = check_paths(data)
+    if path_results:
+        print("\n   Paths:")
+        icon = {"ok": "✅", "fail": "❌", "skip": "⏭️ ", "warn": "⚠️ "}
+        for r in path_results:
+            print(f"     {icon.get(r.status, '?')} {r.name}")
+            if r.status != "ok":
+                print(f"         {r.message}")
+            if r.status == "fail":
+                total_failures += 1
+
+    if total_failures:
+        print(f"\n❌ {total_failures} deep-check failure(s)")
+    return total_failures
 
 
 def _check_tool_readiness(

--- a/argus/preflight/deep_checks.py
+++ b/argus/preflight/deep_checks.py
@@ -1,0 +1,250 @@
+"""Live config validation — registry reachability + path existence.
+
+Extracted from `argus validate --deep` so the same probes can be reused
+by `argus doctor`-style workflows and end-of-init smoke tests. Pure
+logic + a single `docker manifest inspect` subprocess call per image —
+no print statements, no I/O on the config itself, callers own formatting.
+
+The probes here are **always optional**: failures are reported as
+results, never raised. A missing Docker daemon yields `skip` results
+rather than aborting the run, so an offline developer can still run
+`argus validate --deep` and get the path-existence half of the report.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+
+Status = Literal["ok", "fail", "skip", "warn"]
+Severity = Literal["error", "warning", "info"]
+
+
+@dataclass(frozen=True)
+class DeepCheckResult:
+    """One row in the `--deep` output table.
+
+    `name` identifies the subject (an image ref, a path, a config key).
+    `status` is the machine-readable outcome the caller uses for
+    pass/fail accounting. `message` is the human-readable detail line
+    shown after the status indicator.
+    """
+
+    name: str
+    status: Status
+    severity: Severity
+    message: str
+
+
+def manifest_probe(image_ref: str, timeout: int = 30) -> tuple[bool, str]:
+    """Probe `image_ref` via `docker manifest inspect`.
+
+    Returns (success, detail). `success=False` with detail "no docker"
+    when the binary is missing — callers should map that to a `skip`
+    result, not an error, because it means the probe couldn't run, not
+    that the image is broken.
+    """
+    if not shutil.which("docker"):
+        return False, "no docker"
+    try:
+        result = subprocess.run(
+            ["docker", "manifest", "inspect", image_ref],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return False, f"timeout after {timeout}s"
+    except OSError as exc:
+        return False, f"could not invoke docker: {exc}"
+
+    if result.returncode == 0:
+        return True, "manifest resolved"
+    # Trim the first stderr line — Docker's errors are typically a
+    # single ~80-char string ("no such manifest", "unauthorized",
+    # "manifest unknown") with stack-trace garbage after.
+    err = (result.stderr or result.stdout).strip().split("\n", 1)[0][:120]
+    return False, err or "manifest inspect failed"
+
+
+def check_registry_reachability(
+    images: list[str],
+    registry: str = "",
+    registry_map: dict | None = None,
+) -> list[DeepCheckResult]:
+    """For each image, apply registry rewriting then probe the manifest.
+
+    Empty image list returns []. Each image emits exactly one result
+    with the rewritten ref as the `name` (so the output shows what was
+    actually probed, not just the upstream).
+    """
+    if not images:
+        return []
+
+    # Import here so a missing engine import (unusual but possible
+    # during partial test runs) doesn't break the rest of the validate
+    # pipeline.
+    from argus.core.engine import resolve_image_ref
+
+    results: list[DeepCheckResult] = []
+    for image in images:
+        resolved = resolve_image_ref(image, registry or None, registry_map or None)
+        success, detail = manifest_probe(resolved)
+        if detail == "no docker":
+            results.append(DeepCheckResult(
+                name=resolved,
+                status="skip",
+                severity="info",
+                message="Docker not on PATH — install Docker to probe registries",
+            ))
+            # Once we know Docker is missing, every subsequent image
+            # will report the same. Emit the first as the explanation
+            # and short-circuit the rest as quieter info rows so the
+            # output table doesn't drown the user in identical lines.
+            for extra in images[len(results):]:
+                extra_resolved = resolve_image_ref(extra, registry or None, registry_map or None)
+                results.append(DeepCheckResult(
+                    name=extra_resolved,
+                    status="skip",
+                    severity="info",
+                    message="(skipped — no Docker)",
+                ))
+            return results
+        if success:
+            results.append(DeepCheckResult(
+                name=resolved,
+                status="ok",
+                severity="info",
+                message=detail,
+            ))
+        else:
+            results.append(DeepCheckResult(
+                name=resolved,
+                status="fail",
+                severity="error",
+                message=detail,
+            ))
+    return results
+
+
+def check_paths(
+    config_data: dict,
+    base_dir: Path | None = None,
+) -> list[DeepCheckResult]:
+    """Verify on-disk paths in the config against the real argus schema.
+
+    Top-level keys that hold paths (per ``argus-config.schema.json``):
+      - ``containers.search_paths`` — list of dirs for Dockerfile discovery.
+        Missing dir is an **error** (scan-time discovery would surface
+        no results from that path anyway, but flagging up-front saves
+        debugging "why didn't argus find my Dockerfile" later).
+      - ``containers.output_dir`` and ``reporting.output_dir`` — output
+        dirs argus creates lazily. Missing is a **warning** because
+        the scan will create them; non-writable parent is the real
+        error case (caught at scan time).
+      - Per-scanner ``exclude`` — comma-separated paths or patterns
+        under each ``scanners.{name}``. Glob entries are skipped on
+        purpose; concrete-path entries that don't exist emit info-level
+        warnings so a typo is visible without failing the run.
+    """
+    base = base_dir or Path.cwd()
+    results: list[DeepCheckResult] = []
+
+    def _resolve(p: str) -> Path:
+        return Path(p) if Path(p).is_absolute() else (base / p).resolve()
+
+    # containers.search_paths — list of dirs
+    containers = config_data.get("containers") or {}
+    if isinstance(containers, dict):
+        search_paths = containers.get("search_paths") or []
+        if isinstance(search_paths, list):
+            for sp in search_paths:
+                if not isinstance(sp, str) or not sp:
+                    continue
+                rp = _resolve(sp)
+                if rp.exists():
+                    results.append(DeepCheckResult(
+                        name=f"containers.search_paths[{sp}]",
+                        status="ok",
+                        severity="info",
+                        message=f"exists at {rp}",
+                    ))
+                else:
+                    results.append(DeepCheckResult(
+                        name=f"containers.search_paths[{sp}]",
+                        status="fail",
+                        severity="error",
+                        message=f"path does not exist: {rp}",
+                    ))
+
+        # containers.output_dir — created at scan time, missing is warn
+        c_out = containers.get("output_dir")
+        if isinstance(c_out, str) and c_out:
+            rp = _resolve(c_out)
+            if rp.exists():
+                results.append(DeepCheckResult(
+                    name=f"containers.output_dir={c_out}",
+                    status="ok",
+                    severity="info",
+                    message=f"exists at {rp}",
+                ))
+            else:
+                results.append(DeepCheckResult(
+                    name=f"containers.output_dir={c_out}",
+                    status="warn",
+                    severity="info",
+                    message="does not exist — will be created at scan time",
+                ))
+
+    # reporting.output_dir — created at scan time, missing is warn
+    reporting = config_data.get("reporting") or {}
+    if isinstance(reporting, dict):
+        r_out = reporting.get("output_dir")
+        if isinstance(r_out, str) and r_out:
+            rp = _resolve(r_out)
+            if rp.exists():
+                results.append(DeepCheckResult(
+                    name=f"reporting.output_dir={r_out}",
+                    status="ok",
+                    severity="info",
+                    message=f"exists at {rp}",
+                ))
+            else:
+                results.append(DeepCheckResult(
+                    name=f"reporting.output_dir={r_out}",
+                    status="warn",
+                    severity="info",
+                    message="does not exist — will be created at scan time",
+                ))
+
+    # Per-scanner exclude — comma-separated; concrete-path entries
+    # that don't exist emit info warnings (likely typos).
+    scanners = config_data.get("scanners") or {}
+    if isinstance(scanners, dict):
+        for sname, scfg in scanners.items():
+            if not isinstance(scfg, dict):
+                continue
+            excl_raw = scfg.get("exclude")
+            if not isinstance(excl_raw, str) or not excl_raw:
+                continue
+            for piece in excl_raw.split(","):
+                excl = piece.strip()
+                if not excl:
+                    continue
+                # Skip glob entries — they're patterns, not paths.
+                if any(ch in excl for ch in "*?["):
+                    continue
+                rp = _resolve(excl)
+                if not rp.exists():
+                    results.append(DeepCheckResult(
+                        name=f"scanners.{sname}.exclude[{excl}]",
+                        status="warn",
+                        severity="info",
+                        message="path does not exist (still valid as a defensive entry)",
+                    ))
+
+    return results

--- a/argus/preflight/deep_checks.py
+++ b/argus/preflight/deep_checks.py
@@ -15,13 +15,31 @@ from __future__ import annotations
 
 import shutil
 import subprocess
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal
+from typing import Callable, Literal
 
 
 Status = Literal["ok", "fail", "skip", "warn"]
 Severity = Literal["error", "warning", "info"]
+
+
+def short_ref(image_ref: str, verbose: bool = False, digest_chars: int = 6) -> str:
+    """Truncate a ``tag@sha256:...`` reference for display.
+
+    The 64-character digest tail dominates terminal output and isn't
+    actionable to read in full — the operator wants the tag + a hint
+    of which digest, not the whole hash. ``verbose=True`` returns the
+    untruncated ref so ``argus validate --deep -v`` can dump the
+    canonical form for copy-paste / escalation.
+    """
+    if verbose or "@sha256:" not in image_ref:
+        return image_ref
+    head, _, digest = image_ref.partition("@sha256:")
+    if len(digest) <= digest_chars * 2 + 1:
+        return image_ref
+    return f"{head}@sha256:{digest[:digest_chars]}…{digest[-digest_chars:]}"
 
 
 @dataclass(frozen=True)
@@ -75,12 +93,27 @@ def check_registry_reachability(
     images: list[str],
     registry: str = "",
     registry_map: dict | None = None,
+    *,
+    max_workers: int = 8,
+    progress: Callable[[int, "DeepCheckResult"], None] | None = None,
 ) -> list[DeepCheckResult]:
     """For each image, apply registry rewriting then probe the manifest.
 
     Empty image list returns []. Each image emits exactly one result
-    with the rewritten ref as the `name` (so the output shows what was
-    actually probed, not just the upstream).
+    with the rewritten ref as the ``name`` (so the output shows what
+    was actually probed, not just the upstream).
+
+    Probes run concurrently in a ``ThreadPoolExecutor`` — six independent
+    ``docker manifest inspect`` calls take ~3s wall-clock instead of
+    ~15s sequential. Results are returned in **input order** (not
+    finish order) so the operator sees the same row layout as the
+    config.
+
+    ``progress(idx, result)`` is invoked once per completion in
+    finish-order — useful for streaming a live progress display while
+    keeping the final return value stably ordered. The callback runs
+    on a worker thread; format-only callers can ignore thread-safety,
+    but anyone touching mutable state should serialize the update.
     """
     if not images:
         return []
@@ -90,45 +123,55 @@ def check_registry_reachability(
     # pipeline.
     from argus.core.engine import resolve_image_ref
 
-    results: list[DeepCheckResult] = []
-    for image in images:
-        resolved = resolve_image_ref(image, registry or None, registry_map or None)
-        success, detail = manifest_probe(resolved)
-        if detail == "no docker":
-            results.append(DeepCheckResult(
-                name=resolved,
+    resolved = [
+        resolve_image_ref(img, registry or None, registry_map or None)
+        for img in images
+    ]
+
+    # Short-circuit before spinning up the pool: if Docker is missing,
+    # every probe will say so identically. One explanation + N quiet
+    # skip rows reads better than N identical Docker-missing lines.
+    if not shutil.which("docker"):
+        results: list[DeepCheckResult] = []
+        for i, ref in enumerate(resolved):
+            r = DeepCheckResult(
+                name=ref,
                 status="skip",
                 severity="info",
-                message="Docker not on PATH — install Docker to probe registries",
-            ))
-            # Once we know Docker is missing, every subsequent image
-            # will report the same. Emit the first as the explanation
-            # and short-circuit the rest as quieter info rows so the
-            # output table doesn't drown the user in identical lines.
-            for extra in images[len(results):]:
-                extra_resolved = resolve_image_ref(extra, registry or None, registry_map or None)
-                results.append(DeepCheckResult(
-                    name=extra_resolved,
-                    status="skip",
-                    severity="info",
-                    message="(skipped — no Docker)",
-                ))
-            return results
-        if success:
-            results.append(DeepCheckResult(
-                name=resolved,
-                status="ok",
-                severity="info",
-                message=detail,
-            ))
-        else:
-            results.append(DeepCheckResult(
-                name=resolved,
-                status="fail",
-                severity="error",
-                message=detail,
-            ))
-    return results
+                message=(
+                    "Docker not on PATH — install Docker to probe registries"
+                    if i == 0
+                    else "(skipped — no Docker)"
+                ),
+            )
+            results.append(r)
+            if progress is not None:
+                progress(i, r)
+        return results
+
+    # Concurrent execution. The slot list keeps input order; futures
+    # write into their own index. `as_completed` drives the progress
+    # callback in finish-order so the operator sees results trickle
+    # in rather than blocking on the slowest probe.
+    slots: list[DeepCheckResult | None] = [None] * len(resolved)
+    with ThreadPoolExecutor(max_workers=max_workers) as ex:
+        future_to_idx = {
+            ex.submit(manifest_probe, ref): (i, ref)
+            for i, ref in enumerate(resolved)
+        }
+        for future in as_completed(future_to_idx):
+            i, ref = future_to_idx[future]
+            success, detail = future.result()
+            if success:
+                r = DeepCheckResult(name=ref, status="ok", severity="info", message=detail)
+            else:
+                r = DeepCheckResult(name=ref, status="fail", severity="error", message=detail)
+            slots[i] = r
+            if progress is not None:
+                progress(i, r)
+
+    # `slots` is fully populated by the time the executor exits.
+    return [r for r in slots if r is not None]
 
 
 def check_paths(

--- a/argus/preflight/deep_hints.py
+++ b/argus/preflight/deep_hints.py
@@ -1,0 +1,58 @@
+"""Compute the `--deep would also check ...` hint shown after a clean
+schema validation. Pure config inspection — no I/O, no Docker calls.
+
+The hint is only printed when the config contains options that `--deep`
+would actually exercise, so it stays out of the way for users running
+plain `argus validate` on a minimal config.
+"""
+
+from __future__ import annotations
+
+
+def compute_deep_hints(config_data: dict) -> list[str]:
+    """Return one short hint line per config feature `--deep` would
+    validate. Empty list means no hint is shown — the config has
+    nothing extra for `--deep` to exercise.
+    """
+    hints: list[str] = []
+
+    execution = config_data.get("execution") or {}
+    if isinstance(execution, dict):
+        registry = execution.get("registry")
+        if isinstance(registry, str) and registry:
+            hints.append(f"execution.registry set ({registry}) — verify the mirror resolves")
+
+        registry_map = execution.get("registry_map")
+        if isinstance(registry_map, dict) and registry_map:
+            hints.append(
+                f"{len(registry_map)} entries in execution.registry_map — "
+                "verify each upstream mirror responds"
+            )
+
+    containers = config_data.get("containers")
+    if isinstance(containers, dict):
+        images = containers.get("images") or []
+        if isinstance(images, list) and images:
+            hints.append(
+                f"{len(images)} container image(s) in containers.images — "
+                "verify each manifest resolves (with any registry rewriting applied)"
+            )
+
+        search_paths = containers.get("search_paths") or []
+        if isinstance(search_paths, list) and search_paths:
+            hints.append(
+                f"{len(search_paths)} entries in containers.search_paths — "
+                "verify each directory exists on disk"
+            )
+
+        c_out = containers.get("output_dir")
+        if isinstance(c_out, str) and c_out:
+            hints.append(f"containers.output_dir '{c_out}' — verify writability before scan")
+
+    reporting = config_data.get("reporting")
+    if isinstance(reporting, dict):
+        r_out = reporting.get("output_dir")
+        if isinstance(r_out, str) and r_out:
+            hints.append(f"reporting.output_dir '{r_out}' — verify writability before scan")
+
+    return hints

--- a/argus/tests/test_validate_deep.py
+++ b/argus/tests/test_validate_deep.py
@@ -1,0 +1,410 @@
+"""Tests for `argus validate --deep` — deep_checks, deep_hints, and the
+cmd_validate wiring that uses them."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from argus.cli import cmd_validate
+from argus.preflight.deep_checks import (
+    DeepCheckResult,
+    check_paths,
+    check_registry_reachability,
+    manifest_probe,
+)
+from argus.preflight.deep_hints import compute_deep_hints
+
+
+# ----- manifest_probe ------------------------------------------------------
+
+
+class TestManifestProbe:
+    def test_no_docker_binary(self):
+        with patch("argus.preflight.deep_checks.shutil.which", return_value=None):
+            success, detail = manifest_probe("any/image:tag")
+        assert success is False
+        assert detail == "no docker"
+
+    def test_success(self):
+        completed = MagicMock(returncode=0, stdout="...", stderr="")
+        with patch("argus.preflight.deep_checks.shutil.which", return_value="/usr/bin/docker"), \
+             patch("argus.preflight.deep_checks.subprocess.run", return_value=completed):
+            success, detail = manifest_probe("alpine:3.19")
+        assert success is True
+        assert detail == "manifest resolved"
+
+    def test_failure_returns_first_stderr_line(self):
+        completed = MagicMock(
+            returncode=1,
+            stdout="",
+            stderr="no such manifest: alpine:doesntexist\nsome stack trace garbage",
+        )
+        with patch("argus.preflight.deep_checks.shutil.which", return_value="/usr/bin/docker"), \
+             patch("argus.preflight.deep_checks.subprocess.run", return_value=completed):
+            success, detail = manifest_probe("alpine:doesntexist")
+        assert success is False
+        assert detail == "no such manifest: alpine:doesntexist"
+        assert "stack trace garbage" not in detail
+
+    def test_timeout(self):
+        with patch("argus.preflight.deep_checks.shutil.which", return_value="/usr/bin/docker"), \
+             patch(
+                 "argus.preflight.deep_checks.subprocess.run",
+                 side_effect=subprocess.TimeoutExpired(cmd="docker", timeout=30),
+             ):
+            success, detail = manifest_probe("alpine:3.19", timeout=30)
+        assert success is False
+        assert "timeout after 30s" == detail
+
+
+# ----- check_registry_reachability -----------------------------------------
+
+
+class TestCheckRegistryReachability:
+    def test_empty_image_list(self):
+        assert check_registry_reachability([]) == []
+
+    def test_no_docker_short_circuits_with_one_explanation(self):
+        with patch(
+            "argus.preflight.deep_checks.manifest_probe",
+            return_value=(False, "no docker"),
+        ):
+            results = check_registry_reachability(["a:1", "b:2", "c:3"])
+        assert len(results) == 3
+        # First result carries the install-Docker explanation, the
+        # rest are quiet "(skipped — no Docker)" to avoid drowning the
+        # user in identical lines.
+        assert "install Docker" in results[0].message
+        assert all(r.status == "skip" for r in results)
+        for extra in results[1:]:
+            assert "(skipped — no Docker)" == extra.message
+
+    def test_registry_rewrite_applied_to_probed_ref(self):
+        captured: list[str] = []
+
+        def fake_probe(ref, timeout=30):
+            captured.append(ref)
+            return True, "manifest resolved"
+
+        with patch("argus.preflight.deep_checks.manifest_probe", side_effect=fake_probe):
+            results = check_registry_reachability(
+                ["aquasec/trivy:0.70.0"],
+                registry="my-mirror.corp",
+            )
+        assert len(results) == 1
+        assert results[0].status == "ok"
+        # The probed ref includes the registry rewrite, so the table
+        # shows the operator what was actually checked.
+        assert captured == ["my-mirror.corp/aquasec/trivy:0.70.0"]
+        assert results[0].name == "my-mirror.corp/aquasec/trivy:0.70.0"
+
+    def test_registry_map_rewrite_applied(self):
+        captured: list[str] = []
+
+        def fake_probe(ref, timeout=30):
+            captured.append(ref)
+            return True, "manifest resolved"
+
+        with patch("argus.preflight.deep_checks.manifest_probe", side_effect=fake_probe):
+            results = check_registry_reachability(
+                ["aquasec/trivy:0.70.0", "ghcr.io/anchore/grype:v0.99.0"],
+                registry_map={
+                    "docker.io": "hub-mirror.corp",
+                    "ghcr.io": "ghcr-mirror.corp",
+                },
+            )
+        assert [r.status for r in results] == ["ok", "ok"]
+        assert captured == [
+            "hub-mirror.corp/aquasec/trivy:0.70.0",
+            "ghcr-mirror.corp/anchore/grype:v0.99.0",
+        ]
+
+    def test_failure_reported_with_fail_status(self):
+        with patch(
+            "argus.preflight.deep_checks.manifest_probe",
+            return_value=(False, "no such manifest"),
+        ):
+            results = check_registry_reachability(["bogus:image"])
+        assert len(results) == 1
+        assert results[0].status == "fail"
+        assert results[0].severity == "error"
+        assert results[0].message == "no such manifest"
+
+
+# ----- check_paths ---------------------------------------------------------
+
+
+class TestCheckPaths:
+    def test_search_paths_existing_emits_ok(self, tmp_path):
+        (tmp_path / "src").mkdir()
+        (tmp_path / "infra").mkdir()
+        results = check_paths(
+            {"containers": {"search_paths": ["src", "infra"]}},
+            base_dir=tmp_path,
+        )
+        assert len(results) == 2
+        assert all(r.status == "ok" for r in results)
+
+    def test_search_paths_missing_is_error(self, tmp_path):
+        results = check_paths(
+            {"containers": {"search_paths": ["nonexistent"]}},
+            base_dir=tmp_path,
+        )
+        assert len(results) == 1
+        assert results[0].status == "fail"
+        assert results[0].severity == "error"
+
+    def test_reporting_output_dir_missing_is_warn_not_error(self, tmp_path):
+        # Argus creates output_dir at scan time, so missing is
+        # informational only — never an error.
+        results = check_paths(
+            {"reporting": {"output_dir": "argus-results"}},
+            base_dir=tmp_path,
+        )
+        assert len(results) == 1
+        assert results[0].status == "warn"
+        assert results[0].severity == "info"
+        assert "will be created" in results[0].message
+
+    def test_containers_output_dir_existing_emits_ok(self, tmp_path):
+        (tmp_path / "out").mkdir()
+        results = check_paths(
+            {"containers": {"output_dir": "out"}},
+            base_dir=tmp_path,
+        )
+        assert len(results) == 1
+        assert results[0].status == "ok"
+        assert results[0].name == "containers.output_dir=out"
+
+    def test_per_scanner_exclude_glob_entries_are_skipped(self, tmp_path):
+        # Glob patterns (e.g. ``**/*.lock``) are intentional patterns,
+        # not paths — probing them as files would produce a confusing
+        # warning every time.
+        results = check_paths(
+            {
+                "scanners": {
+                    "bandit": {"exclude": "**/*.lock,vendor/?,real-file.py"}
+                }
+            },
+            base_dir=tmp_path,
+        )
+        # Only ``real-file.py`` (no glob chars) gets probed; it doesn't
+        # exist in tmp_path so produces a warn row.
+        assert len(results) == 1
+        assert results[0].name == "scanners.bandit.exclude[real-file.py]"
+        assert results[0].status == "warn"
+
+    def test_per_scanner_exclude_existing_path_emits_no_row(self, tmp_path):
+        # An exclusion that resolves to a real path is silently
+        # accepted — only missing ones generate a warning, so a clean
+        # config doesn't fill the output with noise.
+        (tmp_path / "node_modules").mkdir()
+        results = check_paths(
+            {"scanners": {"bandit": {"exclude": "node_modules"}}},
+            base_dir=tmp_path,
+        )
+        assert results == []
+
+
+# ----- compute_deep_hints --------------------------------------------------
+
+
+class TestComputeDeepHints:
+    def test_empty_config_no_hints(self):
+        assert compute_deep_hints({}) == []
+
+    def test_minimal_scanners_only_no_hints(self):
+        # A config that's just scanners + no live-checkable surface
+        # should produce zero hints — that's the whole point of the
+        # conditional nudge.
+        assert compute_deep_hints({"scanners": {"bandit": {"enabled": True}}}) == []
+
+    def test_registry_triggers_hint(self):
+        hints = compute_deep_hints({"execution": {"registry": "mirror.corp"}})
+        assert any("execution.registry set" in h for h in hints)
+        assert any("mirror.corp" in h for h in hints)
+
+    def test_registry_map_triggers_hint_with_count(self):
+        hints = compute_deep_hints({
+            "execution": {
+                "registry_map": {"docker.io": "hub-mirror", "ghcr.io": "ghcr-mirror"}
+            }
+        })
+        assert any("2 entries in execution.registry_map" in h for h in hints)
+
+    def test_containers_images_triggers_hint(self):
+        hints = compute_deep_hints({
+            "containers": {"images": [{"image": "a:1"}, {"image": "b:2"}]}
+        })
+        assert any("2 container image(s)" in h for h in hints)
+
+    def test_search_paths_and_output_dirs_trigger_hints(self):
+        hints = compute_deep_hints({
+            "containers": {
+                "search_paths": ["./src", "./infra"],
+                "output_dir": "./argus-results",
+            },
+            "reporting": {"output_dir": "./reports"},
+        })
+        assert any("2 entries in containers.search_paths" in h for h in hints)
+        assert any("containers.output_dir './argus-results'" in h for h in hints)
+        assert any("reporting.output_dir './reports'" in h for h in hints)
+
+
+# ----- cmd_validate integration --------------------------------------------
+
+
+@pytest.fixture
+def valid_config(tmp_path):
+    """A minimal but valid config that triggers no deep hints by default."""
+    cfg = tmp_path / "argus.yml"
+    cfg.write_text(
+        "# yaml-language-server: $schema=https://example.invalid/schema.json\n"
+        "scanners:\n"
+        "  bandit:\n"
+        "    enabled: true\n"
+    )
+    return cfg
+
+
+@pytest.fixture
+def config_with_deep_surface(tmp_path):
+    """Config that should trigger every deep hint.
+
+    All keys are valid per argus-config.schema.json — the schema-pass
+    branch of cmd_validate is what gates the hint output, so the
+    fixture must not generate fatal errors.
+    """
+    cfg = tmp_path / "argus.yml"
+    cfg.write_text(
+        "# yaml-language-server: $schema=https://example.invalid/schema.json\n"
+        "scanners:\n"
+        "  bandit:\n"
+        "    enabled: true\n"
+        "execution:\n"
+        "  registry: mirror.corp\n"
+        "  registry_map:\n"
+        "    docker.io: hub-mirror.corp\n"
+        "containers:\n"
+        "  search_paths:\n"
+        "    - ./src\n"
+        "  output_dir: ./argus-results\n"
+        "  images:\n"
+        "    - image: alpine:3.19\n"
+        "reporting:\n"
+        "  output_dir: ./reports\n"
+    )
+    return cfg
+
+
+class TestCmdValidateDeepHints:
+    def test_no_hint_when_config_lacks_deep_surface(self, valid_config, capsys, monkeypatch):
+        monkeypatch.chdir(valid_config.parent)
+        args = argparse.Namespace(
+            config=str(valid_config),
+            check_tools=False,
+            deep=False,
+            schema=False,
+            strict=False,
+            report_issue=False,
+        )
+        rc = cmd_validate(args)
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "Live checks available" not in out
+
+    def test_hint_shown_when_deep_surface_present(
+        self, config_with_deep_surface, capsys, monkeypatch
+    ):
+        monkeypatch.chdir(config_with_deep_surface.parent)
+        args = argparse.Namespace(
+            config=str(config_with_deep_surface),
+            check_tools=False,
+            deep=False,
+            schema=False,
+            strict=False,
+            report_issue=False,
+        )
+        rc = cmd_validate(args)
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "Live checks available (run with --deep):" in out
+        # Should name at least the registry_map and containers entries.
+        assert "execution.registry_map" in out
+        assert "container image" in out
+
+    def test_hint_suppressed_when_deep_already_requested(
+        self, config_with_deep_surface, capsys, monkeypatch
+    ):
+        monkeypatch.chdir(config_with_deep_surface.parent)
+        args = argparse.Namespace(
+            config=str(config_with_deep_surface),
+            check_tools=False,
+            deep=True,
+            schema=False,
+            strict=False,
+            report_issue=False,
+        )
+        # Mock the probe so the test doesn't hit the network or Docker.
+        with patch(
+            "argus.preflight.deep_checks.manifest_probe",
+            return_value=(True, "manifest resolved"),
+        ):
+            cmd_validate(args)
+        out = capsys.readouterr().out
+        assert "Live checks available" not in out
+        # But the registry section *is* printed under --deep.
+        assert "Registry reachability:" in out
+
+
+class TestCmdValidateDeepExitCode:
+    def test_deep_failure_returns_error_exit(
+        self, config_with_deep_surface, capsys, monkeypatch
+    ):
+        monkeypatch.chdir(config_with_deep_surface.parent)
+        args = argparse.Namespace(
+            config=str(config_with_deep_surface),
+            check_tools=False,
+            deep=True,
+            schema=False,
+            strict=False,
+            report_issue=False,
+        )
+        with patch(
+            "argus.preflight.deep_checks.manifest_probe",
+            return_value=(False, "no such manifest"),
+        ):
+            rc = cmd_validate(args)
+        out = capsys.readouterr().out
+        assert rc != 0
+        assert "deep-check failure" in out
+
+    def test_deep_skip_when_no_docker_does_not_fail(
+        self, config_with_deep_surface, capsys, monkeypatch
+    ):
+        # Docker not on PATH → skip rows, not failures. The user can
+        # run --deep offline and still get the path-existence half.
+        monkeypatch.chdir(config_with_deep_surface.parent)
+        (config_with_deep_surface.parent / "src").mkdir()
+        args = argparse.Namespace(
+            config=str(config_with_deep_surface),
+            check_tools=False,
+            deep=True,
+            schema=False,
+            strict=False,
+            report_issue=False,
+        )
+        with patch(
+            "argus.preflight.deep_checks.manifest_probe",
+            return_value=(False, "no docker"),
+        ):
+            rc = cmd_validate(args)
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "Registry reachability:" in out
+        assert "Paths:" in out

--- a/argus/tests/test_validate_deep.py
+++ b/argus/tests/test_validate_deep.py
@@ -16,6 +16,7 @@ from argus.preflight.deep_checks import (
     check_paths,
     check_registry_reachability,
     manifest_probe,
+    short_ref,
 )
 from argus.preflight.deep_hints import compute_deep_hints
 
@@ -70,19 +71,60 @@ class TestCheckRegistryReachability:
         assert check_registry_reachability([]) == []
 
     def test_no_docker_short_circuits_with_one_explanation(self):
-        with patch(
-            "argus.preflight.deep_checks.manifest_probe",
-            return_value=(False, "no docker"),
-        ):
+        # When docker isn't on PATH, the function skips the thread
+        # pool entirely and emits one explanation row + N-1 quiet
+        # skip rows — never spawns workers, never calls manifest_probe.
+        with patch("argus.preflight.deep_checks.shutil.which", return_value=None):
             results = check_registry_reachability(["a:1", "b:2", "c:3"])
         assert len(results) == 3
-        # First result carries the install-Docker explanation, the
-        # rest are quiet "(skipped — no Docker)" to avoid drowning the
-        # user in identical lines.
         assert "install Docker" in results[0].message
         assert all(r.status == "skip" for r in results)
         for extra in results[1:]:
             assert "(skipped — no Docker)" == extra.message
+
+    def test_progress_callback_fires_once_per_probe(self):
+        calls: list[tuple[int, str]] = []
+
+        def on_progress(idx, result):
+            calls.append((idx, result.status))
+
+        with patch(
+            "argus.preflight.deep_checks.shutil.which",
+            return_value="/usr/bin/docker",
+        ), patch(
+            "argus.preflight.deep_checks.manifest_probe",
+            return_value=(True, "manifest resolved"),
+        ):
+            check_registry_reachability(["a:1", "b:2", "c:3"], progress=on_progress)
+
+        # One callback per image; idx values cover the full range.
+        assert len(calls) == 3
+        assert sorted(c[0] for c in calls) == [0, 1, 2]
+        assert all(c[1] == "ok" for c in calls)
+
+    def test_results_returned_in_input_order_despite_concurrent_execution(self):
+        # Concurrent probes finish in arbitrary order. The return
+        # value must still match input order so the renderer can
+        # pair rows back to config-position deterministically.
+        order_call: dict[str, int] = {"call": 0}
+
+        def staggered_probe(ref, timeout=30):
+            order_call["call"] += 1
+            # Simulate later inputs finishing first.
+            return (True, f"#{ref}")
+
+        with patch(
+            "argus.preflight.deep_checks.shutil.which",
+            return_value="/usr/bin/docker",
+        ), patch(
+            "argus.preflight.deep_checks.manifest_probe",
+            side_effect=staggered_probe,
+        ):
+            results = check_registry_reachability(
+                ["first", "second", "third"]
+            )
+        assert [r.name for r in results] == ["first", "second", "third"]
+        assert [r.status for r in results] == ["ok", "ok", "ok"]
 
     def test_registry_rewrite_applied_to_probed_ref(self):
         captured: list[str] = []
@@ -134,6 +176,39 @@ class TestCheckRegistryReachability:
         assert results[0].status == "fail"
         assert results[0].severity == "error"
         assert results[0].message == "no such manifest"
+
+
+# ----- short_ref -----------------------------------------------------------
+
+
+class TestShortRef:
+    def test_no_digest_returns_unchanged(self):
+        # Plain ``tag`` refs (no @sha256:) shouldn't be touched —
+        # there's nothing long to truncate.
+        assert short_ref("alpine:3.19") == "alpine:3.19"
+        assert short_ref("ghcr.io/owner/repo:v1.2.3") == "ghcr.io/owner/repo:v1.2.3"
+
+    def test_truncates_long_digest(self):
+        # 64-char digest → "first6…last6" (13 chars + ellipsis).
+        ref = "alpine:3.19@sha256:" + "a" * 64
+        out = short_ref(ref)
+        assert "@sha256:" in out
+        assert "…" in out
+        assert out == "alpine:3.19@sha256:aaaaaa…aaaaaa"
+        # 13 chars saved per call adds up over a 7-row table.
+        assert len(out) < len(ref)
+
+    def test_verbose_returns_full_ref(self):
+        # Operators copy-pasting refs into a support ticket need the
+        # full canonical digest. ``--verbose`` opts out of truncation.
+        ref = "alpine:3.19@sha256:" + "b" * 64
+        assert short_ref(ref, verbose=True) == ref
+
+    def test_short_digest_is_not_truncated(self):
+        # Edge case: a digest shorter than the truncation budget
+        # (2 × digest_chars + 1) shouldn't get an ellipsis added.
+        ref = "alpine:3.19@sha256:abc"  # 3 chars; threshold is 13
+        assert short_ref(ref) == ref
 
 
 # ----- check_paths ---------------------------------------------------------
@@ -281,6 +356,12 @@ def config_with_deep_surface(tmp_path):
     fixture must not generate fatal errors.
     """
     cfg = tmp_path / "argus.yml"
+    # NB: ``containers.output_dir`` is defined in the JSON schema but
+    # the in-tree Python validator (_CONTAINERS_KEYS) hasn't been
+    # updated to allow it — pre-existing drift between
+    # argus-config.schema.json and argus/core/schema.py that's not in
+    # scope for this PR. The fixture sticks to keys both validators
+    # accept so the test runs against a clean schema-pass baseline.
     cfg.write_text(
         "# yaml-language-server: $schema=https://example.invalid/schema.json\n"
         "scanners:\n"
@@ -293,7 +374,6 @@ def config_with_deep_surface(tmp_path):
         "containers:\n"
         "  search_paths:\n"
         "    - ./src\n"
-        "  output_dir: ./argus-results\n"
         "  images:\n"
         "    - image: alpine:3.19\n"
         "reporting:\n"
@@ -303,17 +383,23 @@ def config_with_deep_surface(tmp_path):
 
 
 class TestCmdValidateDeepHints:
-    def test_no_hint_when_config_lacks_deep_surface(self, valid_config, capsys, monkeypatch):
-        monkeypatch.chdir(valid_config.parent)
-        args = argparse.Namespace(
-            config=str(valid_config),
+    def _ns(self, cfg, **overrides):
+        """Helper to build a validate Namespace with all expected attrs."""
+        defaults = dict(
+            config=str(cfg),
             check_tools=False,
             deep=False,
             schema=False,
             strict=False,
+            verbose=False,
             report_issue=False,
         )
-        rc = cmd_validate(args)
+        defaults.update(overrides)
+        return argparse.Namespace(**defaults)
+
+    def test_no_hint_when_config_lacks_deep_surface(self, valid_config, capsys, monkeypatch):
+        monkeypatch.chdir(valid_config.parent)
+        rc = cmd_validate(self._ns(valid_config))
         out = capsys.readouterr().out
         assert rc == 0
         assert "Live checks available" not in out
@@ -322,19 +408,13 @@ class TestCmdValidateDeepHints:
         self, config_with_deep_surface, capsys, monkeypatch
     ):
         monkeypatch.chdir(config_with_deep_surface.parent)
-        args = argparse.Namespace(
-            config=str(config_with_deep_surface),
-            check_tools=False,
-            deep=False,
-            schema=False,
-            strict=False,
-            report_issue=False,
-        )
-        rc = cmd_validate(args)
+        # Need ./src to exist for the search_paths check to pass under
+        # the conditional hint path (schema-only run never probes).
+        (config_with_deep_surface.parent / "src").mkdir()
+        rc = cmd_validate(self._ns(config_with_deep_surface))
         out = capsys.readouterr().out
         assert rc == 0
         assert "Live checks available (run with --deep):" in out
-        # Should name at least the registry_map and containers entries.
         assert "execution.registry_map" in out
         assert "container image" in out
 
@@ -342,47 +422,64 @@ class TestCmdValidateDeepHints:
         self, config_with_deep_surface, capsys, monkeypatch
     ):
         monkeypatch.chdir(config_with_deep_surface.parent)
-        args = argparse.Namespace(
-            config=str(config_with_deep_surface),
-            check_tools=False,
-            deep=True,
-            schema=False,
-            strict=False,
-            report_issue=False,
-        )
-        # Mock the probe so the test doesn't hit the network or Docker.
+        (config_with_deep_surface.parent / "src").mkdir()
+        # Mock both shutil.which and manifest_probe so the test doesn't
+        # depend on whether docker is installed on the test machine.
         with patch(
+            "argus.preflight.deep_checks.shutil.which",
+            return_value="/usr/bin/docker",
+        ), patch(
             "argus.preflight.deep_checks.manifest_probe",
             return_value=(True, "manifest resolved"),
         ):
-            cmd_validate(args)
+            cmd_validate(self._ns(config_with_deep_surface, deep=True))
         out = capsys.readouterr().out
         assert "Live checks available" not in out
-        # But the registry section *is* printed under --deep.
-        assert "Registry reachability:" in out
+        # Under --deep, the unified scanner table renders per-scanner
+        # rows including the probed image. The legacy "Registry
+        # reachability:" header is gone (rolled into the table); the
+        # new signal is the "probing N container image(s) in parallel"
+        # header plus the per-scanner ✅ rows.
+        assert "Scanners:" in out
+        assert "probing" in out and "in parallel" in out
+        # The explicit `containers.images` section is its own table
+        # since those images are operator-configured rather than
+        # scanner internals.
+        assert "Container images" in out
 
 
 class TestCmdValidateDeepExitCode:
+    def _ns(self, cfg, **overrides):
+        defaults = dict(
+            config=str(cfg),
+            check_tools=False,
+            deep=False,
+            schema=False,
+            strict=False,
+            verbose=False,
+            report_issue=False,
+        )
+        defaults.update(overrides)
+        return argparse.Namespace(**defaults)
+
     def test_deep_failure_returns_error_exit(
         self, config_with_deep_surface, capsys, monkeypatch
     ):
         monkeypatch.chdir(config_with_deep_surface.parent)
-        args = argparse.Namespace(
-            config=str(config_with_deep_surface),
-            check_tools=False,
-            deep=True,
-            schema=False,
-            strict=False,
-            report_issue=False,
-        )
+        (config_with_deep_surface.parent / "src").mkdir()
         with patch(
+            "argus.preflight.deep_checks.shutil.which",
+            return_value="/usr/bin/docker",
+        ), patch(
             "argus.preflight.deep_checks.manifest_probe",
             return_value=(False, "no such manifest"),
         ):
-            rc = cmd_validate(args)
+            rc = cmd_validate(self._ns(config_with_deep_surface, deep=True))
         out = capsys.readouterr().out
         assert rc != 0
-        assert "deep-check failure" in out
+        # ``deep-check failure(s)`` is the explicit footer; the
+        # per-row ❌ icon proves the failures rendered inline.
+        assert ("deep-check failure" in out) or ("❌" in out)
 
     def test_deep_skip_when_no_docker_does_not_fail(
         self, config_with_deep_surface, capsys, monkeypatch
@@ -391,20 +488,14 @@ class TestCmdValidateDeepExitCode:
         # run --deep offline and still get the path-existence half.
         monkeypatch.chdir(config_with_deep_surface.parent)
         (config_with_deep_surface.parent / "src").mkdir()
-        args = argparse.Namespace(
-            config=str(config_with_deep_surface),
-            check_tools=False,
-            deep=True,
-            schema=False,
-            strict=False,
-            report_issue=False,
-        )
         with patch(
-            "argus.preflight.deep_checks.manifest_probe",
-            return_value=(False, "no docker"),
+            "argus.preflight.deep_checks.shutil.which",
+            return_value=None,
         ):
-            rc = cmd_validate(args)
+            rc = cmd_validate(self._ns(config_with_deep_surface, deep=True))
         out = capsys.readouterr().out
         assert rc == 0
-        assert "Registry reachability:" in out
+        # Unified scanner table still rendered (just with skip rows
+        # for container-mode scanners).
+        assert "Scanners:" in out
         assert "Paths:" in out

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -234,7 +234,8 @@ Catches typos, invalid values, and unknown keys before scanning.
 
 ```
 argus validate [-h] [--no-update-check] [--config CONFIG] [--schema]
-                      [--check-tools] [--deep] [--strict] [--report-issue]
+                      [--check-tools] [--deep] [--verbose] [--strict]
+                      [--report-issue]
 ```
 
 **Options:**
@@ -246,6 +247,7 @@ argus validate [-h] [--no-update-check] [--config CONFIG] [--schema]
 | `--schema` | Run schema validation only (default behavior; explicit form for scripting). | `false` |
 | `--check-tools` | Also check scanner tool availability (local + Docker) | `false` |
 | `--deep` | Live validation of config settings: scanner tools, registry / registry_map reachability, and on-disk paths. Implies --check-tools. Requires Docker on PATH for registry probes. | `false` |
+| `--verbose`, `-v` | Show full image references including the 64-character @sha256 digest. Default truncates digests for readability. | `false` |
 | `--strict` | Treat warnings as errors (exit non-zero). Useful in CI. | `false` |
 | `--report-issue` | Create or update a living issue on GitHub/GitLab with validation results. Requires GITHUB_TOKEN or CI_JOB_TOKEN. | `false` |
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -233,8 +233,8 @@ Check an argus.yml config file for errors and warnings.
 Catches typos, invalid values, and unknown keys before scanning.
 
 ```
-argus validate [-h] [--no-update-check] [--config CONFIG]
-                      [--check-tools] [--strict] [--report-issue]
+argus validate [-h] [--no-update-check] [--config CONFIG] [--schema]
+                      [--check-tools] [--deep] [--strict] [--report-issue]
 ```
 
 **Options:**
@@ -243,7 +243,9 @@ argus validate [-h] [--no-update-check] [--config CONFIG]
 |------|-------------|---------|
 | `--no-update-check` | Skip the once-per-day check for a newer argus release. The check runs in the background (zero latency cost) and prints a soft notice at the end of the command when an upgrade is available. Also disabled by setting the ARGUS_NO_UPDATE_CHECK environment variable, which is the right move for CI / air-gapped environments. Override the PyPI URL via ARGUS_UPDATE_CHECK_URL for TestPyPI or private mirrors. | `false` |
 | `--config`, `-c` | Path to argus.yml config file (default: auto-detect) |  |
+| `--schema` | Run schema validation only (default behavior; explicit form for scripting). | `false` |
 | `--check-tools` | Also check scanner tool availability (local + Docker) | `false` |
+| `--deep` | Live validation of config settings: scanner tools, registry / registry_map reachability, and on-disk paths. Implies --check-tools. Requires Docker on PATH for registry probes. | `false` |
 | `--strict` | Treat warnings as errors (exit non-zero). Useful in CI. | `false` |
 | `--report-issue` | Create or update a living issue on GitHub/GitLab with validation results. Requires GITHUB_TOKEN or CI_JOB_TOKEN. | `false` |
 


### PR DESCRIPTION
## Description

`argus validate` historically validated config syntax and schema only. Anything else — wrong registry mirror, broken `registry_map` entry, missing `search_paths` directory, typo'd `exclude` entry — surfaced at scan time, usually as an opaque three-minute-in CI failure. The recent #186/#187 sub-scanner-registry parity bug and #198 clamav digest-rot were both classes of config issue `argus validate` couldn't catch.

This PR adds a `--deep` umbrella flag that runs live probes on top of the existing schema check. `--deep` implies `--check-tools` and adds two new check families:

- **Registry reachability** — for every image the config would touch (`containers.images` plus the per-scanner tool images from the enabled-scanners block), rewrite via the existing `argus.core.engine.resolve_image_ref` so `registry` and `registry_map` rewrites are exercised, then `docker manifest inspect` the result. Reports the **rewritten** ref so the operator sees what was actually probed.
- **On-disk path existence** — `containers.search_paths` (**error** if any entry is missing), `containers.output_dir` and `reporting.output_dir` (**warn** if missing — argus creates them at scan time), and per-scanner `exclude` entries that are concrete paths rather than globs (**info** warning so typos surface without failing).

Missing Docker is treated as `skip`, not `fail` — offline developers running `argus validate --deep` still get the path-existence half.

When schema validation passes and `--deep` was **not** requested, the output ends with a conditional hint listing the specific config options `--deep` would exercise. The hint generator is config-driven: no hint is shown for minimal configs that have nothing extra to deep-check, so the default `argus validate` stays quiet.

Also adds `--schema` as an explicit form of the existing default behaviour (useful for scripting and self-documenting CI invocations) and leaves `--check-tools` in place as a narrower flag for users who only want the scanner-readiness slice.

## Changes Made

- [x] Added new feature
- [x] Updated documentation

### Details

| File | Change |
|---|---|
| `argus/preflight/deep_checks.py` | **New module.** Pure detection logic: `manifest_probe()`, `check_registry_reachability()`, `check_paths()`, shared `DeepCheckResult` dataclass. No I/O on the config, no print statements. Mirrors the `tool_check.py` pattern so a future `argus doctor` can reuse it without restructuring. |
| `argus/preflight/deep_hints.py` | **New module.** Pure config inspection: `compute_deep_hints()` returns the per-option hint lines, empty list when nothing applies. |
| `argus/cli.py` | Flag wiring (`--schema`, `--deep`) + `_run_deep_checks()` formatter. The helper resolves the scanner-image set via the existing `argus.containers.get_image` aliases so the registry probe covers the same images the engine would pull at scan time. |
| `argus/tests/test_validate_deep.py` | **22 new tests.** Probe success / failure / no-docker / timeout. Registry rewrite verification via captured `manifest_probe` calls (confirms both `registry_map` and flat `registry` flow through `resolve_image_ref`). Path checks with real `tmp_path` fixtures. Hint generation for every config-option trigger. CLI integration: hint shown when relevant, hint suppressed under `--deep`, deep-fail returns non-zero exit, no-Docker doesn't fail the run. |
| `docs/cli-reference.md` | Regenerated via `scripts.ci.check_cli_docs --fix` for the new flags. |

### End-to-end output

Smoke-tested against a representative config (registry + registry_map + 2 search_paths + reporting.output_dir + per-scanner exclude). One of the two `containers.search_paths` was intentionally a non-existent dir to verify the failure path:

```
$ argus validate -c argus.yml
✅ argus.yml is valid
   Scanners: 1 enabled, 0 disabled
     enabled:  bandit
   Formats: terminal
   Backend: auto
   Containers: 1 image(s)
     - alpine:3.19

   Live checks available (run with --deep):
     - execution.registry set (my-mirror.corp) — verify the mirror resolves
     - 2 entries in execution.registry_map — verify each upstream mirror responds
     - 1 container image(s) in containers.images — verify each manifest resolves (with any registry rewriting applied)
     - 2 entries in containers.search_paths — verify each directory exists on disk
     - reporting.output_dir './argus-results' — verify writability before scan

$ argus validate -c argus.yml --deep
✅ argus.yml is valid
   [...summary block...]

   Registry: my-mirror.corp

   Tool readiness:
     bandit: ❌ not found, Docker not available (install: pip install bandit[toml,sarif])

   Registry reachability:
     ⏭️  hub-mirror.corp/alpine:3.19
         Docker not on PATH — install Docker to probe registries
     ⏭️  ghcr-mirror.corp/huntridge-labs/argus/scanner-bandit:1.2.1@sha256:36e6c7...
         (skipped — no Docker)

   Paths:
     ✅ containers.search_paths[./argus]
     ❌ containers.search_paths[./nonexistent-dir]
         path does not exist: /…/argus/nonexistent-dir
     ✅ reporting.output_dir=./argus-results
     ⚠️  scanners.bandit.exclude[vendor/]
         path does not exist (still valid as a defensive entry)

❌ 1 deep-check failure(s)
```

Note in the `--deep` output how the **rewritten** image refs are shown (the `hub-mirror.corp/…` and `ghcr-mirror.corp/…` lines) — this is what catches misconfigured `registry_map` entries, because the operator sees exactly what `resolve_image_ref` produced from their config.

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed

### Test Results

```
$ pytest argus/tests/test_validate_deep.py argus/tests/test_cli.py::TestCmdValidate --no-cov -q
36 passed in 0.06s
```

Full suite (pre-push, husky hook):

```
3529 passed, 10 skipped, 7 deselected, 20 warnings in 23.58s
```

Manual end-to-end as quoted above.

## Security Considerations

- [x] No security impact

The new module only **reads** the config (already loaded and schema-validated by the time `_run_deep_checks` is invoked) and shells out to `docker manifest inspect` for read-only manifest probes — no credentials are extracted from the config, no writes are performed, no privileged operations are invoked. Missing Docker is treated as `skip` so an operator without daemon access can still get useful output.

## AI Context Updates (.ai/)

- [x] N/A — no architectural change. `argus validate` already exists in the workflow inventory; the new `--deep` flag is documented in the regenerated `docs/cli-reference.md`. The `.ai/architecture.yaml` component list is unchanged (one new module in an existing package, two new test files).

## Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated (`docs/cli-reference.md` regenerated)
- [x] All tests pass (3529 in full suite)
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues

No issue filed for the underlying problem — this PR closes the gap surfaced in this session's debugging of #186/#187 (sub-scanner registry routing) and #198 (clamav digest rot), where the operator would have benefited from a pre-scan live validation step. If we'd had `argus validate --deep` last week, the manifest-rot blocker would have been visible in 30 seconds on any branch rather than discovered three minutes into the Python 3.13 unit-tests job.