### PR TITLE
fix(containers): re-pin promptfoo to immutable version tag

### DIFF
--- a/argus/containers.py
+++ b/argus/containers.py
@@ -41,9 +41,10 @@ OFFICIAL_IMAGES = {
     "osv-scanner": "ghcr.io/google/osv-scanner:v2.3.6@sha256:2e07e642463100474fc5e214b66e6beccbd6bfa63dd3fbf047b3f755e78a6cfe",
     "zap": "ghcr.io/zaproxy/zaproxy:2.17.0@sha256:2ec1d5d5b44d55cfd02ba9b89cd26852f06d92b7fc0ce9f064b9463babc73074",
     # promptfoo LLM red-team / eval. Opt-in scanner; requires provider
-    # API keys + network at scan time. The publisher tags ``:latest``
-    # (mutable), so the digest pin below is the content-hash gate.
-    "promptfoo": "ghcr.io/promptfoo/promptfoo:latest@sha256:3993e7c105bcbc1c8f763309552728dd2bf30ff5c9c2e14ec69297b42d096f80",
+    # API keys + network at scan time. Pinned to an immutable version tag
+    # + digest (Renovate-managed), like every other image here — the
+    # publisher's ``:latest`` is mutable and silently drifts.
+    "promptfoo": "ghcr.io/promptfoo/promptfoo:0.121.14@sha256:4348f35b8382f2564f23746ddc3160637cfb9242ea8541304ac1ec6641597840",
     "hadolint": "hadolint/hadolint:v2.14.0@sha256:27086352fd5e1907ea2b934eb1023f217c5ae087992eb59fde121dce9c9ff21e",
     # lint-shell via shellcheck. The koalaman/shellcheck-alpine image is
     # the official multi-arch distribution (~3 MB). shellcheck is GPL-3.0


### PR DESCRIPTION
## Description
Re-pin the `promptfoo` scanner image from a mutable `:latest` tag to an
immutable version tag + digest. Upstream repushed `:latest`, orphaning the
pinned digest so the container-manifest check can no longer resolve it —
this is currently red on `main`.

## Changes Made
- [ ] Added new scanner/workflow
- [ ] Modified existing scanner/workflow
- [ ] Updated documentation
- [x] Fixed bug
- [ ] Other (please specify)

### Details
- **Affected:** `argus/containers.py` — the `promptfoo` entry in `OFFICIAL_IMAGES` only.
- **Fix:** `promptfoo` was the sole image pinned to a mutable `:latest` tag.
  The publisher repushed `:latest`, orphaning the pinned digest
  (`sha256:3993e7c1…`), so `scripts/ci/check_container_images.py` fails to
  verify the manifest. That check runs in the Python 3.13 *Unit Tests* leg,
  so the failure surfaces there on `main` and every branch cut from it.
  `:latest` currently resolves to `0.121.14` (identical digest), so the pin
  now reads `0.121.14@sha256:4348f35b…` — matching the `tool:X.Y.Z@sha256`
  shape every other image in the file already uses, so Renovate manages
  future bumps instead of us chasing a moving tag.
- **Breaking changes:** none. Same image content (digest unchanged from what
  `:latest` resolves to today); only the tag segment is now immutable.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results
- Confirmed against the live GHCR registry that `:latest` == `0.121.14` ==
  `sha256:4348f35b8382f2564f23746ddc3160637cfb9242ea8541304ac1ec6641597840`.
- `OFFICIAL_IMAGES["promptfoo"]` imports and resolves to the new ref.
- The manifest check (`check_container_images`) now resolves all pinned
  digests; CI on this branch exercises the full 3.13 leg.

## Security Considerations
- [ ] No security impact
- [x] Security enhancement
- [ ] Potential security implications (explain below)

### Security Details
Immutable version tag + digest is a stronger supply-chain pin than a mutable
`:latest`: the digest remains the tamper-evident content gate, and the tag no
longer silently drifts out from under it. Brings `promptfoo` in line with the
digest-pinning rationale documented at the top of `containers.py`.

## AI Context Updates (.ai/)
- [x] N/A - No .ai/ updates needed

(One-line image-pin change — no components, commands, decisions, or error
patterns altered. `check_architecture_sync` passes unchanged.)

## Checklist
- [x] Code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
None — CI-breaking regression from upstream `:latest` drift. (The same fix
also rides on #230/#231; this standalone PR lands it on `main` directly so a
patch release can go out.)
