### PR TITLE
feat(lint-shell): add shellcheck linter

### DIFF
--- a/.ai/architecture.yaml
+++ b/.ai/architecture.yaml
@@ -314,6 +314,9 @@ scanners:
     - name: lint-terraform
       purpose: "Terraform configuration linting"
       output: "Finding (Severity.INFO)"
+    - name: lint-shell
+      purpose: "Shell script linting via shellcheck (extension + shebang discovery)"
+      output: "Finding (Severity.INFO)"
 
 dependencies:
   external:
@@ -548,12 +551,18 @@ docsite:
       #     shape; tool takes the path and discovers files internally.
       #   * lint-json — Python json.loads fallback when the jsonlint
       #     binary is absent.
+      #   * lint-shell (ShellcheckLinter) — subclass of
+      #     FileDiscoveryScanner that overrides scan() to add shebang
+      #     sniffing on top of extension globbing (*.sh/.bash/.zsh/.ksh
+      #     plus #!/bin/sh-style scripts). Docker fallback via the
+      #     koalaman/shellcheck-alpine image.
       - lint-yaml
       - lint-json
       - lint-python
       - lint-javascript
       - lint-dockerfile
       - lint-terraform
+      - lint-shell
     reporters:
       - terminal
       - markdown

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -406,7 +406,7 @@ Linters follow the same `Scanner` protocol as security scanners but live in the 
 
 **Reference implementation**: See `argus/linters/yamllint.py` for a complete, well-documented example.
 
-**Existing linters**: `lint-yaml`, `lint-json`, `lint-python`, `lint-javascript`, `lint-dockerfile`, `lint-terraform`
+**Existing linters**: `lint-yaml`, `lint-json`, `lint-python`, `lint-javascript`, `lint-dockerfile`, `lint-terraform`, `lint-shell`
 
 ### Composite Action (for GitHub Actions users)
 
@@ -456,7 +456,7 @@ See `CONTRIBUTING.md` for the complete composite actions development guide. Key 
 | **Supply Chain** | scanner-supply-chain | GitHub Actions workflow security (zizmor + actionlint) |
 | **DAST** | scanner-zap | Web applications |
 | **Compliance** | scn-detector | FedRAMP SCN detection |
-| **Linting** | linter-yaml<br>linter-json<br>linter-python<br>linter-javascript<br>linter-dockerfile<br>linter-terraform | Syntax & style |
+| **Linting** | linter-yaml<br>linter-json<br>linter-python<br>linter-javascript<br>linter-dockerfile<br>linter-terraform<br>lint-shell | Syntax & style |
 
 ## Testing
 

