### PR TITLE
fix(container): scan daemon-present images by ref via docker: source (#233)

### DIFF
--- a/.ai/errors.yaml
+++ b/.ai/errors.yaml
@@ -637,3 +637,36 @@ scn_detector_errors:
         scan via docker.sock mount, not registry pull.
 
     reference: "argus/container/scanner.py::_registry_auth_env and docs/troubleshooting/docker.md → 'target image fails to authenticate inside the sub-scanner container'"
+
+  - pattern: "index.docker.io/v2/library/.*UNAUTHORIZED: authentication required|grype.*scan-<hash>.*UNAUTHORIZED"
+    category: container-scanning
+    context: |
+      A locally-built image is scanned by reference (e.g. CI builds
+      ``app:scan-<sha>`` in one step, then runs
+      ``argus scan container --image app:scan-<sha>`` in a later step).
+      Grype/Trivy try to resolve the never-pushed dev tag against Docker
+      Hub (``index.docker.io/v2/library/...``) and fail with UNAUTHORIZED.
+      The scan reports ``0 findings`` but exits non-zero
+      (``1 scanner failure(s) — results are incomplete``, exit 2).
+
+    root_cause: |
+      ``scan_image`` decided local-vs-remote purely from
+      ``target.dockerfile is not None``. A ref-only target (no Dockerfile,
+      because the image was built by a separate step) was therefore
+      classified as *remote*, so the runners used Grype's ``registry:``
+      source / Trivy's ``--image-src remote``. With no registry path on a
+      bare name, that defaults to ``docker.io/library/<name>`` — a repo the
+      runner has no rights to — and the pull is rejected.
+
+    solution:
+      steps:
+        - "Argus now also probes the local Docker daemon (``docker image inspect``) when the target has no Dockerfile."
+        - "If the image is already present locally, it scans via the ``docker:`` daemon source instead of falling through to the registry."
+        - "No config change required — building the image before the scan step is enough."
+      note: |
+        The daemon probe is skipped when Argus built the image itself
+        (``dockerfile:`` set) since localness is already known. A genuinely
+        remote image still routes through the ``registry:`` source and the
+        ``GRYPE_REGISTRY_AUTH_*`` / ``TRIVY_*`` credential env vars.
+
+    reference: "argus/container/scanner.py::scan_image (is_local = dockerfile or is_image_local) — issue #233"

--- a/argus/container/scanner.py
+++ b/argus/container/scanner.py
@@ -483,7 +483,22 @@ def scan_image(
     #
     # The daemon probe (``docker image inspect``) is skipped when we
     # already know we built the image, avoiding a redundant subprocess.
-    is_local = target.dockerfile is not None or is_image_local(target.image_ref)
+    built_here = target.dockerfile is not None
+    is_local = built_here or is_image_local(target.image_ref)
+
+    # Transparency breadcrumb: when a ref we did NOT build is found in the
+    # local daemon, we scan that local copy and skip the registry pull
+    # (and any configured registry auth). That's the intended fix for
+    # never-pushed build tags (#233), but for a fully-qualified registry
+    # ref it also means a *stale* local copy would be scanned instead of
+    # the current registry manifest. Log it so operators can see which
+    # source was used rather than silently diverging from the registry.
+    if is_local and not built_here:
+        logger.info(
+            "Image %s found in the local Docker daemon; scanning the local "
+            "copy via the docker-daemon source (not pulling from a registry)",
+            target.image_ref,
+        )
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         tmp_path = Path(tmp_dir)

--- a/argus/container/scanner.py
+++ b/argus/container/scanner.py
@@ -12,6 +12,7 @@ from argus.core.models import Finding, Severity
 from argus.scanners.container import ContainerScanner
 
 from .discovery import ContainerTarget
+from .resources import is_image_local
 
 logger = logging.getLogger("argus.container")
 
@@ -465,8 +466,24 @@ def scan_image(
     services_findings: list[Finding] = []
     scanner_errors: dict[str, str] = {}
 
-    # Determine if the image is local (built by us) or remote
-    is_local = target.dockerfile is not None
+    # Determine if the image is local (built by us) or remote.
+    #
+    # An image counts as local — and so must be scanned via the
+    # ``docker:`` daemon source rather than resolved against a registry —
+    # in two cases:
+    #   1. We built it from a Dockerfile this run (``target.dockerfile``).
+    #   2. It was built or loaded by an earlier step and handed to us by
+    #      ref. CI commonly builds a throwaway tag (``app:scan-<sha>``)
+    #      then calls ``argus scan container --image app:scan-<sha>``.
+    #      There's no Dockerfile on the target, but the image is sitting
+    #      in the local daemon. Without this check ``is_local`` is False,
+    #      grype/trivy fall through to the ``registry:`` source, and the
+    #      never-pushed dev tag resolves to ``docker.io/library/...`` →
+    #      ``UNAUTHORIZED: authentication required`` (issue #233).
+    #
+    # The daemon probe (``docker image inspect``) is skipped when we
+    # already know we built the image, avoiding a redundant subprocess.
+    is_local = target.dockerfile is not None or is_image_local(target.image_ref)
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         tmp_path = Path(tmp_dir)

--- a/argus/tests/test_container_scanner_runners.py
+++ b/argus/tests/test_container_scanner_runners.py
@@ -383,6 +383,12 @@ class TestScanImageRawOutputPersistence:
         monkeypatch.setattr(scanner_mod, "_run_trivy", fake_trivy)
         monkeypatch.setattr(scanner_mod, "_run_grype", fake_grype)
         monkeypatch.setattr(scanner_mod, "_run_syft", fake_syft)
+        # These tests pass ref-only targets, which would otherwise make
+        # scan_image shell out to a real ``docker image inspect`` (#233
+        # daemon probe). Pin it so the suite stays hermetic and fast —
+        # the local/remote flag is irrelevant to the persistence layer
+        # under test here.
+        monkeypatch.setattr(scanner_mod, "is_image_local", lambda ref: False)
 
     def test_raw_outputs_copied_when_dir_supplied(self, tmp_path, monkeypatch):
         from argus.container.scanner import scan_image
@@ -456,6 +462,7 @@ class TestScanImageRawOutputPersistence:
         monkeypatch.setattr(scanner_mod, "_run_trivy", fake_trivy)
         monkeypatch.setattr(scanner_mod, "_run_grype", lambda *a, **kw: [])
         monkeypatch.setattr(scanner_mod, "_run_syft", lambda *a, **kw: None)
+        monkeypatch.setattr(scanner_mod, "is_image_local", lambda ref: False)
 
         raw_dir = tmp_path / "raw" / "app"
         scan_image(
@@ -697,6 +704,12 @@ class TestScanImageThreadsDockerfile:
             "argus.container.scanner._run_grype",
             lambda *a, **kw: [],
         )
+        # Genuine remote pull — pin the daemon probe (#233) to "absent"
+        # so the test asserts the remote-pull shape deterministically
+        # regardless of what's cached on the host running the suite.
+        monkeypatch.setattr(
+            "argus.container.scanner.is_image_local", lambda ref: False,
+        )
 
         result = scan_image(target, scanners=("trivy", "grype"))
         assert result.dockerfile == ""
@@ -742,9 +755,11 @@ class TestScanImageLocalDaemonDetection:
         monkeypatch.setattr(scanner_mod, "_run_trivy", fake_trivy)
         return captured
 
-    def test_ref_only_target_present_in_daemon_is_local(self, monkeypatch):
+    def test_ref_only_target_present_in_daemon_is_local(self, monkeypatch, caplog):
         """No Dockerfile, but the image sits in the local daemon →
-        ``local=True`` so grype/trivy use the ``docker:`` source."""
+        ``local=True`` so grype/trivy use the ``docker:`` source. The
+        choice is logged (transparency breadcrumb) since we did not
+        build the image ourselves."""
         from argus.container import scanner as scanner_mod
         from argus.container.scanner import scan_image
         from argus.container.discovery import ContainerTarget
@@ -756,10 +771,16 @@ class TestScanImageLocalDaemonDetection:
         target = ContainerTarget(
             name="opa", image_ref="hardening-test-opa:scan-6d7bd4a0",
         )
-        scan_image(target, scanners=("trivy", "grype"), sbom=False)
+        with caplog.at_level("INFO", logger="argus.container"):
+            scan_image(target, scanners=("trivy", "grype"), sbom=False)
 
         assert captured["grype_local"] is True
         assert captured["trivy_local"] is True
+        # Operators get a breadcrumb that the local copy was scanned
+        # (not pulled from a registry) — the ref appears in the log.
+        joined = " ".join(r.message for r in caplog.records)
+        assert "local Docker daemon" in joined
+        assert "hardening-test-opa:scan-6d7bd4a0" in joined
 
     def test_ref_only_target_absent_from_daemon_is_remote(self, monkeypatch):
         """No Dockerfile and not in the daemon → genuine remote pull,
@@ -777,9 +798,10 @@ class TestScanImageLocalDaemonDetection:
         assert captured["grype_local"] is False
         assert captured["trivy_local"] is False
 
-    def test_dockerfile_target_skips_daemon_probe(self, tmp_path, monkeypatch):
+    def test_dockerfile_target_skips_daemon_probe(self, tmp_path, monkeypatch, caplog):
         """When we built the image this run, ``local`` is already known —
-        the daemon probe is short-circuited (no redundant subprocess)."""
+        the daemon probe is short-circuited (no redundant subprocess) and
+        the not-built-by-us breadcrumb does not fire."""
         from argus.container import scanner as scanner_mod
         from argus.container.scanner import scan_image
         from argus.container.discovery import ContainerTarget
@@ -800,12 +822,18 @@ class TestScanImageLocalDaemonDetection:
             dockerfile=tmp_path / "Dockerfile",
             context=tmp_path,
         )
-        scan_image(target, scanners=("trivy", "grype"), sbom=False)
+        with caplog.at_level("INFO", logger="argus.container"):
+            scan_image(target, scanners=("trivy", "grype"), sbom=False)
 
         # Short-circuit: ``dockerfile is not None`` makes ``is_local`` True
         # without ever consulting the daemon.
         assert captured["grype_local"] is True
         assert probed["called"] is False
+        # We built it, so the "found in local daemon" breadcrumb (meant
+        # for refs we did NOT build) must not appear.
+        assert "local Docker daemon" not in " ".join(
+            r.message for r in caplog.records
+        )
 
 
 # ───────────────────────────────────────────────

--- a/argus/tests/test_container_scanner_runners.py
+++ b/argus/tests/test_container_scanner_runners.py
@@ -704,6 +704,111 @@ class TestScanImageThreadsDockerfile:
 
 
 # ───────────────────────────────────────────────
+# Local-daemon detection for ref-only targets (#233)
+# ───────────────────────────────────────────────
+#
+# CI commonly builds a throwaway image in one step (``app:scan-<sha>``),
+# then scans it by ref in a later step via
+# ``argus scan container --image app:scan-<sha>``. The target carries no
+# Dockerfile, so the old ``is_local = target.dockerfile is not None`` test
+# classified it as a *remote* image — grype/trivy fell through to the
+# ``registry:`` source and resolved the never-pushed dev tag against
+# Docker Hub (``docker.io/library/...``), failing with
+# ``UNAUTHORIZED: authentication required``. The fix also probes the local
+# Docker daemon, so an image already present there scans via ``docker:``.
+
+
+class TestScanImageLocalDaemonDetection:
+    """``is_local`` must reflect daemon presence, not just Dockerfile origin."""
+
+    def _capture_local_flag(self, monkeypatch):
+        """Stub the runners to record the ``local`` flag they receive.
+
+        Returns a dict the assertions read after ``scan_image`` runs.
+        """
+        from argus.container import scanner as scanner_mod
+
+        captured: dict = {}
+
+        def fake_grype(image_ref, tmp_path, local=False, **_kwargs):
+            captured["grype_local"] = local
+            return []
+
+        def fake_trivy(image_ref, tmp_path, local=False, **_kwargs):
+            captured["trivy_local"] = local
+            return []
+
+        monkeypatch.setattr(scanner_mod, "_run_grype", fake_grype)
+        monkeypatch.setattr(scanner_mod, "_run_trivy", fake_trivy)
+        return captured
+
+    def test_ref_only_target_present_in_daemon_is_local(self, monkeypatch):
+        """No Dockerfile, but the image sits in the local daemon →
+        ``local=True`` so grype/trivy use the ``docker:`` source."""
+        from argus.container import scanner as scanner_mod
+        from argus.container.scanner import scan_image
+        from argus.container.discovery import ContainerTarget
+
+        captured = self._capture_local_flag(monkeypatch)
+        # Pretend ``docker image inspect`` succeeds for this ref.
+        monkeypatch.setattr(scanner_mod, "is_image_local", lambda ref: True)
+
+        target = ContainerTarget(
+            name="opa", image_ref="hardening-test-opa:scan-6d7bd4a0",
+        )
+        scan_image(target, scanners=("trivy", "grype"), sbom=False)
+
+        assert captured["grype_local"] is True
+        assert captured["trivy_local"] is True
+
+    def test_ref_only_target_absent_from_daemon_is_remote(self, monkeypatch):
+        """No Dockerfile and not in the daemon → genuine remote pull,
+        ``local=False`` so the ``registry:`` source + auth env apply."""
+        from argus.container import scanner as scanner_mod
+        from argus.container.scanner import scan_image
+        from argus.container.discovery import ContainerTarget
+
+        captured = self._capture_local_flag(monkeypatch)
+        monkeypatch.setattr(scanner_mod, "is_image_local", lambda ref: False)
+
+        target = ContainerTarget(name="webapp", image_ref="ghcr.io/org/web:1.0")
+        scan_image(target, scanners=("trivy", "grype"), sbom=False)
+
+        assert captured["grype_local"] is False
+        assert captured["trivy_local"] is False
+
+    def test_dockerfile_target_skips_daemon_probe(self, tmp_path, monkeypatch):
+        """When we built the image this run, ``local`` is already known —
+        the daemon probe is short-circuited (no redundant subprocess)."""
+        from argus.container import scanner as scanner_mod
+        from argus.container.scanner import scan_image
+        from argus.container.discovery import ContainerTarget
+
+        captured = self._capture_local_flag(monkeypatch)
+
+        probed = {"called": False}
+
+        def boom(ref):
+            probed["called"] = True
+            return False
+
+        monkeypatch.setattr(scanner_mod, "is_image_local", boom)
+
+        target = ContainerTarget(
+            name="myapp",
+            image_ref="myapp:argus-scan",
+            dockerfile=tmp_path / "Dockerfile",
+            context=tmp_path,
+        )
+        scan_image(target, scanners=("trivy", "grype"), sbom=False)
+
+        # Short-circuit: ``dockerfile is not None`` makes ``is_local`` True
+        # without ever consulting the daemon.
+        assert captured["grype_local"] is True
+        assert probed["called"] is False
+
+
+# ───────────────────────────────────────────────
 # Registry credential forwarding (#180)
 # ───────────────────────────────────────────────
 #

--- a/docs/troubleshooting/docker.md
+++ b/docs/troubleshooting/docker.md
@@ -264,6 +264,31 @@ same creds proves whether your account has access. If `docker pull`
 fails too, the issue is creds or registry permissions, not the scan
 plumbing.
 
+**Fix — locally-built image scanned by reference resolves to Docker Hub.**
+A different shape again: you built the image in one CI step (e.g.
+`docker build -t hardening-test-opa:scan-<sha> .`) and scan it by ref in a
+later step with `argus scan container --image hardening-test-opa:scan-<sha>`.
+The image is never pushed anywhere, yet Grype tries to resolve it against
+Docker Hub:
+
+```
+failed to catalog: errors occurred attempting to resolve 'hardening-test-opa:scan-<sha>':
+  - oci-registry: ... GET https://index.docker.io/v2/library/hardening-test-opa/manifests/scan-<sha>: UNAUTHORIZED: authentication required
+```
+
+The scan then reports `0 findings` but exits non-zero
+(`1 scanner failure(s) — results are incomplete`, exit 2). Root cause: the
+target has no `dockerfile:` (Argus didn't build it), so it used to be
+classified as *remote* and the runners fell through to the `registry:`
+source — which defaults a bare name to `docker.io/library/<name>`.
+
+Argus now also probes the local Docker daemon (`docker image inspect`) for
+ref-only targets; if the image is already present, it scans via the
+`docker:` daemon source instead. **No config change is needed** — just make
+sure the image is built (present in the daemon) before the scan step runs.
+This is the SDK/CLI counterpart to the daemon-vs-registry source selection,
+and applies to Trivy (`--image-src remote` is dropped) and Syft as well.
+
 **Fix — air-gapped GHES (mirror images).** Pre-pull every Argus scanner
 image on a machine with internet, push them to your internal registry, and
 point Argus at the mirror via `execution.registry`:

--- a/docs/troubleshooting/docker.md
+++ b/docs/troubleshooting/docker.md
@@ -289,6 +289,16 @@ sure the image is built (present in the daemon) before the scan step runs.
 This is the SDK/CLI counterpart to the daemon-vs-registry source selection,
 and applies to Trivy (`--image-src remote` is dropped) and Syft as well.
 
+One consequence worth knowing: if you pass a *fully-qualified registry ref*
+(e.g. `ghcr.io/org/app:1.0`) that also happens to be cached locally, Argus
+scans the **local copy**, not the current registry manifest — so a stale
+local image would be scanned instead of what the registry serves today.
+Argus logs an `INFO` line naming the image when this happens (`… found in
+the local Docker daemon; scanning the local copy …`); run with `--verbose`
+to see it. If you specifically want the registry version, remove the local
+copy first (`docker rmi <ref>`) so the probe misses and the `registry:`
+source is used.
+
 **Fix — air-gapped GHES (mirror images).** Pre-pull every Argus scanner
 image on a machine with internet, push them to your internal registry, and
 point Argus at the mirror via `execution.registry`:


### PR DESCRIPTION
## Summary

Fixes #233. After the `0.7.2 → 1.3.x` bump, the container scanner failed for a **locally-built image scanned by reference**: grype tried to resolve the build tag (`hardening-test-opa:scan-<hash>`) against **Docker Hub** and failed with `UNAUTHORIZED: authentication required`. The scan reported `0 findings` but exited non-zero (`1 scanner failure(s)`, exit 2).

## Root cause

`scan_image` decided local-vs-remote purely from `target.dockerfile is not None`:

```python
is_local = target.dockerfile is not None
```

The composite action (and CLI `argus scan container --image ...`) hands the scanner a **ref-only** target — the image was built in an earlier step, so there's no Dockerfile on the target. It was therefore classified as *remote*, and `_run_grype` / `_run_trivy` used the `registry:` source (`--image-src remote` for trivy). With no registry on a bare name, that defaults to `docker.io/library/<name>` — which the runner has no rights to.

The per-runner scheme selection (`docker:` vs `registry:`) was already correct; the bug was the **input** to it.

## Fix

Probe the local Docker daemon for ref-only targets:

```python
is_local = target.dockerfile is not None or is_image_local(target.image_ref)
```

- If the image is already in the daemon (built by a prior step), scan via the `docker:` daemon source.
- The `docker image inspect` probe is **short-circuited** when Argus built the image itself (`dockerfile:` set) — no redundant subprocess.
- Genuinely remote images still route through `registry:` + the `GRYPE_REGISTRY_AUTH_*` / `TRIVY_*` credential env vars.
- One shared `is_local` flag, so grype, trivy, and syft all benefit uniformly. **No config change required.**

## Tests

New `TestScanImageLocalDaemonDetection` in `test_container_scanner_runners.py` captures the `local` flag the runners receive:

- ref-only target present in daemon → `local=True` (both grype + trivy)
- ref-only target absent from daemon → `local=False`
- dockerfile target → `local=True` **without** probing the daemon (short-circuit)

Full container suite green (143 passed across the runner/engine/scanner files). The one unrelated failure in `test_container.py::test_happy_path_extracts_files` is a pre-existing Windows path-separator issue in tar extraction, untouched by this change.

## Docs / AICaC

- `.ai/errors.yaml`: new error pattern for the `index.docker.io/.../UNAUTHORIZED` symptom.
- `docs/troubleshooting/docker.md`: new "locally-built image scanned by reference resolves to Docker Hub" remediation section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
