### PR TITLE
feat(container): bind scan results to the resolved image content digest

### DIFF
--- a/.ai/architecture.yaml
+++ b/.ai/architecture.yaml
@@ -401,6 +401,11 @@ data_flow:
             exposure-findings.json / services-findings.json to <output_dir>/raw/<image>/
             (the exposure / services helpers have no upstream JSON output, so the
             lifecycle path synthesizes one when they produce findings)
+        → Bind to content: scan_image resolves the image's digest (RepoDigest when
+          pulled/pushed, config Id for never-pushed local builds; best-effort, "" if
+          unknown) onto ContainerScanResult.digest and each finding's metadata
+          (image_digest + image_ref) — so results attest what was scanned, not just a
+          mutable tag (#237). Surfaced in per-image markdown and argus-results.json/SARIF.
         → Map ContainerScanResult → ScanResult(scanner="container/<name>", findings=combined)
         → Same JsonReporter / SARIF reporter pipeline as source scans —
           argus view consumes the canonical argus-results.json without

--- a/argus/container/resources.py
+++ b/argus/container/resources.py
@@ -7,6 +7,7 @@ No hard disk limits — we try the scan and handle failures gracefully
 rather than refusing to run based on arbitrary thresholds.
 """
 
+import json
 import logging
 import shutil
 import subprocess
@@ -124,6 +125,47 @@ def is_image_local(image_ref: str) -> bool:
         return result.returncode == 0
     except (subprocess.TimeoutExpired, Exception):
         return False
+
+
+def get_image_digest(image_ref: str) -> str:
+    """Return the content digest of a daemon-present image, best-effort.
+
+    Binds a scan result to *what was actually scanned* rather than the
+    mutable tag it was scanned by (issue #237). Prefers a registry
+    ``RepoDigest`` (``repo@sha256:...`` — the manifest digest, which a
+    deploy-time check can compare against the registry) and falls back to
+    the image **config ID** (``sha256:...``) for locally-built,
+    never-pushed images, which have no RepoDigest until they're pushed but
+    whose config ID is still a stable content hash of the build.
+
+    Returns ``""`` when docker is unavailable or the image can't be
+    inspected — an unknown digest is never fatal; callers treat it as
+    "not recorded", mirroring :func:`is_image_local`.
+    """
+    if shutil.which("docker") is None:
+        return ""
+
+    try:
+        result = subprocess.run(
+            ["docker", "image", "inspect", image_ref,
+             "--format", "{{json .RepoDigests}}|{{.Id}}"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return ""
+        repo_part, _, id_part = result.stdout.strip().partition("|")
+        repo_digests = json.loads(repo_part) if repo_part else []
+        if repo_digests:
+            # ``repo@sha256:...`` — return the digest portion (the
+            # content identifier, registry-comparable).
+            _, _, digest = repo_digests[0].rpartition("@")
+            if digest:
+                return digest
+        return id_part.strip()  # config digest for never-pushed builds
+    except (subprocess.TimeoutExpired, Exception):
+        return ""
 
 
 def get_remote_image_size(image_ref: str) -> int:

--- a/argus/container/scanner.py
+++ b/argus/container/scanner.py
@@ -12,7 +12,7 @@ from argus.core.models import Finding, Severity
 from argus.scanners.container import ContainerScanner
 
 from .discovery import ContainerTarget
-from .resources import is_image_local
+from .resources import get_image_digest, is_image_local
 
 logger = logging.getLogger("argus.container")
 
@@ -597,9 +597,22 @@ def scan_image(
         extra=[*exposure_findings, *services_findings],
     )
 
+    # Bind the result to the scanned image's content digest (#237): a clean
+    # scan should attest *what* was scanned, not just a mutable tag. The
+    # findings carry it in metadata so it travels into argus-results.json /
+    # SARIF; the ContainerScanResult.digest field feeds the per-image
+    # markdown and audit manifest. Best-effort — an unknown digest is
+    # non-fatal and simply isn't recorded.
+    digest = get_image_digest(target.image_ref)
+    if digest:
+        for finding in combined:
+            finding.metadata.setdefault("image_ref", target.image_ref)
+            finding.metadata.setdefault("image_digest", digest)
+
     return ContainerScanResult(
         name=target.name,
         image_ref=target.image_ref,
+        digest=digest,
         dockerfile=str(target.dockerfile) if target.dockerfile else "",
         context=str(target.context) if target.context else "",
         trivy_findings=trivy_findings,

--- a/argus/tests/test_container_resources.py
+++ b/argus/tests/test_container_resources.py
@@ -7,6 +7,7 @@ from argus.container.resources import (
     check_disk_space,
     remove_docker_image,
     is_image_local,
+    get_image_digest,
 )
 
 
@@ -91,3 +92,44 @@ class TestIsImageLocal:
     def test_timeout_returns_false(self, mock_which, mock_run):
         mock_run.side_effect = subprocess.TimeoutExpired("docker", 10)
         assert is_image_local("app:latest") is False
+
+
+class TestGetImageDigest:
+    """get_image_digest binds a scan to content, not a mutable tag (#237)."""
+
+    @patch("argus.container.resources.subprocess.run")
+    @patch("argus.container.resources.shutil.which", return_value="/usr/bin/docker")
+    def test_pulled_image_prefers_repo_digest(self, mock_which, mock_run):
+        # A pulled/pushed image carries a registry RepoDigest — return the
+        # manifest digest (registry-comparable), not the config ID.
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout='["ghcr.io/org/app@sha256:aaaa"]|sha256:cfgbbbb',
+        )
+        assert get_image_digest("ghcr.io/org/app:1.0") == "sha256:aaaa"
+
+    @patch("argus.container.resources.subprocess.run")
+    @patch("argus.container.resources.shutil.which", return_value="/usr/bin/docker")
+    def test_local_built_falls_back_to_config_id(self, mock_which, mock_run):
+        # A never-pushed local build has no RepoDigest — fall back to the
+        # config ID, still a stable content hash of the build.
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="[]|sha256:cfgbbbb",
+        )
+        assert get_image_digest("app:scan-6d7bd4a0") == "sha256:cfgbbbb"
+
+    @patch("argus.container.resources.subprocess.run")
+    @patch("argus.container.resources.shutil.which", return_value="/usr/bin/docker")
+    def test_inspect_failure_returns_empty(self, mock_which, mock_run):
+        mock_run.return_value = MagicMock(returncode=1, stdout="")
+        assert get_image_digest("missing:tag") == ""
+
+    @patch("argus.container.resources.shutil.which", return_value=None)
+    def test_no_docker_returns_empty(self, mock_which):
+        assert get_image_digest("app:latest") == ""
+
+    @patch("argus.container.resources.subprocess.run")
+    @patch("argus.container.resources.shutil.which", return_value="/usr/bin/docker")
+    def test_timeout_returns_empty(self, mock_which, mock_run):
+        mock_run.side_effect = subprocess.TimeoutExpired("docker", 10)
+        assert get_image_digest("app:latest") == ""

--- a/argus/tests/test_container_scanner_runners.py
+++ b/argus/tests/test_container_scanner_runners.py
@@ -1615,3 +1615,58 @@ class TestRunSyftUsesResolvedImage:
 
         assert len(intercepted) == 1
         assert "harbor.corp/dockerhub-cache/fake/syft:test" in " ".join(intercepted[0])
+
+
+class TestScanImageBindsContentDigest:
+    """scan_image records the scanned image's content digest (#237) so a
+    clean scan attests *what* was scanned, not just a mutable tag."""
+
+    def test_digest_populated_and_stamped_on_findings(self, monkeypatch):
+        from argus.container import scanner as scanner_mod
+        from argus.container.scanner import scan_image
+        from argus.container.discovery import ContainerTarget
+        from argus.core.models import Finding, Severity
+
+        finding = Finding(
+            id="CVE-2024-1", severity=Severity.HIGH, title="vuln",
+            scanner="container", cve="CVE-2024-1",
+            metadata={"package": "openssl"},
+        )
+        monkeypatch.setattr(scanner_mod, "_run_trivy", lambda *a, **kw: [finding])
+        monkeypatch.setattr(scanner_mod, "_run_grype", lambda *a, **kw: [])
+        monkeypatch.setattr(scanner_mod, "is_image_local", lambda ref: True)
+        monkeypatch.setattr(scanner_mod, "get_image_digest", lambda ref: "sha256:deadbeef")
+
+        target = ContainerTarget(name="app", image_ref="app:scan-6d7bd4a0")
+        result = scan_image(target, scanners=("trivy",), sbom=False)
+
+        # Result-level digest → per-image markdown + audit manifest.
+        assert result.digest == "sha256:deadbeef"
+        # Finding-level metadata → argus-results.json / SARIF.
+        f = result.combined_findings[0]
+        assert f.metadata["image_digest"] == "sha256:deadbeef"
+        assert f.metadata["image_ref"] == "app:scan-6d7bd4a0"
+        assert f.metadata["package"] == "openssl"  # existing metadata preserved
+
+    def test_unknown_digest_is_non_fatal(self, monkeypatch):
+        """docker absent / inspect failed → empty digest, no metadata stamp,
+        scan still succeeds (mirrors is_image_local's degrade-to-safe)."""
+        from argus.container import scanner as scanner_mod
+        from argus.container.scanner import scan_image
+        from argus.container.discovery import ContainerTarget
+        from argus.core.models import Finding, Severity
+
+        finding = Finding(
+            id="CVE-2024-2", severity=Severity.LOW, title="v",
+            scanner="container", metadata={},
+        )
+        monkeypatch.setattr(scanner_mod, "_run_trivy", lambda *a, **kw: [finding])
+        monkeypatch.setattr(scanner_mod, "_run_grype", lambda *a, **kw: [])
+        monkeypatch.setattr(scanner_mod, "is_image_local", lambda ref: False)
+        monkeypatch.setattr(scanner_mod, "get_image_digest", lambda ref: "")
+
+        target = ContainerTarget(name="app", image_ref="ghcr.io/org/app:1.0")
+        result = scan_image(target, scanners=("trivy",), sbom=False)
+
+        assert result.digest == ""
+        assert "image_digest" not in result.combined_findings[0].metadata

--- a/docs/container-scanning.md
+++ b/docs/container-scanning.md
@@ -404,6 +404,41 @@ updates:
 
 See [dependabot.example.yml](../examples/dependabot.example.yml) for a complete example.
 
+## Result provenance: the scanned content digest
+
+Every container scan records the **content digest** of the image it actually
+inspected, not just the tag it was asked to scan. This matters because a tag
+is mutable: a "clean" scan of `app:scan-<sha>` proves nothing about what later
+ships if different content can be published under the same tag.
+
+Argus resolves the digest best-effort from the local daemon:
+
+- **Pulled / pushed images** → the registry `RepoDigest`
+  (`repo@sha256:…`), which a deploy-time check can compare against the
+  registry manifest.
+- **Locally-built, never-pushed images** → the image **config ID**
+  (`sha256:…`). These have no `RepoDigest` until pushed, but the config ID is
+  a stable content hash of the build.
+
+The digest is surfaced two ways:
+
+- **Per-image markdown** shows a `**Digest:**` line under the image.
+- **Each finding** carries `image_digest` (and `image_ref`) in its
+  `metadata`, so it travels into `argus-results.json` and SARIF.
+
+This closes the scan-vs-deploy substitution gap **when you trust the runner**:
+a deploy gate (or admission controller) that compares the *deployed* image's
+digest against the digest Argus recorded will reject anything that was swapped
+after the scan. An unknown digest (docker unavailable, inspect failed) is
+non-fatal — it's simply left unrecorded.
+
+> **Scope.** This does not defend against a *hostile* runner — an attacker who
+> controls the environment Argus runs in controls its output. And note that a
+> ref-only image already present in the local daemon is scanned from that local
+> copy (see [#233](https://github.com/huntridge-labs/argus/pull/234)); the
+> recorded digest is exactly what makes that choice auditable. A signed
+> `cosign attest` of findings bound to the digest is tracked as a follow-up.
+
 ## Troubleshooting
 
 ### Authentication Failures


### PR DESCRIPTION
## Description
Implements the core of #237: bind every container scan result to the **content
digest** of the image actually scanned, so a clean scan attests *what* was
scanned rather than a mutable tag. `ContainerScanResult.digest` existed but was
never populated.

## Changes Made
- [ ] Added new scanner/workflow
- [x] Modified existing scanner/workflow
- [x] Updated documentation
- [ ] Fixed bug
- [x] Other (please specify): **supply-chain hardening — content-digest binding**

### Details
- **`container/resources.py`** — new `get_image_digest(image_ref)`: prefers the
  registry `RepoDigest` (`repo@sha256:…`, registry-comparable) for pulled/pushed
  images, falls back to the image **config Id** (`sha256:…`) for never-pushed
  local builds. Best-effort: returns `""` when docker is unavailable or the
  image can't be inspected — non-fatal, mirroring `is_image_local`.
- **`container/scanner.py`** — `scan_image` resolves the digest and (a) sets
  `ContainerScanResult.digest` (→ per-image markdown + audit manifest, already
  wired) and (b) stamps `image_digest` + `image_ref` into each finding's
  `metadata` (→ `argus-results.json` / SARIF) when a digest is resolved.
- **Breaking changes:** none. Additive; unknown digest leaves findings untouched.
- **Deferred (tracked):** OpenVEX product-digest pinning and a signed
  `cosign attest` of findings bound to the digest — the issue scopes attest as a
  stretch goal.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

### Test Results
- `TestGetImageDigest` (5 cases: pulled→RepoDigest, local→config Id, inspect
  failure→"", no-docker→"", timeout→"").
- `TestScanImageBindsContentDigest` (digest populated + stamped on findings;
  unknown digest is non-fatal and leaves metadata untouched).
- Full SDK suite green locally: **2668 passed, 16 skipped**; `check_architecture_sync` passes.

## Security Considerations
- [ ] No security impact
- [x] Security enhancement
- [ ] Potential security implications (explain below)

### Security Details
Closes the scan-vs-deploy substitution gap **for a trusted runner**: a deploy
gate / admission controller can compare the *deployed* image's digest against
the digest Argus recorded and reject anything swapped after the scan. A hostile
runner remains out of scope (it controls its own output). Complements #234 — a
ref-only image served from the local daemon is now auditable by the recorded
digest.

## AI Context Updates (.ai/)
- [x] `.ai/architecture.yaml` updated (container scan flow notes the digest binding)
- [x] N/A for workflows/decisions/errors

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (docs/container-scanning.md — "Result provenance" section)
- [x] All tests pass

## Related Issues
Closes #237.