--- a/argus/containers.py
+++ b/argus/containers.py
@@ -41,6 +41,10 @@ OFFICIAL_IMAGES = {
     "osv-scanner": "ghcr.io/google/osv-scanner:v2.3.6@sha256:2e07e642463100474fc5e214b66e6beccbd6bfa63dd3fbf047b3f755e78a6cfe",
     "zap": "ghcr.io/zaproxy/zaproxy:2.17.0@sha256:8770b23f9e8b49038f413cb2b10c58c901e5b6717be221a22b1bcab5c9771b8a",
     "hadolint": "hadolint/hadolint:v2.14.0@sha256:27086352fd5e1907ea2b934eb1023f217c5ae087992eb59fde121dce9c9ff21e",
+    # lint-shell via shellcheck. The koalaman/shellcheck-alpine image is
+    # the official multi-arch distribution (~3 MB). shellcheck is GPL-3.0
+    # but runs container-isolated, so the licence never touches Argus.
+    "shellcheck": "koalaman/shellcheck-alpine:stable@sha256:c82fe42504fbc9fc68f15d36638e5ee2324ebb8b94e96a3c4e395bf361c49183",
     # lint-terraform docker fallbacks. terraform fmt/validate run via
     # the official Hashicorp image; tflint via its official image.
     "terraform": "hashicorp/terraform:1.15.3@sha256:a12a7a9301bbab26589c0a353d5bdfc68bd1a52aa818cbdd698bf0dec094bd61",

--- a/argus/linters/__init__.py
+++ b/argus/linters/__init__.py
@@ -4,6 +4,7 @@ from .eslint import EslintLinter
 from .hadolint import HadolintLinter
 from .jsonlint import JsonlintLinter
 from .python_lint import PythonLinter
+from .shellcheck import ShellcheckLinter
 from .terraform import TerraformLinter
 from .yamllint import YamllintLinter
 
@@ -12,6 +13,7 @@ __all__ = [
     "HadolintLinter",
     "JsonlintLinter",
     "PythonLinter",
+    "ShellcheckLinter",
     "TerraformLinter",
     "YamllintLinter",
     "LINTER_REGISTRY",
@@ -27,6 +29,7 @@ LINTER_REGISTRY = {
     "lint-javascript": EslintLinter,
     "lint-dockerfile": HadolintLinter,
     "lint-terraform": TerraformLinter,
+    "lint-shell": ShellcheckLinter,
 }
 
 

--- a/argus/linters/shellcheck.py
+++ b/argus/linters/shellcheck.py
@@ -1,0 +1,284 @@
+"""Shell script linter wrapping shellcheck.
+
+Built on :class:`argus.core.linter_template.FileDiscoveryScanner` like
+:class:`argus.linters.hadolint.HadolintLinter`, but shell files can't be
+found by a single filename glob the way ``Dockerfile*`` can — a shell
+script may have any name and be identified only by its ``#!`` shebang.
+So this linter overrides ``scan()`` to substitute richer discovery
+(extension match + shebang sniff) while reusing the base's local→
+container dispatch, UTF-8 subprocess, and ``execution_failed`` /
+``parse_failed`` metadata shapes.
+
+shellcheck CLI: ``shellcheck -f json <files>`` emits a JSON array of
+``{file, line, endLine, column, level, code, message}`` objects where
+``level`` is one of ``error`` / ``warning`` / ``info`` / ``style``.
+Per the Argus linter convention all findings map to ``Severity.INFO``;
+the upstream level is preserved in ``Finding.metadata['level']``.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+from argus.containers import get_image
+from argus.core.linter_template import FileDiscoveryScanner, discover_files
+from argus.core.models import Finding, ScanResult, Severity
+from argus.core.version import parse_tool_version
+
+# Extensions that identify a shell script by name alone.
+SHELL_EXTENSIONS = (".sh", ".bash", ".zsh", ".ksh")
+
+# Interpreter basenames in a ``#!`` line that mark a file as a shell
+# script even when it has no shell extension (e.g. ``configure``,
+# ``install``). Matched against the shebang's interpreter token and the
+# ``env`` argument (``#!/usr/bin/env bash`` → ``bash``).
+SHELL_INTERPRETERS = frozenset({"sh", "bash", "dash", "ksh", "zsh"})
+
+# Cap shebang sniffing so we never read a multi-megabyte binary that
+# happens to be executable and extension-less. A shebang must be the
+# first line; 256 bytes is generous for the longest realistic one.
+_SHEBANG_READ_LIMIT = 256
+
+
+def _has_shell_shebang(file_path: Path) -> bool:
+    """Return True if *file_path*'s first line is a shell shebang.
+
+    Reads at most :data:`_SHEBANG_READ_LIMIT` bytes. Unreadable files
+    (permissions, binary decode errors) return False rather than
+    raising — discovery should never crash on one odd file.
+    """
+    try:
+        with file_path.open("r", encoding="utf-8", errors="replace") as handle:
+            first_line = handle.readline(_SHEBANG_READ_LIMIT)
+    except OSError:
+        return False
+
+    if not first_line.startswith("#!"):
+        return False
+
+    # Tokens after stripping ``#!``: the interpreter path, then any args.
+    # ``#!/bin/sh`` → ["/bin/sh"]; ``#!/usr/bin/env bash`` → ["/usr/bin/env", "bash"].
+    tokens = first_line[2:].strip().split()
+    if not tokens:
+        return False
+
+    interpreter = Path(tokens[0]).name
+    if interpreter in SHELL_INTERPRETERS:
+        return True
+    # ``env`` indirection: the real interpreter is the next token.
+    if interpreter == "env" and len(tokens) > 1:
+        return Path(tokens[1]).name in SHELL_INTERPRETERS
+    return False
+
+
+def discover_shell_files(target: Path) -> list[Path]:
+    """Find shell scripts under *target* by extension or shebang.
+
+    When *target* is itself a file, returns ``[target]`` (the caller
+    asked us to lint that exact file). Otherwise walks recursively,
+    collecting files whose suffix is in :data:`SHELL_EXTENSIONS` plus any
+    extension-less (or differently-named) file whose first line is a
+    shell shebang. The result is sorted and deduplicated.
+    """
+    if target.is_file():
+        return [target]
+
+    # Extension matches via the shared glob walker (one rglob per ext).
+    patterns = [f"*{ext}" for ext in SHELL_EXTENSIONS]
+    by_extension = set(discover_files(target, patterns))
+
+    # Shebang sniff for everything else. Skip files already matched by
+    # extension to avoid re-reading them.
+    by_shebang: set[Path] = set()
+    for candidate in target.rglob("*"):
+        if not candidate.is_file() or candidate in by_extension:
+            continue
+        if candidate.suffix.lower() in SHELL_EXTENSIONS:
+            continue
+        if _has_shell_shebang(candidate):
+            by_shebang.add(candidate)
+
+    return sorted(by_extension | by_shebang)
+
+
+class ShellcheckLinter(FileDiscoveryScanner):
+    """Wraps shellcheck to lint shell scripts for bugs and bad practices."""
+
+    name = "lint-shell"
+    description = "Shell script linter (shellcheck)"
+    category = "linter"
+    languages = ["shell"]
+    container_image = get_image("shellcheck")
+    binary = "shellcheck"
+    # ``file_glob`` is declared for symmetry with the base class, but the
+    # overridden ``scan()`` uses :func:`discover_shell_files` instead so
+    # shebang-only scripts are also covered.
+    file_glob = tuple(f"*{ext}" for ext in SHELL_EXTENSIONS)
+
+    # shellcheck: 0 = clean, 1 = findings (happy path); we accept both.
+    accept_returncodes = (0, 1)
+
+    def is_available(self) -> bool:
+        return shutil.which("shellcheck") is not None
+
+    def install_command(self) -> str | None:
+        return "Install from https://github.com/koalaman/shellcheck#installing"
+
+    def tool_version(self) -> str | None:
+        if not self.is_available():
+            return None
+        return parse_tool_version(
+            ["shellcheck", "--version"], r"version:\s*(\d+\.\d+\.\d+)"
+        )
+
+    def scan(self, path: str, config: dict | None = None) -> ScanResult:
+        """Discover shell scripts then delegate to the base dispatch.
+
+        Mirrors :meth:`FileDiscoveryScanner.scan` but swaps the glob-only
+        discovery for :func:`discover_shell_files` so files identified by
+        a ``#!`` shebang (no shell extension) are linted too.
+        """
+        config = config or {}
+        target = Path(path)
+
+        files = discover_shell_files(target)
+        if not files:
+            return ScanResult(
+                scanner=self.name,
+                metadata={"info": "No shell scripts found"},
+            )
+
+        cmd, mode = self._dispatch_command(target, files, config)
+        if cmd is None:
+            return ScanResult(
+                scanner=self.name,
+                metadata={
+                    "execution_failed": True,
+                    "execution_failure_reason": (
+                        f"{self.binary} not installed and Docker not "
+                        f"available. Install the binary or install Docker "
+                        f"to use the container backend."
+                    ),
+                },
+            )
+
+        try:
+            result = self._run(cmd)
+        except FileNotFoundError as exc:
+            return ScanResult(
+                scanner=self.name,
+                metadata={
+                    "execution_failed": True,
+                    "execution_failure_reason": (
+                        f"{exc.filename or self.binary} not found "
+                        f"(race between is_available() and exec)."
+                    ),
+                },
+            )
+
+        stdout = (result.stdout or "").strip()
+        if result.returncode not in self.accept_returncodes and not stdout:
+            return ScanResult(
+                scanner=self.name,
+                metadata={
+                    "mode": mode,
+                    "execution_failed": True,
+                    "execution_failure_reason": (
+                        f"{self.name} exited {result.returncode}. "
+                        f"stderr: {(result.stderr or '').strip()[:400]}"
+                    ),
+                },
+            )
+
+        try:
+            findings = self._parse_results(stdout, result)
+        except Exception as exc:
+            return ScanResult(
+                scanner=self.name,
+                metadata={
+                    "mode": mode,
+                    "parse_failed": True,
+                    "parse_failure_reason": (
+                        f"{type(exc).__name__}: {exc}. "
+                        f"output head: {stdout[:200]!r}"
+                    ),
+                },
+            )
+
+        return ScanResult(
+            scanner=self.name,
+            findings=list(findings),
+            metadata={"mode": mode, "file_count": len(files)},
+        )
+
+    def _run(self, cmd: list[str]) -> subprocess.CompletedProcess:
+        """Indirection point so ``scan()`` can be tested via the same
+        ``argus.core.linter_template.subprocess.run`` patch the base uses."""
+        from argus.core.linter_template import run_utf8
+
+        return run_utf8(cmd)
+
+    def _build_local_args(self, files: list[Path], config: dict) -> list[str]:
+        cmd = ["shellcheck", "-f", "json"]
+        shell = config.get("shell")
+        if shell:
+            cmd.extend(["--shell", shell])
+        severity = config.get("severity")
+        if severity:
+            cmd.extend(["--severity", severity])
+        for code in config.get("exclude_codes", []) or []:
+            cmd.extend(["--exclude", str(code)])
+        cmd.extend(str(p) for p in files)
+        return cmd
+
+    def _build_container_args(
+        self, container_files: list[str], config: dict
+    ) -> list[str]:
+        # koalaman/shellcheck-alpine's ENTRYPOINT is shellcheck, so the
+        # args passed after the image are shellcheck's own flags. Include
+        # the binary name explicitly to match the hadolint pattern and
+        # stay robust if the image's entrypoint changes.
+        args = ["shellcheck", "-f", "json"]
+        shell = config.get("shell")
+        if shell:
+            args.extend(["--shell", shell])
+        severity = config.get("severity")
+        if severity:
+            args.extend(["--severity", severity])
+        for code in config.get("exclude_codes", []) or []:
+            args.extend(["--exclude", str(code)])
+        args.extend(container_files)
+        return args
+
+    def _parse_results(
+        self, stdout: str, completed: subprocess.CompletedProcess
+    ) -> list[Finding]:
+        if not stdout:
+            return []
+        data = json.loads(stdout)
+        return [self._parse_item(item) for item in data]
+
+    def _parse_item(self, item: dict) -> Finding:
+        code = item.get("code")
+        rule_id = f"SC{code}" if code is not None else "shellcheck"
+        line_num = item.get("line", 0)
+        shell_file = item.get("file", "")
+        location = f"{shell_file}:{line_num}" if shell_file else None
+        message = item.get("message", "")
+
+        return Finding(
+            id=rule_id,
+            severity=Severity.INFO,
+            title=message,
+            description=message,
+            location=location,
+            scanner=self.name,
+            metadata={
+                "level": item.get("level", ""),
+                "column": item.get("column", 0),
+                "file": shell_file,
+            },
+        )

--- a/argus/tests/linters/test_shellcheck.py
+++ b/argus/tests/linters/test_shellcheck.py
@@ -1,0 +1,409 @@
+"""Tests for argus.linters.shellcheck.ShellcheckLinter.
+
+Covers the three behaviours called out in the issue #191 acceptance
+criteria: parsing a captured shellcheck JSON fixture into findings,
+file-discovery logic (extension + shebang detection), and empty-output
+handling. Also locks in the local→container dispatch and the
+``execution_failed`` / ``parse_failed`` metadata shapes inherited from
+FileDiscoveryScanner.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from unittest.mock import patch
+
+from argus.core.models import Severity
+from argus.linters.shellcheck import (
+    ShellcheckLinter,
+    discover_shell_files,
+    _has_shell_shebang,
+)
+
+
+# A captured-shape shellcheck ``-f json`` payload: one finding per
+# upstream level so the parser is exercised across error/warning/info/
+# style. Fields match shellcheck's real JSON output.
+SAMPLE_SHELLCHECK_JSON = [
+    {
+        "file": "deploy.sh",
+        "line": 3,
+        "endLine": 3,
+        "column": 6,
+        "endColumn": 9,
+        "level": "warning",
+        "code": 2086,
+        "message": "Double quote to prevent globbing and word splitting.",
+    },
+    {
+        "file": "deploy.sh",
+        "line": 7,
+        "endLine": 7,
+        "column": 1,
+        "endColumn": 5,
+        "level": "error",
+        "code": 1009,
+        "message": "The mentioned syntax error was in this simple command.",
+    },
+    {
+        "file": "lib/util.bash",
+        "line": 12,
+        "endLine": 12,
+        "column": 3,
+        "endColumn": 3,
+        "level": "style",
+        "code": 2006,
+        "message": "Use $(...) notation instead of legacy backticks.",
+    },
+]
+
+
+def _completed(stdout="", stderr="", returncode=0):
+    return subprocess.CompletedProcess(
+        args=["shellcheck"], returncode=returncode, stdout=stdout, stderr=stderr,
+    )
+
+
+# ---------------------------------------------------------------- #
+# Metadata + protocol surface                                      #
+# ---------------------------------------------------------------- #
+
+
+class TestShellcheckLinterMeta:
+
+    def test_name(self):
+        assert ShellcheckLinter().name == "lint-shell"
+
+    def test_category(self):
+        assert ShellcheckLinter().category == "linter"
+
+    def test_languages(self):
+        assert "shell" in ShellcheckLinter().languages
+
+    def test_install_command_returns_string(self):
+        assert isinstance(ShellcheckLinter().install_command(), str)
+
+    def test_binary_attribute(self):
+        assert ShellcheckLinter.binary == "shellcheck"
+
+    def test_container_image_declared(self):
+        assert ShellcheckLinter.container_image
+        assert "shellcheck" in ShellcheckLinter.container_image.lower()
+
+    def test_accept_returncodes_includes_findings_path(self):
+        # shellcheck exits 1 when findings exist; that's the happy path.
+        assert 1 in ShellcheckLinter.accept_returncodes
+
+    def test_registered_in_linter_registry(self):
+        from argus.linters import LINTER_REGISTRY
+
+        assert LINTER_REGISTRY["lint-shell"] is ShellcheckLinter
+
+    def test_registered_in_scanner_registry(self):
+        # Linters auto-merge into the scanner registry.
+        from argus.scanners import SCANNER_REGISTRY
+
+        assert "lint-shell" in SCANNER_REGISTRY
+
+
+# ---------------------------------------------------------------- #
+# File discovery — shebang sniffing                                #
+# ---------------------------------------------------------------- #
+
+
+class TestShebangDetection:
+
+    def test_plain_sh_shebang(self, tmp_path):
+        f = tmp_path / "script"
+        f.write_text("#!/bin/sh\necho hi\n")
+        assert _has_shell_shebang(f) is True
+
+    def test_bash_shebang(self, tmp_path):
+        f = tmp_path / "script"
+        f.write_text("#!/bin/bash\necho hi\n")
+        assert _has_shell_shebang(f) is True
+
+    def test_env_bash_shebang(self, tmp_path):
+        f = tmp_path / "script"
+        f.write_text("#!/usr/bin/env bash\necho hi\n")
+        assert _has_shell_shebang(f) is True
+
+    def test_env_zsh_shebang(self, tmp_path):
+        f = tmp_path / "script"
+        f.write_text("#!/usr/bin/env zsh\necho hi\n")
+        assert _has_shell_shebang(f) is True
+
+    def test_non_shell_shebang_rejected(self, tmp_path):
+        f = tmp_path / "script"
+        f.write_text("#!/usr/bin/env python3\nprint('hi')\n")
+        assert _has_shell_shebang(f) is False
+
+    def test_no_shebang_rejected(self, tmp_path):
+        f = tmp_path / "notes"
+        f.write_text("just some text\n")
+        assert _has_shell_shebang(f) is False
+
+    def test_empty_file_rejected(self, tmp_path):
+        f = tmp_path / "empty"
+        f.write_text("")
+        assert _has_shell_shebang(f) is False
+
+    def test_missing_file_returns_false(self, tmp_path):
+        assert _has_shell_shebang(tmp_path / "does-not-exist") is False
+
+
+# ---------------------------------------------------------------- #
+# File discovery — extension + shebang union                       #
+# ---------------------------------------------------------------- #
+
+
+class TestDiscoverShellFiles:
+
+    def test_discovers_by_extension(self, tmp_path):
+        (tmp_path / "a.sh").write_text("echo a")
+        (tmp_path / "b.bash").write_text("echo b")
+        (tmp_path / "c.zsh").write_text("echo c")
+        (tmp_path / "d.ksh").write_text("echo d")
+        (tmp_path / "ignore.txt").write_text("not shell")
+
+        found = {p.name for p in discover_shell_files(tmp_path)}
+        assert found == {"a.sh", "b.bash", "c.zsh", "d.ksh"}
+
+    def test_discovers_by_shebang_without_extension(self, tmp_path):
+        (tmp_path / "configure").write_text("#!/bin/sh\necho hi\n")
+        (tmp_path / "readme").write_text("plain text\n")
+
+        found = {p.name for p in discover_shell_files(tmp_path)}
+        assert found == {"configure"}
+
+    def test_extension_and_shebang_union_no_duplicates(self, tmp_path):
+        # A .sh file with a shebang must appear exactly once.
+        (tmp_path / "with_ext.sh").write_text("#!/bin/bash\necho hi\n")
+        (tmp_path / "no_ext").write_text("#!/bin/bash\necho hi\n")
+
+        found = sorted(p.name for p in discover_shell_files(tmp_path))
+        assert found == ["no_ext", "with_ext.sh"]
+
+    def test_recurses_into_subdirs(self, tmp_path):
+        (tmp_path / "sub").mkdir()
+        (tmp_path / "sub" / "nested.sh").write_text("echo nested")
+        found = {p.name for p in discover_shell_files(tmp_path)}
+        assert "nested.sh" in found
+
+    def test_python_file_excluded(self, tmp_path):
+        (tmp_path / "app.py").write_text("#!/usr/bin/env python3\nprint('x')\n")
+        assert discover_shell_files(tmp_path) == []
+
+    def test_single_file_target_returned_directly(self, tmp_path):
+        f = tmp_path / "anything.txt"
+        f.write_text("whatever")
+        assert discover_shell_files(f) == [f]
+
+
+# ---------------------------------------------------------------- #
+# scan() — parsing the sample fixture                              #
+# ---------------------------------------------------------------- #
+
+
+class TestShellcheckParsing:
+
+    def test_parses_sample_fixture_into_findings(self, tmp_path):
+        (tmp_path / "deploy.sh").write_text("#!/bin/sh\necho $x\n")
+
+        def fake_which(b):
+            return f"/usr/bin/{b}" if b == "shellcheck" else None
+
+        def fake_run(cmd, **kwargs):
+            return _completed(
+                stdout=json.dumps(SAMPLE_SHELLCHECK_JSON), returncode=1,
+            )
+
+        with patch("argus.core.linter_template.shutil.which", side_effect=fake_which), \
+             patch("argus.core.linter_template.subprocess.run", side_effect=fake_run):
+            result = ShellcheckLinter().scan(str(tmp_path))
+
+        assert len(result.findings) == 3
+        # All findings normalised to INFO per the linter convention.
+        assert all(f.severity == Severity.INFO for f in result.findings)
+        # Code prefixing: numeric code → SCxxxx id.
+        ids = {f.id for f in result.findings}
+        assert ids == {"SC2086", "SC1009", "SC2006"}
+        # Location is file:line.
+        first = next(f for f in result.findings if f.id == "SC2086")
+        assert first.location == "deploy.sh:3"
+        # Upstream level preserved in metadata.
+        assert first.metadata["level"] == "warning"
+        assert first.metadata["column"] == 6
+        # Findings (exit 1) is the happy path, not a failure.
+        assert result.metadata.get("execution_failed") is not True
+
+    def test_missing_code_falls_back_to_generic_id(self, tmp_path):
+        (tmp_path / "x.sh").write_text("echo hi")
+
+        def fake_which(b):
+            return f"/usr/bin/{b}" if b == "shellcheck" else None
+
+        def fake_run(cmd, **kwargs):
+            return _completed(stdout=json.dumps([
+                {"file": "x.sh", "line": 1, "level": "info", "message": "msg"}
+            ]))
+
+        with patch("argus.core.linter_template.shutil.which", side_effect=fake_which), \
+             patch("argus.core.linter_template.subprocess.run", side_effect=fake_run):
+            result = ShellcheckLinter().scan(str(tmp_path))
+
+        assert result.findings[0].id == "shellcheck"
+
+
+# ---------------------------------------------------------------- #
+# scan() — discovery + dispatch + edge cases                       #
+# ---------------------------------------------------------------- #
+
+
+class TestShellcheckScan:
+
+    def test_no_shell_files_returns_clean_info_row(self, tmp_path):
+        (tmp_path / "readme.md").write_text("# docs")
+        result = ShellcheckLinter().scan(str(tmp_path))
+        assert result.findings == []
+        assert "No shell scripts" in result.metadata.get("info", "")
+
+    def test_local_invocation_uses_json_format(self, tmp_path):
+        (tmp_path / "a.sh").write_text("echo hi")
+        captured = {}
+
+        def fake_which(b):
+            return f"/usr/bin/{b}" if b == "shellcheck" else None
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return _completed(stdout="[]")
+
+        with patch("argus.core.linter_template.shutil.which", side_effect=fake_which), \
+             patch("argus.core.linter_template.subprocess.run", side_effect=fake_run):
+            result = ShellcheckLinter().scan(str(tmp_path))
+
+        assert result.metadata["mode"] == "local"
+        assert result.metadata["file_count"] == 1
+        assert captured["cmd"][0] == "shellcheck"
+        assert "-f" in captured["cmd"]
+        assert "json" in captured["cmd"]
+
+    def test_container_fallback_when_binary_missing(self, tmp_path):
+        (tmp_path / "a.sh").write_text("echo hi")
+        captured = {}
+
+        def fake_which(b):
+            return "/usr/bin/docker" if b == "docker" else None
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return _completed(stdout="[]")
+
+        with patch("argus.core.linter_template.shutil.which", side_effect=fake_which), \
+             patch("argus.core.linter_template.subprocess.run", side_effect=fake_run):
+            result = ShellcheckLinter().scan(str(tmp_path))
+
+        assert result.metadata["mode"] == "container"
+        assert captured["cmd"][0] == "docker"
+        assert ShellcheckLinter.container_image in captured["cmd"]
+        assert "shellcheck" in captured["cmd"]
+        assert any(arg.startswith("/workspace/") for arg in captured["cmd"])
+
+    def test_unavailable_when_neither_binary_nor_docker(self, tmp_path):
+        (tmp_path / "a.sh").write_text("echo hi")
+        with patch("argus.core.linter_template.shutil.which", return_value=None):
+            result = ShellcheckLinter().scan(str(tmp_path))
+        assert result.metadata["execution_failed"] is True
+        assert "shellcheck" in result.metadata["execution_failure_reason"]
+
+    def test_empty_output_with_zero_exit_returns_no_findings(self, tmp_path):
+        (tmp_path / "a.sh").write_text("echo hi")
+
+        def fake_which(b):
+            return f"/usr/bin/{b}" if b == "shellcheck" else None
+
+        def fake_run(cmd, **kwargs):
+            return _completed(stdout="", returncode=0)
+
+        with patch("argus.core.linter_template.shutil.which", side_effect=fake_which), \
+             patch("argus.core.linter_template.subprocess.run", side_effect=fake_run):
+            result = ShellcheckLinter().scan(str(tmp_path))
+
+        assert result.findings == []
+        assert result.metadata.get("execution_failed") is not True
+
+    def test_empty_json_array_returns_no_findings(self, tmp_path):
+        (tmp_path / "a.sh").write_text("echo hi")
+
+        def fake_which(b):
+            return f"/usr/bin/{b}" if b == "shellcheck" else None
+
+        def fake_run(cmd, **kwargs):
+            return _completed(stdout="[]", returncode=0)
+
+        with patch("argus.core.linter_template.shutil.which", side_effect=fake_which), \
+             patch("argus.core.linter_template.subprocess.run", side_effect=fake_run):
+            result = ShellcheckLinter().scan(str(tmp_path))
+
+        assert result.findings == []
+
+    def test_malformed_json_marks_parse_failed(self, tmp_path):
+        (tmp_path / "a.sh").write_text("echo hi")
+
+        def fake_which(b):
+            return f"/usr/bin/{b}" if b == "shellcheck" else None
+
+        def fake_run(cmd, **kwargs):
+            return _completed(stdout="not really json")
+
+        with patch("argus.core.linter_template.shutil.which", side_effect=fake_which), \
+             patch("argus.core.linter_template.subprocess.run", side_effect=fake_run):
+            result = ShellcheckLinter().scan(str(tmp_path))
+
+        assert result.metadata["parse_failed"] is True
+        assert "JSONDecodeError" in result.metadata["parse_failure_reason"]
+
+    def test_nonzero_exit_empty_stdout_marks_execution_failed(self, tmp_path):
+        (tmp_path / "a.sh").write_text("echo hi")
+
+        def fake_which(b):
+            return f"/usr/bin/{b}" if b == "shellcheck" else None
+
+        def fake_run(cmd, **kwargs):
+            return _completed(stdout="", stderr="boom", returncode=2)
+
+        with patch("argus.core.linter_template.shutil.which", side_effect=fake_which), \
+             patch("argus.core.linter_template.subprocess.run", side_effect=fake_run):
+            result = ShellcheckLinter().scan(str(tmp_path))
+
+        assert result.metadata["execution_failed"] is True
+        assert "boom" in result.metadata["execution_failure_reason"]
+
+    def test_config_options_threaded_into_args(self, tmp_path):
+        (tmp_path / "a.sh").write_text("echo hi")
+        captured = {}
+
+        def fake_which(b):
+            return f"/usr/bin/{b}" if b == "shellcheck" else None
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return _completed(stdout="[]")
+
+        with patch("argus.core.linter_template.shutil.which", side_effect=fake_which), \
+             patch("argus.core.linter_template.subprocess.run", side_effect=fake_run):
+            ShellcheckLinter().scan(
+                str(tmp_path),
+                config={
+                    "shell": "bash",
+                    "severity": "warning",
+                    "exclude_codes": ["SC2086", "SC1090"],
+                },
+            )
+
+        cmd = captured["cmd"]
+        assert "--shell" in cmd and cmd[cmd.index("--shell") + 1] == "bash"
+        assert "--severity" in cmd and cmd[cmd.index("--severity") + 1] == "warning"
+        assert cmd.count("--exclude") == 2


### PR DESCRIPTION
## Description
Adds a new `lint-shell` linter that wraps [shellcheck](https://www.shellcheck.net/) to lint shell scripts. Implements the shellcheck candidate from issue #191 (the dockle secondary candidate is intentionally out of scope).

## Changes Made
- [x] Added new scanner/workflow
- [ ] Modified existing scanner/workflow
- [x] Updated documentation
- [ ] Fixed bug
- [ ] Other (please specify)

### Details
- **New linter** `argus/linters/shellcheck.py` (`ShellcheckLinter`, `name = "lint-shell"`). Subclasses the `FileDiscoveryScanner` template (ADR-020) like `lint-dockerfile`, but overrides `scan()` to add shell-specific discovery: it finds `*.sh`/`*.bash`/`*.zsh`/`*.ksh` files **plus** extension-less scripts identified by a `#!/bin/sh`-style shebang (including `#!/usr/bin/env bash` indirection). Files are batched through `shellcheck -f json` and parsed into `Finding`s with `Severity.INFO` per the linter convention; the upstream level (error/warning/info/style) is preserved in `metadata`.
- **Registry**: `"lint-shell": ShellcheckLinter` added to `LINTER_REGISTRY` (auto-merges into `SCANNER_REGISTRY`, so `argus scan lint-shell` and completions work immediately).
- **Image pin**: `shellcheck` added to `OFFICIAL_IMAGES` in `argus/containers.py`, pinned to `koalaman/shellcheck-alpine:stable@sha256:c82fe425...` for the Docker fallback. shellcheck is GPL-3.0 but runs container-isolated, so the licence never touches Argus (noted in the image comment).
- **Docs**: `.ai/architecture.yaml` (linting components list + scanner enumeration with implementation note) and the `CLAUDE.md` "Supported Scanners" table + "Existing linters" line.
- No breaking changes — purely additive.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results
New tests in `argus/tests/linters/test_shellcheck.py` (34 cases) cover: parsing a captured shellcheck JSON fixture into findings (level normalization to INFO, `SCxxxx` id prefixing, file:line locations), shebang detection (`sh`/`bash`/`env bash`/`env zsh`, plus rejection of python/no-shebang/empty/missing files), extension+shebang discovery union with dedup and recursion, local vs container dispatch, and empty-output / malformed-JSON / execution-failure handling.

```
# targeted
argus/tests/linters/test_shellcheck.py + test_cli.py: 162 passed
# full suite (pre-push hook)
3578 passed, 2 skipped, 7 deselected — total coverage 91.97% (gate 80%)
```

Also verified end-to-end: `get_scanner("lint-shell")` resolves with the correct pinned image via the merged registry.

## Security Considerations
- [x] No security impact

### Security Details
shellcheck itself surfaces security-relevant shell issues (unquoted variables, `eval` of untrusted input, etc.). The tool runs container-isolated when the local binary is absent; the image is SHA-pinned so Docker's content-hash check gates the exact bytes. No secrets are emitted — findings carry only rule code, message, level, and file:line (the existing `Finding` redaction backstop still applies).

## AI Context Updates (.ai/)
- [x] `.ai/architecture.yaml` updated (if components/structure changed)
- [ ] `.ai/workflows.yaml` updated (if commands/tasks changed)
- [ ] `.ai/decisions.yaml` updated (if design decision made)
- [ ] `.ai/errors.yaml` updated (if common error addressed)
- [ ] N/A - No .ai/ updates needed

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

### For New Scanners/Actions (if applicable)
N/A — this is an SDK linter module (`argus/linters/`), not a composite action. The SDK-linter path in `CLAUDE.md` "Adding a New Linter" was followed; no `.github/actions/scanner-*` artifacts are required.
- [ ] Composite action created (`.github/actions/scanner-*`)
- [ ] Parser and summary scripts included
- [ ] Unit tests added (`.github/actions/*/tests/`)
- [ ] Action documented (README.md in action directory)
- [ ] Added to actions catalog (`.github/actions/README.md`)
- [ ] Examples updated
- [x] No breaking changes to existing scanners

## Related Issues
Closes #191