### PR TITLE
ci(deps): move github-actions updates from Dependabot to Renovate

### DIFF
--- a/.ai/decisions.yaml
+++ b/.ai/decisions.yaml
@@ -2359,3 +2359,109 @@ decisions:
       - ADR-024  # core/secrets.py — resolve_secret precedence and stdin slot registry
     pr_references:
       - "(introduces containers.registry_auth + longest-prefix matching; closes #180 acceptance gap for multi-registry deployments)"
+
+  - id: ADR-029
+    title: "GitHub Actions dependency updates handled by Renovate, not Dependabot"
+    date: "2026-06-01"
+    status: accepted
+
+    context: |
+      Dependabot's github-actions ecosystem silently stopped opening
+      PRs (#196) despite real updates being available across our
+      workflows and composite actions. Root cause was confirmed from
+      the updater job log (run 26753720008): the ecosystem was
+      configured with ``directories: ["/", "/.github/actions/*"]``,
+      which fans out to ~30 composite-action directories. Dependabot
+      runs one updater job per (ecosystem, directory) pair and the
+      whole github-actions ecosystem shares a single GitHub-hosted
+      job that is hard-capped at ``max-updater-run-time`` (2700s /
+      45 min, NOT user-configurable on GitHub-hosted Dependabot).
+      The fan-out exhausted that budget on git-fetch churn before any
+      PR was produced — the job ended with
+      ``##[error]The operation was canceled`` (dependabot-core
+      #11645). Independently, the ``cooldown`` we set interacts badly
+      with frequently-released actions: Dependabot only checks the
+      age of the latest release and, if that is inside the cooldown
+      window, skips the dependency entirely rather than offering the
+      newest eligible older version (dependabot-core #13691).
+
+      An earlier attempt (#218) added ``ignore: huntridge-labs/argus*``
+      on the theory that self-referential composite-action pins were
+      the stall. That was merged but did NOT fix the timeout — it was
+      the wrong root cause. dependabot-core #6704 (composite
+      ``action.yml`` ``uses:`` not bumped) is a separate open
+      limitation that also affects us.
+
+    decision: |
+      Move GitHub Actions updates off Dependabot and onto Renovate,
+      which already runs in this repo for custom managers. Renovate's
+      github-actions manager scans every workflow and composite
+      ``action.yml`` repo-wide in a single pass (no per-directory job
+      model, so no 45-min fan-out timeout) and its ``minimumReleaseAge``
+      cooldown offers the newest version older than the window instead
+      of skipping the dependency.
+
+      - ``.github/renovate.json``: add ``github-actions`` to
+        ``enabledManagers`` and three packageRules — minor/patch/digest
+        grouped (``github-actions-minor-patch``), major separated
+        (``github-actions-major``), both with ``pinDigests: true`` to
+        keep the ``@sha # vX`` pin style; and a rule disabling updates
+        to our own ``huntridge-labs/argus`` composite actions
+        (release-it version-bumps those on tag, not Renovate). The
+        global ``minimumReleaseAge: 7 days`` supply-chain delay,
+        weekly schedule, and ``chore(deps):`` prefix auto-apply.
+      - ``.github/dependabot.yml``: remove the entire github-actions
+        ecosystem block. Dependabot keeps pip, docker, and npm — those
+        are single-directory ecosystems unaffected by the fan-out
+        timeout and have no Renovate manager configured.
+
+    alternatives_considered:
+      - name: "Increase the Dependabot updater timeout"
+        rejected_because: |
+          ``max-updater-run-time`` is fixed at 2700s on GitHub-hosted
+          Dependabot and is not exposed in dependabot.yml. The only way
+          to raise it is self-hosting the Dependabot updater, which is
+          far more operational surface than the problem warrants.
+      - name: "Split github-actions into ~30 per-directory Dependabot blocks"
+        rejected_because: |
+          Each (ecosystem, directory) pair gets its own job and budget,
+          which would sidestep the shared-timeout, but it means
+          hand-maintaining 30+ near-identical blocks that must track
+          every new/removed composite action — brittle and noisy. It
+          also does nothing for the cooldown-skip bug (#13691), which
+          is independent of directory count.
+      - name: "Keep Dependabot + ignore self-referential action pins (#218)"
+        rejected_because: |
+          Already tried and merged; the timeout persisted. The
+          self-refs were never the cause — the directory fan-out was.
+      - name: "Run both Dependabot and Renovate on github-actions"
+        rejected_because: |
+          Duplicate, conflicting PRs for the same ``uses:`` bump. One
+          tool must own each ecosystem; Renovate owns github-actions,
+          Dependabot owns pip/docker/npm.
+
+    consequences:
+      positive:
+        - "github-actions updates resume — Renovate's repo-wide single pass has no per-directory timeout."
+        - "Frequently-released actions are no longer skipped: minimumReleaseAge offers the newest version older than the 7-day window instead of skipping the dependency (fixes the #13691 interaction)."
+        - "SHA pins preserved and maintained: pinDigests keeps the @sha # vX shape and bumps the digest in place."
+        - "Composite action.yml uses: refs are now covered (Renovate scans them; Dependabot's #6704 left them stale)."
+      negative:
+        - "Two update tools to reason about — contributors must know github-actions PRs come from Renovate and pip/docker/npm from Dependabot. Documented in both config files' headers."
+        - "Renovate groups and labels differ slightly from Dependabot's (groupName vs Dependabot groups); existing PR-filtering automation keyed on Dependabot labels won't match the github-actions PRs."
+
+    implementation: |
+      - .github/renovate.json — enabledManagers gains "github-actions";
+        three github-actions packageRules appended (minor-patch group +
+        pinDigests, major group + pinDigests, disable
+        huntridge-labs/argus self-refs); description rewritten to state
+        the Dependabot→Renovate split and cite #196 / dependabot-core
+        #11645 / #13691.
+      - .github/dependabot.yml — github-actions ecosystem block removed,
+        replaced by a pointer comment to renovate.json; pip/docker/npm
+        unchanged.
+
+    related:
+      - ADR-014  # Third-party images stay SHA-pinned via Renovate (same pinDigests philosophy for actions)
+    pr_references:
+      - "(moves github-actions updates from Dependabot to Renovate; closes #196; supersedes the #218 ignore-self-refs attempt)"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,63 +9,12 @@
 
 version: 2
 updates:
-  # GitHub Actions - grouped by semantic version level
-  - package-ecosystem: "github-actions"
-    directories:
-      - "/"
-      - "/.github/actions/*"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-      timezone: "America/New_York"
-
-    # Group updates by semantic version level
-    groups:
-      # Major version updates (e.g., v1 -> v2)
-      # These require careful review as they may contain breaking changes
-      github-actions-major:
-        patterns:
-          - "*"
-        update-types:
-          - "major"
-
-      # Minor and patch version updates (e.g., v1.2 -> v1.3, v1.2.3 -> v1.2.4)
-      # New features and bug fixes, generally safe to update together
-      github-actions-minor-patch:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
-
-    # Commit message configuration
-    commit-message:
-      prefix: "chore(deps)"
-
-    # PR configuration
-    open-pull-requests-limit: 10
-
-    # Labels for PRs
-    labels:
-      - "dependencies"
-      - "github-actions"
-      - "automated"
-
-    # Allow Dependabot to rebase PRs
-    rebase-strategy: "auto"
-    cooldown:
-      default-days: 7
-
-    # Don't try to "update" our own actions. The composite wrappers and
-    # reusable workflows pin this repo's own composite actions (comment-pr,
-    # setup-argus) by tag; release-it version-bumps those on release, not
-    # Dependabot. These self-references proliferated in the early-April
-    # composite-wrapper rewrite, matching when the github-actions ecosystem
-    # stopped producing PRs (#196) -- the prime suspect for the stall.
-    # Ignoring them is correct regardless of that.
-    ignore:
-      - dependency-name: "huntridge-labs/argus*"
+  # GitHub Actions updates are handled by Renovate (.github/renovate.json),
+  # not Dependabot. Dependabot's per-directory github-actions updater timed
+  # out scanning the composite-action directories and, with a cooldown set,
+  # skipped frequently-released actions (dependabot-core #11645 / #13691).
+  # Renovate scans workflows + composite action.yml repo-wide in one pass.
+  # See #196.
 
   # Python (pip) dependencies
   - package-ecosystem: "pip"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,11 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "description": "Renovate configuration for dependencies Dependabot can't track. Dependabot handles GitHub Actions SHAs, npm, pip, and Dockerfile FROM. Renovate handles image tags pinned in Python source plus tool versions in shell scripts and Dockerfiles. SUPPLY CHAIN POLICY: all updates wait 7 days after release (see Trivy supply chain attack GHSA-69fq-xp46-6x23, March 2026) so a compromised release has time to be caught before we propose it.",
+  "description": "Renovate configuration. Dependabot handles npm, pip, and Dockerfile FROM. Renovate handles GitHub Actions (workflows + composite actions), image tags pinned in Python source, and tool versions in Dockerfiles / composite actions. GitHub Actions moved here from Dependabot (see #196): Dependabot's per-directory updater timed out scanning the composite-action directories and, with a cooldown set, skipped frequently-released actions (dependabot-core #11645 / #13691); Renovate scans actions repo-wide in one pass. SUPPLY CHAIN POLICY: all updates wait 7 days after release (see Trivy supply chain attack GHSA-69fq-xp46-6x23, March 2026) so a compromised release has time to be caught before we propose it.",
   "extends": [
     "config:recommended"
   ],
   "enabledManagers": [
-    "custom.regex"
+    "custom.regex",
+    "github-actions"
   ],
   "dependencyDashboard": true,
   "labels": [
@@ -210,6 +211,43 @@
       ],
       "groupName": "tool-versions",
       "automerge": false
+    },
+    {
+      "description": "GitHub Actions: keep SHA-pinned (@sha + # vX comment), group minor/patch/digest bumps. Replaces the Dependabot github-actions ecosystem, which timed out scanning the composite-action directories (dependabot-core #11645) and skipped frequently-released actions under cooldown (dependabot-core #13691).",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "digest",
+        "pin"
+      ],
+      "groupName": "github-actions-minor-patch",
+      "pinDigests": true,
+      "automerge": false
+    },
+    {
+      "description": "GitHub Actions major bumps reviewed on their own PR",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "github-actions-major",
+      "pinDigests": true,
+      "automerge": false
+    },
+    {
+      "description": "Never bump our own composite actions (comment-pr, setup-argus); release-it version-bumps those on tag.",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchDepNames": [
+        "/^huntridge-labs\\/argus(\\/|$)/"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Description
Moves **GitHub Actions** dependency updates from Dependabot to Renovate. Dependabot's `github-actions` ecosystem silently stopped opening PRs (#196); the confirmed root cause is structural, not a flake.

## Changes Made
- [x] Modified existing scanner/workflow
- [x] Updated documentation
- [x] Fixed bug
- [x] Other (please specify): dependency-update tooling / CI config

### Details
**Root cause of #196 (confirmed from updater job log, run `26753720008`):**
- Dependabot runs one updater job per `(ecosystem, directory)` pair, and the whole `github-actions` ecosystem shared a single job hard-capped at `max-updater-run-time` (2700s / 45 min, **not** user-configurable on GitHub-hosted Dependabot). Our `directories: ["/", "/.github/actions/*"]` fanned out to ~30 composite-action directories; the job exhausted the budget on git-fetch churn and ended with `The operation was canceled` ([dependabot-core #11645](https://github.com/dependabot/dependabot-core/issues/11645)).
- Independently, `cooldown` + frequently-released actions = Dependabot only checks the *latest* release's age and **skips the dependency entirely** if it's inside the window, rather than offering the newest eligible older version ([dependabot-core #13691](https://github.com/dependabot/dependabot-core/issues/13691)).
- The earlier #218 `ignore: huntridge-labs/argus*` attempt was the wrong root cause — it merged but the timeout persisted. ([dependabot-core #6704](https://github.com/dependabot/dependabot-core/issues/6704) — composite `action.yml` `uses:` not bumped — is a separate open limitation that also affected us.)

**Fix:**
- `.github/renovate.json`: add `github-actions` to `enabledManagers` + three `packageRules`:
  - `github-actions-minor-patch` (minor/patch/digest, `pinDigests: true`)
  - `github-actions-major` (major, separated, `pinDigests: true`)
  - disable updates to our own `huntridge-labs/argus` composite actions (release-it owns those)
  - global `minimumReleaseAge: 7 days`, weekly schedule, and `chore(deps):` prefix auto-apply.
- `.github/dependabot.yml`: remove the entire `github-actions` ecosystem block (replaced with a pointer comment). **pip / docker / npm stay on Dependabot** — single-directory ecosystems, unaffected by the fan-out timeout.
- `.ai/decisions.yaml`: ADR-029 recording the decision + rejected alternatives.

Renovate's `github-actions` manager scans every workflow and composite `action.yml` repo-wide in a single pass (no per-directory job model → no timeout), and `minimumReleaseAge` offers the newest version older than the window instead of skipping.

**Breaking changes:** none for consumers. github-actions update PRs will now come from Renovate (different labels/grouping than Dependabot).

## Testing
- [x] Manual testing performed

### Test Results
- `renovate.json` validated against the canonical schema (`docs.renovatebot.com/renovate-schema.json`): the new `github-actions` manager + packageRules are valid. (Note: a locally-`npx`'d `renovate-config-validator` flagged the *pre-existing* `customManagers[*].managerFilePatterns` keys — that binary predates the `fileMatch`→`managerFilePatterns` rename; the live schema and running bot accept the field. Not introduced by this PR.)
- `dependabot.yml` parses; remaining ecosystems: `pip`, `docker`, `npm`.
- Pre-push suite: **3663 passed, 20 skipped**.

## Security Considerations
- [x] Security enhancement

### Security Details
Restores automated GitHub Actions update coverage that had silently lapsed (#196), and **preserves SHA-pinning** via `pinDigests` (keeps the `@<sha> # vX` shape, bumps the digest in place) — consistent with the repo's SHA-pinned-actions supply-chain policy. The 7-day `minimumReleaseAge` cooldown still applies (GHSA-69fq-xp46-6x23 posture).

## AI Context Updates (.ai/)
- [x] `.ai/decisions.yaml` updated (ADR-029)
- [x] N/A for the others — no component/command/error-pattern changes

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (config headers + ADR)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Closes #196
