### PR TITLE
feat(scanner-mumps): support tree-sitter >=0.22 (Language pointer API)

### DIFF
--- a/.ai/errors.yaml
+++ b/.ai/errors.yaml
@@ -108,6 +108,32 @@ error_patterns:
 
     reference: "argus/scanners/mumps/taint.py (filter_charset_guarded)"
 
+  - pattern: "TypeError: Language.__init__.*argument|Parser.*set_language|tree-sitter bump fails all mumps unit-test legs"
+    category: scanner
+    context: |
+      A tree-sitter / py-tree-sitter upgrade (e.g. Dependabot proposing
+      >=0.22, surfaced by #247) breaks the MUMPS parser and fails every
+      mumps unit-test leg. py-tree-sitter 0.22 removed the two-arg
+      ``Language(path, name)`` constructor and ``Parser.set_language``.
+
+    root_cause: |
+      ``MumpsParser`` used the pre-0.22 API
+      (``Language(str(grammar), "mumps")`` + ``Parser()`` +
+      ``parser.set_language(...)``). 0.22+ requires a pre-loaded language
+      pointer wrapped in a PyCapsule and takes the language in the
+      ``Parser(language)`` constructor. The compiled ``mumps.so`` (language
+      ABI 14) itself is compatible with both lines — only the Python loader
+      changed.
+
+    solution:
+      steps:
+        - "The grammar loader is version-gated (_tree_sitter_minor): ≤0.21 keeps the two-arg Language + set_language; ≥0.22 wraps the grammar's tree_sitter_mumps() pointer with ctypes + PyCapsule_New(... b'tree_sitter.Language') via _grammar_capsule, then Language(capsule) + Parser(language). Both branches live in _load_grammar."
+        - "The [mumps] extra floats across the tested range (tree-sitter>=0.20,<0.26); the <0.26 ceiling bounds it to versions CI has exercised. No grammar rebuild — the same mumps.so loads on both lines."
+        - "docker/Dockerfile.mumps bumps its build-time TREE_SITTER_VERSION to the current line (0.25.2) so the scanner-mumps image ships the new binding."
+        - "No Dependabot ignore is needed — the dual path absorbs the API break."
+      verification: "TestTreeSitterVersionGating in test_mumps_scanner.py pins the branch selection; the full mumps suite passes on both 0.21.3 and 0.25.2"
+    reference: "argus/scanners/mumps/parser.py (_tree_sitter_minor / _grammar_capsule / _load_grammar) — issue #248, PR #249"
+
   # ==============================================================================
   # SARIF ERRORS
   # ==============================================================================

--- a/argus/scanners/mumps/parser.py
+++ b/argus/scanners/mumps/parser.py
@@ -92,6 +92,50 @@ class ParsedSource:
         return f"{self.path}:{line}:{col}"
 
 
+def _tree_sitter_minor() -> tuple[int, int]:
+    """(major, minor) of the installed py-tree-sitter binding."""
+    from importlib.metadata import version
+    parts = version("tree-sitter").split(".")
+    return int(parts[0]), int(parts[1])
+
+
+def _grammar_capsule(grammar: Path):
+    """Return a ``tree_sitter.Language`` PyCapsule for the compiled grammar.
+
+    The grammar shared library exports ``tree_sitter_mumps()`` returning a
+    ``const TSLanguage *``; py-tree-sitter >= 0.22 wants that pointer wrapped
+    in a PyCapsule named ``tree_sitter.Language`` rather than a path + name.
+    """
+    import ctypes
+    lib = ctypes.cdll.LoadLibrary(str(grammar))
+    lib.tree_sitter_mumps.restype = ctypes.c_void_p
+    new_capsule = ctypes.pythonapi.PyCapsule_New
+    new_capsule.restype = ctypes.py_object
+    new_capsule.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_void_p]
+    return new_capsule(lib.tree_sitter_mumps(), b"tree_sitter.Language", None)
+
+
+def _load_grammar(grammar: Path):
+    """Load the compiled MUMPS grammar; return ``(Language, Parser)``.
+
+    py-tree-sitter changed its API at 0.22: the two-argument
+    ``Language(path, name)`` was replaced by ``Language(<pointer>)`` and the
+    language now goes to the ``Parser`` constructor instead of
+    ``set_language``. We support both so the ``[mumps]`` extra works across
+    the 0.20–0.25 range without forcing a binding version (#248). The
+    compiled grammar (ABI 14) is accepted by both.
+    """
+    from tree_sitter import Language, Parser
+    if _tree_sitter_minor() >= (0, 22):
+        language = Language(_grammar_capsule(grammar))
+        return language, Parser(language)
+    # Pre-0.22 two-argument API.
+    language = Language(str(grammar), "mumps")
+    parser = Parser()
+    parser.set_language(language)
+    return language, parser
+
+
 class MumpsParser:
     """Lazy-initialized parser for MUMPS source files.
 
@@ -109,7 +153,7 @@ class MumpsParser:
         if cls._parser is not None:
             return
         try:
-            from tree_sitter import Language, Parser
+            import tree_sitter  # noqa: F401  (availability check only)
         except ImportError as exc:
             raise GrammarUnavailable(
                 "py-tree-sitter not installed. Install via "
@@ -122,10 +166,7 @@ class MumpsParser:
                 f"MUMPS grammar shared library not found. Searched: {paths}. "
                 "Run scripts/build-mumps-grammar.sh or use the scanner-mumps container image.",
             )
-        cls._language = Language(str(grammar), "mumps")
-        parser = Parser()
-        parser.set_language(cls._language)
-        cls._parser = parser
+        cls._language, cls._parser = _load_grammar(grammar)
 
     @classmethod
     def parse(cls, path: Path, source_bytes: bytes) -> ParsedSource:

--- a/argus/tests/scanners/test_mumps_scanner.py
+++ b/argus/tests/scanners/test_mumps_scanner.py
@@ -144,6 +144,70 @@ class TestGrammarLoading:
             MumpsParser.parse(Path("x.m"), b" ; empty\n")
 
 
+class TestTreeSitterVersionGating:
+    """Dual-path grammar loading across the py-tree-sitter 0.22 API break (#248).
+
+    py-tree-sitter 0.22 dropped the two-arg ``Language(path, name)``
+    constructor and ``Parser.set_language``. ``_load_grammar`` selects the
+    path by version; CI installs only one tree-sitter, so these tests pin the
+    branch *selection* directly. The ≥0.22 ctypes/PyCapsule loader
+    (``_grammar_capsule``) is exercised end-to-end against the real grammar
+    in test_mumps_rules.py.
+    """
+
+    @staticmethod
+    def _install_fake_tree_sitter(monkeypatch, calls):
+        import sys
+        import types
+
+        class _Lang:
+            def __init__(self, *args):
+                calls["language_args"] = args
+
+        class _Parser:
+            def __init__(self, *args):
+                calls["parser_args"] = args
+
+            def set_language(self, language):
+                calls["set_language"] = language
+
+        module = types.ModuleType("tree_sitter")
+        module.Language = _Lang
+        module.Parser = _Parser
+        monkeypatch.setitem(sys.modules, "tree_sitter", module)
+
+    def test_minor_parses_major_minor(self, monkeypatch):
+        from argus.scanners.mumps import parser as pm
+        monkeypatch.setattr("importlib.metadata.version", lambda _n: "0.25.2")
+        assert pm._tree_sitter_minor() == (0, 25)
+
+    def test_modern_path_uses_capsule_and_parser_ctor(self, monkeypatch):
+        from argus.scanners.mumps import parser as pm
+        calls: dict = {}
+        self._install_fake_tree_sitter(monkeypatch, calls)
+        monkeypatch.setattr(pm, "_tree_sitter_minor", lambda: (0, 25))
+        capsule = object()
+        monkeypatch.setattr(pm, "_grammar_capsule", lambda _g: capsule)
+
+        language, _parser = pm._load_grammar(Path("/x/mumps.so"))
+
+        assert calls["language_args"] == (capsule,)   # Language(<capsule>)
+        assert calls["parser_args"] == (language,)    # Parser(language)
+        assert "set_language" not in calls            # set_language is gone in ≥0.22
+
+    def test_legacy_path_uses_two_arg_language_and_set_language(self, monkeypatch):
+        from argus.scanners.mumps import parser as pm
+        calls: dict = {}
+        self._install_fake_tree_sitter(monkeypatch, calls)
+        monkeypatch.setattr(pm, "_tree_sitter_minor", lambda: (0, 21))
+
+        language, _parser = pm._load_grammar(Path("/x/mumps.so"))
+
+        assert calls["language_args"] == ("/x/mumps.so", "mumps")  # 2-arg form
+        assert calls["parser_args"] == ()                          # no-arg ctor
+        assert calls["set_language"] is language                   # bound via set_language
+
+
 class _StubNode:
     """Empty AST node — has no children so walk() yields only itself
     and the call-graph builder finds zero labels / edges."""

--- a/docker/Dockerfile.mumps
+++ b/docker/Dockerfile.mumps
@@ -36,14 +36,15 @@ LABEL org.opencontainers.image.source="https://github.com/huntridge-labs/argus"
 LABEL org.opencontainers.image.description="Argus MUMPS / M language SAST scanner"
 LABEL org.opencontainers.image.licenses="AGPL-3.0"
 
-ARG TREE_SITTER_VERSION=0.21.3
+ARG TREE_SITTER_VERSION=0.25.2
 
 # libstdc++ for the dlopened grammar .so. apk upgrade picks up OS CVEs.
 RUN apk upgrade --no-cache && \
     apk add --no-cache libstdc++
 
-# Python deps: py-tree-sitter v0.21 (we use the Language(path, name)
-# constructor that v0.22 dropped), plus the minimum Argus core needs
+# Python deps: py-tree-sitter (MumpsParser supports both the pre-0.22
+# Language(path, name) API and the >=0.22 Language(<pointer>) + Parser(lang)
+# API, so this floats with the [mumps] extra — #248), plus the minimum Argus core needs
 # to import and run a scan. ``--virtual .ts-build-deps`` lets us drop
 # gcc / python-dev after the install layer so the runtime image stays
 # small (the grammar is already compiled in the previous stage).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,9 +98,11 @@ browser = [
 # Apache-2.0, MITRE PR 23-4084) is not on PyPI; installing this extra only
 # brings in py-tree-sitter. Users still need either
 # ``scripts/build-mumps-grammar.sh`` (local) or the scanner-mumps container image
-# (which ships a prebuilt grammar). Pinned below 0.22 because v0.22
-# reworked Language() to require a pre-loaded library pointer.
-mumps = ["tree-sitter>=0.20,<0.22"]
+# (which ships a prebuilt grammar). MumpsParser supports both the pre-0.22
+# Language(path, name) API and the >=0.22 Language(<pointer>) + Parser(lang)
+# API (#248), so the binding floats across the tested 0.20–0.25 range; the
+# <0.26 ceiling just bounds it to versions CI has exercised.
+mumps = ["tree-sitter>=0.20,<0.26"]
 # All optional features
 all = ["argus-security[ai,completion,mcp,terminal,browser,mumps]"]
 


### PR DESCRIPTION
> ⏸️ **Hold — do not merge until the in-flight release tags.** Built off the
> released `main` (`9b65035`); this is a fast-follow, intentionally excluded
> from the current release.

## Description
Closes #248 — lets Argus use **latest tree-sitter** instead of being capped at
`<0.22`. py-tree-sitter 0.22 replaced `Language(path, name)` with
`Language(<pointer>)` and moved the language into the `Parser` constructor
(`set_language` removed); the cap existed because `MumpsParser` used the old
2-arg API (and is why Dependabot's cap-widening #247 broke all four unit-test
legs). Rather than ignore the update, this ports the loader.

## Changes Made
- [ ] Added new scanner/workflow
- [x] Modified existing scanner/workflow
- [x] Updated documentation (inline rationale in pyproject + Dockerfile)
- [x] Other (please specify): **dependency-compat port (tree-sitter ≥0.22)**

### Details
- **`scanners/mumps/parser.py`** — dual-path loader: on **≥0.22** it dlopens the
  compiled `.so`, wraps `tree_sitter_mumps()`'s `TSLanguage*` in a
  `tree_sitter.Language` PyCapsule, and uses `Language(capsule)` +
  `Parser(language)`; on **<0.22** it keeps the legacy 2-arg path. One small
  helper picks the path by binding version.
- **`pyproject.toml`** — `[mumps]` cap `>=0.20,<0.22` → `>=0.20,<0.26`.
- **`docker/Dockerfile.mumps`** — `TREE_SITTER_VERSION` `0.21.3` → `0.25.2` so
  the shipped `scanner-mumps` image runs the latest binding.
- **The compiled grammar is unchanged** (ABI 14, accepted by both bindings) —
  no grammar regen, build script untouched.

## Testing
- [x] Unit tests added/updated (existing mumps suite exercises both paths)
- [x] Manual testing performed (both bindings)

### Test Results
- Mumps rule + scanner suites — **139 passed on tree-sitter 0.21.3 (old path)
  AND 139 passed on 0.25.2 (new path)**, including the golden security-count
  guard (parse output is identical across bindings).
- Full SDK suite green on 0.25.2 (**2686 passed**); arch-sync green.
- CI installs the latest in-range binding (0.25.x) via `.[all]`, so the new
  path is now exercised in CI on every run.

## Security Considerations
- [x] Security enhancement

### Security Details
Keeps the security-critical MUMPS parser on a maintained tree-sitter line
(picks up upstream fixes) and removes the need to pin an old binding or ignore
Dependabot updates — closing the churn from #247 without an ignore rule.

## AI Context Updates (.ai/)
- [x] N/A — internal loader change, no component/structure change (arch-sync passes)

## Checklist
- [x] Code follows project style guidelines
- [x] All tests pass (both bindings + full suite)

## Related Issues
Closes #248. Resolves the tree-sitter dependency churn surfaced by #247.
