### PR TITLE
feat(scanner-kics): add KICS IaC scanner

### DIFF
--- a/.ai/architecture.yaml
+++ b/.ai/architecture.yaml
@@ -258,6 +258,10 @@ scanners:
     - name: checkov
       purpose: "IaC policy-as-code scanning"
       output: SARIF
+    - name: kics
+      purpose: "Multi-format IaC scanning — Ansible, Bicep, Helm, Terraform, Kubernetes, Dockerfile, CloudFormation, OpenAPI"
+      output: JSON
+      note: "Checkmarx KICS (Apache-2.0). Runs concurrently with trivy-iac/checkov — they catch different things on the same target (issue #188)"
 
   dependencies:
     - name: osv
@@ -526,6 +530,7 @@ docsite:
       - gitleaks
       - osv
       - checkov
+      - kics
       - opengrep
       - supply-chain
       - zap

--- a/argus/containers.py
+++ b/argus/containers.py
@@ -32,6 +32,12 @@ OFFICIAL_IMAGES = {
     "gitleaks": "zricethezav/gitleaks:v8.30.1@sha256:c00b6bd0aeb3071cbcb79009cb16a60dd9e0a7c60e2be9ab65d25e6bc8abbb7f",
     "clamav": "clamav/clamav:1.5.2-35@sha256:898c176d1cfec61d4585f71d1e2e8515b3cc8d5f83cd9fc2f6748e8b20de82a2",
     "checkov": "bridgecrew/checkov:3.2.527@sha256:f4c7c5bde21df03432ca8d9d1305ffe21b7205ea752c3d4e65559abae67ead4a",
+    # KICS (Checkmarx) multi-format IaC scanner. The upstream
+    # ``checkmarx/kics`` repo tags ``:latest`` mutably (no semver release
+    # tag per build), so the digest pin below is the content-hash gate
+    # that protects us between Renovate-driven bumps — same pattern as
+    # the eslint entry.
+    "kics": "checkmarx/kics:latest@sha256:3e5a268eb8adda2e5a483c9359ddfc4cd520ab856a7076dc0b1d8784a37e2602",
     "osv-scanner": "ghcr.io/google/osv-scanner:v2.3.6@sha256:2e07e642463100474fc5e214b66e6beccbd6bfa63dd3fbf047b3f755e78a6cfe",
     "zap": "ghcr.io/zaproxy/zaproxy:2.17.0@sha256:8770b23f9e8b49038f413cb2b10c58c901e5b6717be221a22b1bcab5c9771b8a",
     "hadolint": "hadolint/hadolint:v2.14.0@sha256:27086352fd5e1907ea2b934eb1023f217c5ae087992eb59fde121dce9c9ff21e",

--- a/argus/scanners/__init__.py
+++ b/argus/scanners/__init__.py
@@ -6,6 +6,7 @@ from .clamav import ClamavScanner
 from .container import ContainerScanner
 from .gitleaks import GitleaksScanner
 from .grype import GrypeScanner
+from .kics import KICSScanner
 from .opengrep import OpengrepScanner
 from .osv import OsvScanner
 from .supply_chain import SupplyChainScanner
@@ -21,6 +22,7 @@ __all__ = [
     "ContainerScanner",
     "GitleaksScanner",
     "GrypeScanner",
+    "KICSScanner",
     "OpengrepScanner",
     "OsvScanner",
     "SupplyChainScanner",
@@ -43,6 +45,7 @@ SCANNER_REGISTRY = {
     "gitleaks": GitleaksScanner,
     "osv": OsvScanner,
     "checkov": CheckovScanner,
+    "kics": KICSScanner,
     "opengrep": OpengrepScanner,
     "supply-chain": SupplyChainScanner,
     "zap": ZapScanner,

--- a/argus/scanners/kics.py
+++ b/argus/scanners/kics.py
@@ -1,0 +1,225 @@
+"""KICS (Keeping Infrastructure as Code Secure) scanner.
+
+KICS (Checkmarx, Apache-2.0) is a multi-format IaC scanner. It covers
+formats the existing ``trivy-iac`` / ``checkov`` pair handles poorly or
+not at all — Ansible, Bicep, Helm, CDK output, OpenAPI, Tekton, Buildah,
+and several server-side template engines — alongside the usual
+Terraform / Kubernetes / Dockerfile / CloudFormation surface (see
+issue #188). The three IaC scanners are intentionally allowed to run
+concurrently: they catch different things on the same target.
+
+CLI shape::
+
+    kics scan -p <path> --report-formats json -o <outdir>
+
+KICS writes ``results.json`` into ``<outdir>`` (filename fixed by KICS,
+not configurable per-format). The JSON has a top-level ``queries`` array;
+each query is one rule and carries a ``files`` array of per-match
+locations.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+from argus.containers import get_image
+from argus.core.models import Finding, ScanResult, Severity
+from argus.core.redact import redact_secret
+from argus.core.scanner_template import ScanPaths
+from argus.core.version import parse_tool_version
+
+
+# KICS per-match fields that echo raw source content. ``actual_value``
+# and ``search_value`` quote the literal that triggered the match — for
+# a secrets/credentials query (KICS ships Ansible "Passwords And Secrets"
+# and Dockerfile/K8s secret queries) that literal IS the secret. We
+# redact every per-match value field before it reaches a Finding rather
+# than trying to enumerate which query IDs are secret-bearing: the
+# location (``file_name:line``) plus the query name is enough triage
+# signal, and the raw value carries no defensive benefit downstream.
+_REDACTED_MATCH_FIELDS = ("actual_value", "expected_value", "search_value")
+
+# KICS emits the fixed name ``results.json`` for ``--report-formats json``.
+_KICS_RESULT_FILENAME = "results.json"
+
+
+class KICSScanner:
+    """Wraps KICS to scan infrastructure-as-code for misconfigurations."""
+
+    name = "kics"
+    description = (
+        "Multi-format IaC scanner — Ansible, Bicep, Helm, Terraform, "
+        "Kubernetes, Dockerfile, CloudFormation, OpenAPI and more"
+    )
+    category = "iac"
+    languages = [
+        "ansible",
+        "bicep",
+        "helm",
+        "terraform",
+        "kubernetes",
+        "dockerfile",
+        "cloudformation",
+        "openapi",
+    ]
+    container_image = get_image("kics")
+    # The official KICS image uses ENTRYPOINT ["kics"]; engine strips
+    # argv[0] for ENTRYPOINT-based images.
+    container_entrypoint = "kics"
+
+    def scan(self, path: str, config: dict | None = None) -> ScanResult:
+        """Run a KICS scan against *path* and return results.
+
+        KICS exits non-zero when it finds issues (exit 40/50 = results
+        at/above the configured severity). That's the happy path, not a
+        failure — only a missing ``results.json`` is treated as an
+        execution failure.
+        """
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            output_file = Path(tmp_dir) / _KICS_RESULT_FILENAME
+            paths = ScanPaths(
+                workspace=path,
+                output=str(output_file),
+            )
+
+            result = subprocess.run(
+                self.build_args(paths, config or {}),
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+            )
+
+            if not output_file.exists():
+                return ScanResult(
+                    scanner=self.name,
+                    metadata={
+                        "execution_failed": True,
+                        "execution_failure_reason": (
+                            f"No output produced (exit={result.returncode}). "
+                            f"stderr: {(result.stderr or '').strip()[:400]}"
+                        ),
+                    },
+                )
+
+            findings = self.parse_results(output_file)
+            return ScanResult(
+                scanner=self.name,
+                findings=findings,
+                raw_report=output_file,
+            )
+
+    def build_args(self, paths: ScanPaths, config: dict) -> list[str]:
+        """Build the full argv (including the binary name).
+
+        ``ScanPaths.output`` is a file path (``.../results.json``) in both
+        execution environments — the engine's container path passes
+        ``/output/results.json``, local ``scan()`` passes a tempdir file.
+        KICS's ``-o`` takes the output *directory* and names the file
+        ``results.json`` itself, so we pass the parent dir. Engine drops
+        argv[0] for ENTRYPOINT-based images, so the same method serves
+        local and container execution.
+        """
+        output_dir = os.path.dirname(paths.output) or "."
+        args = [
+            "kics", "scan",
+            "-p", paths.workspace,
+            "--report-formats", "json",
+            "-o", output_dir,
+            # Don't let a single unparsable file abort the whole scan,
+            # and don't colorize the JSON path's stderr.
+            "--no-progress",
+            "--no-color",
+        ]
+        config_file = config.get("config_file")
+        if config_file:
+            # Local: caller passes the host path; container: prefix the
+            # workspace mount since the file is mounted there.
+            args.extend([
+                "--config",
+                config_file if "/" in config_file else f"{paths.workspace}/{config_file}",
+            ])
+        exclude = config.get("exclude")
+        if exclude:
+            args.extend(["--exclude-paths", exclude])
+        return args
+
+    def is_available(self) -> bool:
+        """Check if KICS is installed."""
+        return shutil.which("kics") is not None
+
+    def install_command(self) -> str | None:
+        """Return install command for KICS."""
+        return "curl -sfL https://raw.githubusercontent.com/Checkmarx/kics/master/install.sh | bash"
+
+    def tool_version(self) -> str | None:
+        """Return the installed KICS version, or None if not available."""
+        if not self.is_available():
+            return None
+        return parse_tool_version(["kics", "version"], r"(\d+\.\d+\.\d+)")
+
+    def parse_results(self, raw_output_path: Path) -> list[Finding]:
+        """Parse KICS JSON output into findings.
+
+        One :class:`Finding` is emitted per (query, matched-file) pair so
+        each finding points at a concrete ``file:line`` location, mirroring
+        how ``trivy-iac`` emits one finding per misconfiguration site.
+        """
+        data = json.loads(
+            raw_output_path.read_text(encoding="utf-8", errors="replace")
+        )
+        queries = data.get("queries", [])
+
+        findings: list[Finding] = []
+        for query in queries:
+            for matched_file in query.get("files", []):
+                findings.append(self._parse_match(query, matched_file))
+        return findings
+
+    def _parse_match(self, query: dict, matched_file: dict) -> Finding:
+        """Convert a single (query, matched-file) pair into a Finding.
+
+        Redaction commitment: KICS echoes the offending source snippet in
+        ``actual_value`` / ``expected_value`` / ``search_value``. For a
+        secrets-class query that snippet is the secret itself, so every
+        per-match value field is replaced with the redaction placeholder
+        before it reaches ``Finding.metadata``. The ``file:line`` location
+        and query name remain as triage signal. ``Finding.__post_init__``
+        runs a vendor-prefix second pass as defence-in-depth.
+        """
+        severity = Severity.from_string(query.get("severity", "UNKNOWN"))
+
+        file_name = matched_file.get("file_name", "")
+        line = matched_file.get("line")
+        location = f"{file_name}:{line}" if file_name and line else (file_name or None)
+
+        cwe_raw = query.get("cwe")
+        cwe = f"CWE-{cwe_raw}" if cwe_raw else None
+
+        redacted_match = {
+            field: redact_secret(matched_file.get(field))
+            for field in _REDACTED_MATCH_FIELDS
+            if matched_file.get(field) is not None
+        }
+
+        return Finding(
+            id=query.get("query_id", "UNKNOWN"),
+            severity=severity,
+            title=query.get("query_name", ""),
+            description=query.get("description", ""),
+            location=location,
+            cwe=cwe,
+            scanner=self.name,
+            metadata={
+                "platform": query.get("platform", ""),
+                "category": query.get("category", ""),
+                "query_url": query.get("query_url", ""),
+                "issue_type": matched_file.get("issue_type", ""),
+                "expected_value": redacted_match.get("expected_value", ""),
+                "actual_value": redacted_match.get("actual_value", ""),
+                "search_value": redacted_match.get("search_value", ""),
+            },
+        )

--- a/argus/tests/scanners/test_kics.py
+++ b/argus/tests/scanners/test_kics.py
@@ -1,0 +1,135 @@
+"""Tests for argus.scanners.kics — KICSScanner."""
+
+import json
+
+from argus.core.models import Severity
+from argus.core.redact import REDACTED_PLACEHOLDER
+from argus.core.scanner_template import ScanPaths
+from argus.scanners.kics import KICSScanner
+
+
+class TestKICSParseResults:
+    """Test KICSScanner.parse_results with fixture data."""
+
+    def test_parse_results_with_findings(self, fixtures_dir):
+        scanner = KICSScanner()
+        path = fixtures_dir / "kics" / "results-with-findings.json"
+        findings = scanner.parse_results(path)
+
+        assert len(findings) == 4
+
+        severities = [f.severity for f in findings]
+        assert severities.count(Severity.HIGH) == 1
+        assert severities.count(Severity.MEDIUM) == 1
+        assert severities.count(Severity.LOW) == 1
+        assert severities.count(Severity.INFO) == 1
+
+    def test_parse_results_zero_findings(self, fixtures_dir):
+        scanner = KICSScanner()
+        path = fixtures_dir / "kics" / "results-zero-findings.json"
+        findings = scanner.parse_results(path)
+
+        assert len(findings) == 0
+
+    def test_finding_fields(self, fixtures_dir):
+        scanner = KICSScanner()
+        path = fixtures_dir / "kics" / "results-with-findings.json"
+        findings = scanner.parse_results(path)
+
+        medium = [f for f in findings if f.severity == Severity.MEDIUM][0]
+        assert medium.id == "63ec5b46-7c4a-4e3e-9b8f-3d2c8e1f0a11"
+        assert "encryption" in medium.title.lower()
+        assert medium.scanner == "kics"
+        assert medium.cwe == "CWE-311"
+        assert medium.location == "terraform/s3.tf:8"
+        assert medium.metadata["platform"] == "Terraform"
+        assert medium.metadata["category"] == "Encryption"
+
+    def test_finding_without_cwe_has_none(self, fixtures_dir):
+        scanner = KICSScanner()
+        path = fixtures_dir / "kics" / "results-with-findings.json"
+        findings = scanner.parse_results(path)
+
+        # The LOW (Kubernetes runAsNonRoot) query has no cwe in the fixture.
+        low = [f for f in findings if f.severity == Severity.LOW][0]
+        assert low.cwe is None
+
+
+class TestKICSScannerMeta:
+    """Test KICSScanner metadata methods."""
+
+    def test_name(self):
+        assert KICSScanner().name == "kics"
+
+    def test_category(self):
+        assert KICSScanner().category == "iac"
+
+    def test_install_command(self):
+        cmd = KICSScanner().install_command()
+        assert cmd is not None
+        assert "kics" in cmd
+
+    def test_build_args_passes_output_directory(self):
+        # KICS -o takes the output *directory*, not the results file.
+        scanner = KICSScanner()
+        paths = ScanPaths(workspace="/workspace", output="/output/results.json")
+        args = scanner.build_args(paths, {})
+
+        assert "scan" in args
+        assert "/workspace" in args
+        # -o is followed by the parent dir of the results file.
+        out_idx = args.index("-o")
+        assert args[out_idx + 1] == "/output"
+        # JSON report format requested.
+        fmt_idx = args.index("--report-formats")
+        assert args[fmt_idx + 1] == "json"
+
+
+class TestKICSRedaction:
+    """KICS echoes the offending source snippet in each match's
+    ``actual_value`` / ``expected_value`` / ``search_value``. For a
+    secrets-class query (KICS ships "Passwords And Secrets" queries for
+    Ansible, Dockerfile, K8s, etc.) that snippet IS the secret, leaking
+    to every downstream consumer — terminal output, JSON / Markdown /
+    SARIF exports, and the MCP server's AI-assistant context.
+
+    These tests assert the parser strips every per-match value field so
+    the literal never reaches a Finding, while the location + query name
+    remain as triage signal.
+    """
+
+    # The HIGH "Generic Password" query in the fixture carries this
+    # literal in both search_value and actual_value. Distinctive so a
+    # substring leak-check over the serialized Finding can't be fooled
+    # by overlap with KICS's own rule taxonomy.
+    _SECRET_LITERAL = "s3cr3t-pw-KICS999"
+
+    def test_match_value_fields_are_redacted(self, fixtures_dir):
+        scanner = KICSScanner()
+        path = fixtures_dir / "kics" / "results-with-findings.json"
+        findings = scanner.parse_results(path)
+
+        secret = [
+            f for f in findings
+            if f.id == "487f4be7-3fd9-4506-a07a-eae252180c08"
+        ]
+        assert secret, "fixture is expected to include the secrets query"
+        for f in secret:
+            assert f.metadata["actual_value"] == REDACTED_PLACEHOLDER
+            assert f.metadata["search_value"] == REDACTED_PLACEHOLDER
+            assert f.metadata["expected_value"] == REDACTED_PLACEHOLDER
+
+    def test_secret_literal_never_appears_in_serialized_finding(self, fixtures_dir):
+        # Belt-and-suspenders: dump the whole Finding to JSON and assert
+        # the literal isn't present anywhere — catches a future field we
+        # forgot to redact.
+        scanner = KICSScanner()
+        path = fixtures_dir / "kics" / "results-with-findings.json"
+        findings = scanner.parse_results(path)
+
+        for f in findings:
+            blob = json.dumps(f.to_dict())
+            assert self._SECRET_LITERAL not in blob, (
+                f"KICS secret literal {self._SECRET_LITERAL!r} leaked into "
+                "Finding JSON — redaction regressed"
+            )

--- a/docs/scanners.md
+++ b/docs/scanners.md
@@ -62,6 +62,7 @@ See [examples/github-enterprise/](../examples/github-enterprise/) for GHES templ
 - [Infrastructure Scanners](#infrastructure-scanners)
   - [Trivy IaC](#trivy-iac)
   - [Checkov](#checkov)
+  - [KICS](#kics)
 - [Malware Scanner](#malware-scanner)
   - [ClamAV](#clamav)
 - [DAST Scanners](#dast-scanners)
@@ -526,6 +527,46 @@ with:
   framework: terraform
   enable_code_security: true
 ```
+
+</details>
+
+### KICS
+
+Checkmarx KICS (Keeping Infrastructure as Code Secure) — multi-format IaC scanner with ~3000 built-in queries (Apache-2.0). Covers formats `trivy-iac`/`checkov` handle poorly or not at all, most notably **Ansible**.
+
+**Supported frameworks:** Ansible, Bicep, Helm, Terraform, Kubernetes, Dockerfile, CloudFormation, OpenAPI, Tekton, Buildah, and server-side template engines.
+
+KICS, `trivy-iac`, and `checkov` are designed to run concurrently — they catch different things on the same target. Scope KICS to `--scanners kics` if you only want the formats the other two miss.
+
+<details>
+<summary><strong>Configuration & Examples</strong></summary>
+
+**SDK usage:**
+
+```bash
+# Run KICS on its own
+argus scan kics --path infrastructure/
+
+# Run the full IaC trio
+argus scan trivy-iac checkov kics
+```
+
+**Severity levels:** HIGH, MEDIUM, LOW, INFO (mapped directly to Argus severities).
+
+**Config (`argus.yml`):**
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `config_file` | Path to a KICS config file (`--config`) | `''` |
+| `exclude` | Comma-separated paths to exclude (`--exclude-paths`) | `''` |
+
+```yaml
+scanners:
+  kics:
+    exclude: "examples,vendor"
+```
+
+> **Secrets handling:** KICS echoes the offending source snippet in each match's `actual_value` / `search_value` fields, which for a secrets-class query is the secret itself. Argus redacts all per-match value fields before they reach a finding — the `file:line` location and query name remain as triage signal.
 
 </details>
 
@@ -1029,7 +1070,7 @@ with:
 python -m argus scan codeql opengrep bandit gitleaks
 
 # Infrastructure only
-python -m argus scan trivy-iac checkov
+python -m argus scan trivy-iac checkov kics
 
 # Container only
 python -m argus scan container

--- a/tests/fixtures/scanner-outputs/kics/results-with-findings.json
+++ b/tests/fixtures/scanner-outputs/kics/results-with-findings.json
@@ -1,0 +1,116 @@
+{
+  "kics_version": "v2.1.3",
+  "files_scanned": 6,
+  "lines_scanned": 412,
+  "files_parsed": 6,
+  "lines_parsed": 412,
+  "queries_total": 3012,
+  "queries_failed_to_execute": 0,
+  "scan_id": "console",
+  "severity_counters": {
+    "HIGH": 1,
+    "MEDIUM": 1,
+    "LOW": 1,
+    "INFO": 1,
+    "TRACE": 0
+  },
+  "total_counter": 4,
+  "total_bom_resources": 0,
+  "start": "2026-05-26T12:00:00.000000Z",
+  "end": "2026-05-26T12:00:11.000000Z",
+  "paths": [
+    "/workspace"
+  ],
+  "queries": [
+    {
+      "query_name": "Passwords And Secrets - Generic Password",
+      "query_id": "487f4be7-3fd9-4506-a07a-eae252180c08",
+      "query_url": "https://docs.kics.io/latest/secrets/",
+      "severity": "HIGH",
+      "platform": "Ansible",
+      "category": "Secret Management",
+      "description": "Query to find passwords and secrets in infrastructure code.",
+      "description_id": "d69d8d87",
+      "cwe": "798",
+      "files": [
+        {
+          "file_name": "playbooks/deploy.yml",
+          "similarity_id": "a1b2c3",
+          "line": 14,
+          "issue_type": "RedundantAttribute",
+          "search_key": "db_password",
+          "search_value": "db_password: s3cr3t-pw-KICS999",
+          "expected_value": "Hardcoded secret should not be present",
+          "actual_value": "db_password: s3cr3t-pw-KICS999"
+        }
+      ]
+    },
+    {
+      "query_name": "S3 Bucket Without Server-Side-Encryption",
+      "query_id": "63ec5b46-7c4a-4e3e-9b8f-3d2c8e1f0a11",
+      "query_url": "https://docs.kics.io/latest/queries/terraform-queries/aws/63ec5b46/",
+      "severity": "MEDIUM",
+      "platform": "Terraform",
+      "category": "Encryption",
+      "description": "S3 Bucket should have server-side encryption enabled.",
+      "description_id": "1f9a2b3c",
+      "cwe": "311",
+      "files": [
+        {
+          "file_name": "terraform/s3.tf",
+          "similarity_id": "d4e5f6",
+          "line": 8,
+          "issue_type": "MissingAttribute",
+          "search_key": "aws_s3_bucket[data].server_side_encryption_configuration",
+          "search_value": "",
+          "expected_value": "server_side_encryption_configuration should be defined",
+          "actual_value": "server_side_encryption_configuration is undefined"
+        }
+      ]
+    },
+    {
+      "query_name": "Container Running As Root",
+      "query_id": "22cd11b8-1d3a-4f2e-8a7c-9b0e6f5d4c33",
+      "query_url": "https://docs.kics.io/latest/queries/k8s-queries/22cd11b8/",
+      "severity": "LOW",
+      "platform": "Kubernetes",
+      "category": "Insecure Configurations",
+      "description": "Container should not run as root.",
+      "description_id": "5c6d7e8f",
+      "files": [
+        {
+          "file_name": "k8s/deployment.yaml",
+          "similarity_id": "g7h8i9",
+          "line": 23,
+          "issue_type": "MissingAttribute",
+          "search_key": "spec.template.spec.securityContext.runAsNonRoot",
+          "search_value": "",
+          "expected_value": "runAsNonRoot should be set to true",
+          "actual_value": "runAsNonRoot is undefined"
+        }
+      ]
+    },
+    {
+      "query_name": "Healthcheck Instruction Missing",
+      "query_id": "b03a748a-542d-44f4-bb86-9199ab4fd2d5",
+      "query_url": "https://docs.kics.io/latest/queries/dockerfile-queries/b03a748a/",
+      "severity": "INFO",
+      "platform": "Dockerfile",
+      "category": "Insecure Configurations",
+      "description": "Ensure that HEALTHCHECK is being used.",
+      "description_id": "9a0b1c2d",
+      "files": [
+        {
+          "file_name": "Dockerfile",
+          "similarity_id": "j0k1l2",
+          "line": 1,
+          "issue_type": "MissingAttribute",
+          "search_key": "FROM={{alpine:3.19}}",
+          "search_value": "",
+          "expected_value": "Dockerfile should contain instruction 'HEALTHCHECK'",
+          "actual_value": "Dockerfile does not contain instruction 'HEALTHCHECK'"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/scanner-outputs/kics/results-zero-findings.json
+++ b/tests/fixtures/scanner-outputs/kics/results-zero-findings.json
@@ -1,0 +1,25 @@
+{
+  "kics_version": "v2.1.3",
+  "files_scanned": 6,
+  "lines_scanned": 412,
+  "files_parsed": 6,
+  "lines_parsed": 412,
+  "queries_total": 3012,
+  "queries_failed_to_execute": 0,
+  "scan_id": "console",
+  "severity_counters": {
+    "HIGH": 0,
+    "MEDIUM": 0,
+    "LOW": 0,
+    "INFO": 0,
+    "TRACE": 0
+  },
+  "total_counter": 0,
+  "total_bom_resources": 0,
+  "start": "2026-05-26T12:00:00.000000Z",
+  "end": "2026-05-26T12:00:09.000000Z",
+  "paths": [
+    "/workspace"
+  ],
+  "queries": []
+}


### PR DESCRIPTION
## Description
Adds the Checkmarx **KICS** (Keeping Infrastructure as Code Secure) multi-format IaC scanner as an SDK scanner module (`argus scan kics`). KICS broadens IaC coverage past the existing `trivy-iac` / `checkov` pair — most notably **Ansible** — and is designed to run concurrently with them, since the three catch different things on the same target (the dedup-strategy question raised in #188 is settled as "run all; opt into `--scanners kics` for KICS-specific formats").

## Changes Made
- [x] Added new scanner/workflow
- [ ] Modified existing scanner/workflow
- [x] Updated documentation
- [ ] Fixed bug
- [ ] Other (please specify)

### Details
- **Which scanners are affected?** New `kics` SDK scanner; no existing scanner changes.
- **What's included?**
  - `argus/scanners/kics.py` — `KICSScanner` implementing the `Scanner` protocol (`scan` / `build_args` / `is_available` / `install_command` / `tool_version` / `parse_results`). Runs `kics scan -p <path> --report-formats json -o <outdir>` and parses `results.json` (top-level `queries` → per-match `files`) into `Finding` objects, one per (query, matched-file) pair, with HIGH/MEDIUM/LOW/INFO mapped to Argus severities.
  - Registered `"kics"` in `SCANNER_REGISTRY`.
  - Pinned `checkmarx/kics` (tag + sha256 digest) in `containers.py` `OFFICIAL_IMAGES`, following the mutable-`:latest` digest-gate pattern used by the eslint entry.
  - `docs/scanners.md` (Infrastructure Scanners section + TOC) and `.ai/architecture.yaml` (scanners list + components).
- **Breaking changes?** None. Purely additive — KICS is not in any default scanner set and is opt-in via `--scanners kics`.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results
- New `argus/tests/scanners/test_kics.py` (10 tests): severity mapping, empty-output handling, finding-field extraction, CWE-absent handling, `build_args` output-directory derivation, and the secret-redaction leak assertions.
- Crafted fixtures `tests/fixtures/scanner-outputs/kics/{results-with-findings,results-zero-findings}.json`.
- Full suite green on push via the pre-push hook: `3554 passed, 2 skipped`. SDK coverage gate (`--cov-fail-under=80`) holds.
- `argus scan --list` shows `kics` with the container backend.

## Security Considerations
- [ ] No security impact
- [x] Security enhancement
- [ ] Potential security implications (explain below)

### Security Details
Per the CLAUDE.md secret-leak audit (step 4): KICS echoes the offending source snippet in each match's `actual_value` / `expected_value` / `search_value` — for a secrets-class query (KICS ships Ansible/Dockerfile/K8s "Passwords And Secrets" queries) that snippet **is** the secret. The parser redacts every per-match value field via `argus.core.redact.redact_secret` before building the `Finding`; the `file:line` location and query name remain as triage signal. A test dumps each `Finding.to_dict()` to JSON and asserts a distinctive planted secret literal never appears. The image is digest-pinned so Docker's content-hash check gates the exact tested bytes.

## AI Context Updates (.ai/)
- [x] `.ai/architecture.yaml` updated (scanners list + components)
- [ ] `.ai/workflows.yaml` updated (if commands/tasks changed)
- [ ] `.ai/decisions.yaml` updated (if design decision made)
- [ ] `.ai/errors.yaml` updated (if common error addressed)
- [ ] N/A - No .ai/ updates needed

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

### For New Scanners/Actions (if applicable)
KICS is an **SDK scanner module**, not a composite action (its CLI runs fully off-platform, so the SDK path is preferred per CLAUDE.md "Adding a New Scanner"). The composite-action checklist below is therefore N/A:
- [ ] Composite action created (`.github/actions/scanner-*`) — N/A (SDK scanner)
- [ ] Parser and summary scripts included — N/A
- [ ] Unit tests added (`.github/actions/*/tests/`) — added as SDK tests instead
- [ ] Action documented (README.md in action directory) — N/A
- [ ] Added to actions catalog (`.github/actions/README.md`) — N/A
- [x] Examples updated (SDK scanner-selection examples in `docs/scanners.md`)
- [x] No breaking changes to existing scanners

## Related Issues
Closes #188