### PR TITLE
ci(release): make publishing release manual-only (stop per-merge prod-gated runs)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,12 @@ jobs:
       pull-requests: write
       packages: write       # buildx push + imagetools create on GHCR
       id-token: write       # cosign keyless signing + PyPI OIDC trusted publish
-    if: (github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore(release):')) || (github.event_name == 'workflow_dispatch' && github.event.inputs.dryRun != 'true')
+    # Manual-only. Pushes to main no longer auto-trigger a publishing
+    # release (that queued a prod-gated run per merge that had to be
+    # cancelled). Cut releases deliberately via the Actions "Run workflow"
+    # button — weekly cadence, or ad-hoc for hotfixes. The dry-run preview
+    # below still runs on every push for visibility.
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.dryRun != 'true'
 
     env:
       IMAGE_REGISTRY: ghcr.io/huntridge-labs/argus
@@ -267,7 +272,7 @@ jobs:
           echo "Pre-release version: ${VERSION_BEFORE}"
 
       - name: Release (Auto)
-        if: github.event_name == 'push' || github.event.inputs.releaseType == 'auto'
+        if: github.event.inputs.releaseType == 'auto'
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
           HUSKY: 0


### PR DESCRIPTION
## Description
Stop the publishing release from auto-triggering on every push to `main`. That behavior queued a `prod`-gated deployment run per merge, which had to be manually cancelled to hold the intended weekly (or hotfix) release cadence — today that backlog reached 16 waiting runs.

## Changes Made
- [x] Modified existing scanner/workflow
- [x] Fixed bug
- [x] Other (please specify): release-pipeline trigger change

### Details
- The `release` (publishing) job now runs **only on `workflow_dispatch` with `dryRun=false`** — it no longer fires on push to `main`.
- Dropped the now-dead `github.event_name == 'push'` clause from the "Release (Auto)" step.
- **Unchanged:** the `on: push` trigger and the **dry-run preview** job — the per-merge "what would release" preview still runs (it is not gated and does not queue), so you keep release visibility on every merge.

How to release now: **Actions → Release → Run workflow**, pick `auto`/`patch`/`minor`/`major`, `dryRun=false`. Weekly cadence or ad-hoc hotfix, deliberately — no per-merge gated runs to cancel.

No breaking changes to release behavior when invoked manually (the dispatch path is identical to before).

## Testing
- [x] Manual testing performed

### Test Results
- `release.yml` parses; `actionlint` clean.
- Confirmed: `on:` keeps `push: [main]`; the `dry-run` preview job keeps its push condition; the `release` job condition is now `github.event_name == 'workflow_dispatch' && github.event.inputs.dryRun != 'true'`.

## Security Considerations
- [x] No security impact

### Security Details
Trigger scoping only. The publishing path (cosign signing, GHCR push, PyPI OIDC, release-it) is unchanged when run via dispatch; making it manual-only reduces accidental/automatic publishes.

## AI Context Updates (.ai/)
- [x] N/A - No .ai/ updates needed

## Checklist
- [x] Code follows project style guidelines
- [x] All tests pass
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
None (process change; context: drained a 16-run `prod`-approval backlog today).
