### PR TITLE
ci: add Python 3.14 to the test/publish matrix and trove classifiers

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
 
     steps:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
 
     steps:
       - name: Checkout code

--- a/docs/developer/testing-strategy.md
+++ b/docs/developer/testing-strategy.md
@@ -35,7 +35,7 @@ All validation happens within the argus repo. No external repos required for PR 
 
 | Workflow | What It Tests | Trigger |
 |----------|--------------|---------|
-| `test-unit.yml` | pytest suite (403+ tests), Python 3.11/3.12/3.13, version ref coverage | PR, push to main |
+| `test-unit.yml` | pytest suite (403+ tests), Python 3.11/3.12/3.13/3.14, version ref coverage | PR, push to main |
 | `test-actions.yml` | Composite action E2E with real scanners against test fixtures | PR (path-filtered), push to main |
 | `build-containers.yml` | Build images → scan with Trivy+Grype → test argus CLI → validate audit trail | PR (path-filtered) |
 | `test-examples-functional.yml` | Example workflow YAML validation | PR (path-filtered) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Security",
     "Topic :: Software Development :: Quality Assurance",
     "Topic :: Software Development :: Testing",


### PR DESCRIPTION
## Description
Officially support **Python 3.14** — add it to the unit-test and publish-install matrices and the trove classifiers, backed by a full local validation proving it harms neither app users nor CI.

## Changes Made
- [x] Modified existing scanner/workflow
- [x] Updated documentation
- [x] Other (please specify): supported-runtime / packaging metadata

### Details
- `.github/workflows/test-unit.yml`: add `'3.14'` to the matrix → every PR now runs the full `pytest` suite on 3.14. The `if: matrix.python-version == '3.13'` one-shot steps (E2E, version-ref/CLI-doc/container/`.ai` checks) intentionally stay on 3.13.
- `.github/workflows/publish-pypi.yml`: add `'3.14'` to the `test-install` matrix → the install-from-wheel smoke (`argus --version` / `scan --list` / `--help`) runs on 3.14 before any publish.
- `pyproject.toml`: add the `Programming Language :: Python :: 3.14` classifier. `requires-python` is unchanged (`>=3.11` already permits 3.14).
- `docs/developer/testing-strategy.md`: reflect 3.14 in the matrix description.

**No breaking changes** — 3.11/3.12/3.13 remain supported and tested. This is the *validated* path to 3.14 support, distinct from the Renovate scalar `python-version` bumps in #222, which flip ~33 CI jobs to 3.14 without touching this binding compat surface (matrix + classifiers). Once this lands, those bumps are no longer a false-positive signal.

## Testing
- [x] Manual testing performed

### Test Results
Isolated `python3.14` venv mirroring CI exactly (`pip install -r requirements.txt` → `pip install -e '.[all]'` → `pytest`) on **Python 3.14.2**:

```
--- install requirements.txt --- REQ_OK
--- install .[all] (every optional extra) --- ALL_OK   # no missing 3.14 wheels, no source-build fallback
======== 3671 passed, 12 skipped, 25 deselected, 21 warnings in 37.11s ========
Required test coverage of 80% reached. Total coverage: 92.13%
```

Every optional extra (terminal/Textual, browser/FastAPI, MCP, AI) installed and its tests ran — 0 failures. CI's matrix leg will re-prove this on every PR. (21 non-fatal warnings remain — worth a later glance for 3.14 deprecations, not blocking.)

## Security Considerations
- [x] Security enhancement

### Security Details
Continuously testing on 3.14 lets the project adopt 3.14's stdlib hardenings (e.g. the `tarfile`/`realpath` path-extraction fix CVE-2025-4517, authenticated `forkserver` socket) once it standardizes its runtime floor there, and surfaces any 3.14 regression in CI before users hit it. No reduction in any existing supported version.

## AI Context Updates (.ai/)
- [x] N/A — `.ai/` only references the "Python 3.11+" floor (still accurate); no component/command/decision change.

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (testing-strategy.md)
- [x] All tests pass (3671 passed on 3.14.2; existing matrix unaffected)
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Relates to #222 (makes its `python-version` → 3.14 bumps legitimate). Does not close an issue.
