### PR TITLE
feat(govulncheck): reachability-aware Go vulnerability scanner

### DIFF
--- a/.ai/architecture.yaml
+++ b/.ai/architecture.yaml
@@ -484,6 +484,11 @@ scanners:
     purpose: Dependency vulnerability scanning via OSV database
     output: JSON/SARIF
     note: Any trigger, uses official google/osv-scanner-action Docker image
+  - name: govulncheck
+    purpose: "Reachability-aware Go vulnerability scanning — reports vulns only when the affected symbol is actually called (call graph built from source), cutting the presence-based false positives that grype/trivy/osv surface on Go binaries/modules"
+    languages: [go]
+    output: JSON/SARIF
+    note: "Go-only, source mode (govulncheck ./...). Two finding tiers: reachable (real OSV severity, gates) and imported-but-not-called (INFO, never gates, metadata.reachable=false). Go advisories frequently lack CVSS → reachable findings may be UNKNOWN severity (documented limitation, not a parse bug). Custom image docker/Dockerfile.govulncheck (WORKDIR /workspace, since the engine sets no -w on the container). Local execution runs with cwd=scan path so the ./... pattern resolves against the target module. Streamed-JSON parser (govulncheck emits concatenated objects, not one document)."
   - name: dependency-review
     purpose: PR dependency diff analysis and license compliance
     output: JSON

--- a/.ai/errors.yaml
+++ b/.ai/errors.yaml
@@ -291,13 +291,42 @@ errors:
       - "Tab-complete via `argus completion zsh` (or bash/fish) \u2014 completions\
         \ are generated from the live registry"
       examples:
-        security_scanners: bandit, gitleaks, opengrep, osv, trivy-iac, checkov, clamav,
-          supply-chain, zap, container
+        security_scanners: bandit, gosec, govulncheck, gitleaks, opengrep, osv, trivy-iac,
+          checkov, clamav, supply-chain, zap, container
         linters: lint-yaml, lint-json, lint-python, lint-javascript, lint-dockerfile,
           lint-terraform
         composite_only: codeql, dependency-review, scn-detector (composite-action-only;
           not registered as SDK scanners)
     symptom: Scanner X not found in matrix
+  GO_CVE_FALSE_POSITIVE:
+    category: scanner
+    context: |
+      A Go project's container/binary scan (grype, trivy) or its OSV
+      dependency scan flags a CVE, you open a fix PR, and the upstream
+      maintainer responds that it's a false positive because the vulnerable
+      code path is never used. Presence-based scanners flag a CVE whenever
+      the vulnerable *package* is in the dependency graph, regardless of
+      whether the vulnerable *symbol* is ever called.
+    root_cause: |
+      grype/trivy/osv are presence-based: they enumerate packages (from the
+      image, the binary's embedded module list, or go.mod) and match them
+      against a CVE database. They have no call-graph / reachability
+      analysis, so "library X has CVE-Y" is reported even when your code
+      never reaches the affected function. For Go specifically this is a
+      large, well-known false-positive class.
+    solution:
+      steps:
+      - "Verify Go findings with the reachability-aware scanner before filing upstream fixes: `argus scan govulncheck --path <go-module>`."
+      - "govulncheck builds the call graph from source and reports a vuln only when the affected symbol is actually reachable. Findings carry metadata.reachable: a 'reachable: false' finding (severity INFO, titled '[imported, not called]') is present-but-unreachable, i.e. the false-positive case."
+      - "Treat reachable findings as actionable; treat imported-but-not-called as informational (they never gate on fail_on_severity)."
+      - "Keep osv/grype/trivy for breadth and non-Go ecosystems; use govulncheck as the Go reachability filter."
+      note: |
+        Go advisories often lack a CVSS, so a reachable govulncheck finding
+        may be severity UNKNOWN. That's a Go vuln-DB limitation, not a parse
+        bug; combine with osv if you need CVSS-derived severity for gating.
+    reference: argus/scanners/govulncheck.py; docs/scanners.md Dependency Scanners
+      govulncheck (Go)
+    symptom: Go CVE false positive|vulnerability reported but code isn't used|UNAFFECTED.*govulncheck
   CODEQL__UNSUPPORTED_LANGUAGE:
     category: scanner
     context: CodeQL fails to analyze repository

--- a/.github/actions/scanner-govulncheck/.docsite.yml
+++ b/.github/actions/scanner-govulncheck/.docsite.yml
@@ -1,0 +1,1 @@
+category: dependency

--- a/.github/actions/scanner-govulncheck/README.md
+++ b/.github/actions/scanner-govulncheck/README.md
@@ -1,0 +1,66 @@
+# govulncheck Go Vulnerability Scanner
+
+Reachability-aware Go vulnerability scanning using [govulncheck](https://go.dev/security/vuln/), Go's official vulnerability tool, run through the Argus SDK.
+
+## Why this exists
+
+Presence-based scanners (grype, trivy, osv-scanner) report **every** known vulnerability in **every** dependency in a Go module's graph — even when the affected function is never called. That produces a large class of false positives: "the vulnerable package is in `go.mod`, so it's flagged," regardless of whether your code can reach the vulnerable code path.
+
+`govulncheck` builds the program **call graph from source** and reports a vulnerability only when the affected symbol is actually reachable. That reachability filter is the difference between "you import a library that has a CVE somewhere" and "your code calls the vulnerable function."
+
+## Finding tiers
+
+| Tier | Meaning | Severity in Argus |
+|------|---------|-------------------|
+| **Called / reachable** | govulncheck found a call path to the vulnerable symbol | Real (OSV-derived) severity — gates on `fail_on_severity` |
+| **Imported, not called** | The vulnerable module/package is in the build graph but the affected symbol isn't called | `INFO` — visible for audit, never gates |
+
+`metadata.reachable` (`true`/`false`) and, for reachable findings, `metadata.call_stack` (entry point → vulnerable symbol) are attached to every finding.
+
+## Requirements
+
+- A Go module (a `go.mod`). govulncheck's source mode type-checks and builds the target packages to compute reachability, so it needs the Go toolchain and the module's dependencies resolvable (network access to the module proxy and to `https://vuln.go.dev`).
+- This action sets up Go and installs govulncheck for you.
+
+## Usage
+
+```yaml
+- uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+- uses: huntridge-labs/argus/.github/actions/scanner-govulncheck@1.4.0
+  with:
+    scan_path: '.'
+    fail_on_severity: 'high'
+    enable_code_security: true
+```
+
+## Inputs
+
+| Input | Description | Default |
+|-------|-------------|---------|
+| `scan_path` | Path to the Go module to scan (directory containing `go.mod`) | `.` |
+| `go_version` | Go version to set up | `stable` |
+| `govulncheck_version` | govulncheck version to install | `latest` |
+| `fail_on_severity` | Fail at/above this severity (`none`, `low`, `medium`, `high`, `critical`) | `none` |
+| `enable_code_security` | Upload SARIF to the GitHub Security tab | `false` |
+| `post_pr_comment` | Post results as a PR comment | `false` |
+| `job_id` | Job ID for artifact naming | `${{ github.job }}` |
+
+To narrow the scan to a sub-package (e.g. `./cmd/...`), set `scanners.govulncheck.scan_target` in `argus.yml` — the SDK reads it from the per-scanner config block.
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `critical_count` / `high_count` / `medium_count` / `low_count` | Findings by severity |
+| `total_count` | Total findings (reachable + imported-not-called) |
+| `scan_status` | `clean` or `vulnerable` |
+
+## Severity note
+
+Go advisories (`GO-YYYY-NNNN`) frequently carry no machine-readable severity. When that's the case a reachable finding is reported as `UNKNOWN` (not guessed), so it won't trip `fail_on_severity: high`. Pair govulncheck with `scanner-osv` if you need CVSS-derived severities for gating, and rely on govulncheck for the reachability signal.
+
+## Relationship to other scanners
+
+- **`scanner-gosec`** — Go SAST (code anti-patterns like SQL string-building). Complementary; not dependency CVEs.
+- **`scanner-osv`** — presence-based dependency CVEs across many ecosystems. Broader coverage, no reachability.
+- **`scanner-govulncheck`** (this) — Go-only, reachability-filtered dependency CVEs. The lowest false-positive Go dependency signal.

--- a/.github/actions/scanner-govulncheck/action.yml
+++ b/.github/actions/scanner-govulncheck/action.yml
@@ -1,0 +1,196 @@
+name: 'govulncheck Go Vulnerability Scanner'
+description: |
+  Run govulncheck for reachability-aware Go vulnerability scanning via the
+  Argus SDK.
+
+  Unlike presence-based scanners (grype/trivy/osv), govulncheck builds the
+  program call graph from source and reports a vulnerability only when the
+  affected symbol is actually reachable — cutting the "vulnerable package
+  is in go.mod but never called" false positives. Imported-but-not-called
+  vulnerabilities are still surfaced, but as INFO so they never gate.
+
+  Requires Go source (a module with go.mod). This action sets up Go and
+  installs govulncheck, then runs it through the SDK so results integrate
+  with security-summary like every other scanner.
+
+  **Usage Example:**
+  ```yaml
+  - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+  - uses: huntridge-labs/argus/.github/actions/scanner-govulncheck@1.4.0
+    with:
+      scan_path: '.'
+      fail_on_severity: 'high'
+  ```
+
+author: 'Argus'
+
+branding:
+  icon: 'shield'
+  color: 'blue'
+
+inputs:
+  scan_path:
+    description: 'Path to the Go module to scan (directory containing go.mod)'
+    required: false
+    default: '.'
+  go_version:
+    description: 'Go version to set up (govulncheck source mode needs a Go toolchain)'
+    required: false
+    default: 'stable'
+  govulncheck_version:
+    description: 'govulncheck version to install'
+    required: false
+    default: 'latest'
+  enable_code_security:
+    description: 'Whether GitHub Code Security is enabled (uploads SARIF to the Security tab)'
+    required: false
+    default: 'false'
+  post_pr_comment:
+    description: 'Whether to post PR comments'
+    required: false
+    default: 'false'
+  fail_on_severity:
+    description: 'Fail if findings at or above this severity. Options: none, low, medium, high, critical.'
+    required: false
+    default: 'none'
+  job_id:
+    description: 'Job ID for artifact naming'
+    required: false
+    default: ${{ github.job }}
+
+outputs:
+  critical_count:
+    description: 'Number of critical severity findings'
+    value: ${{ steps.scan.outputs.critical_count }}
+  high_count:
+    description: 'Number of high severity findings'
+    value: ${{ steps.scan.outputs.high_count }}
+  medium_count:
+    description: 'Number of medium severity findings'
+    value: ${{ steps.scan.outputs.medium_count }}
+  low_count:
+    description: 'Number of low severity findings'
+    value: ${{ steps.scan.outputs.low_count }}
+  total_count:
+    description: 'Total number of vulnerability findings (reachable + imported-not-called)'
+    value: ${{ steps.scan.outputs.total_count }}
+  scan_status:
+    description: 'Overall scan status (clean or vulnerable)'
+    value: ${{ steps.scan.outputs.scan_status }}
+
+runs:
+  using: 'composite'
+  steps:
+    # IMPORTANT: Caller must checkout the repository before calling this action
+    # Example:
+    #   - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    #   - uses: ./.github/actions/scanner-govulncheck
+
+    - name: Set up Go
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      with:
+        go-version: ${{ inputs.go_version }}
+
+    - name: Install govulncheck
+      shell: bash
+      env:
+        GOVULNCHECK_VERSION: ${{ inputs.govulncheck_version }}
+      # govulncheck has no official binary release / image; upstream
+      # distributes it via `go install`. Install it onto PATH so the SDK's
+      # local-binary path (preferred over the container fallback) finds it.
+      run: |
+        go install "golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}"
+        echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+    - name: Set up Python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      with:
+        python-version: '3.14'
+
+    - name: Install Argus SDK
+      shell: bash
+      # Install the SDK from the checked-out composite source. This matches
+      # the consumer-scoped intent of composite actions (``uses: .../<wrapper>@tag``
+      # implicitly pins the SDK version to the same tag) and sidesteps the
+      # PyPI-release lag that would break ``pip install argus-security>=X``
+      # for consumers until after the release ships. See
+      # scanner-container/action.yml for the original rationale.
+      run: pip install "${{ github.action_path }}/../../.."
+
+    - name: Run govulncheck via Argus SDK
+      id: scan
+      shell: bash
+      env:
+        SCAN_PATH: ${{ inputs.scan_path }}
+        FAIL_ON_SEVERITY: ${{ inputs.fail_on_severity }}
+      run: |
+        mkdir -p govulncheck-reports scanner-summaries
+
+        # --path points govulncheck at the module root (its cwd), so the
+        # default ``./...`` pattern resolves there. To narrow the scan to a
+        # sub-package, set scanners.govulncheck.scan_target in argus.yml.
+        SCAN_EXIT=0
+        python -m argus scan govulncheck \
+          --path "${SCAN_PATH}" \
+          --severity-threshold "${FAIL_ON_SEVERITY:-none}" \
+          --format sarif --format json --format markdown \
+          --output-dir ./govulncheck-reports \
+          --output-vars ./govulncheck-reports/counts.env \
+          --no-timestamp \
+          || SCAN_EXIT=$?
+
+        # Forward counts to GitHub Actions outputs
+        [ -f govulncheck-reports/counts.env ] && cat govulncheck-reports/counts.env >> "$GITHUB_OUTPUT"
+
+        # Derive scan_status from passed flag
+        if [ -f govulncheck-reports/counts.env ]; then
+          PASSED=$(grep '^passed=' govulncheck-reports/counts.env | cut -d= -f2)
+          if [ "$PASSED" = "true" ]; then
+            echo "scan_status=clean" >> "$GITHUB_OUTPUT"
+          else
+            echo "scan_status=vulnerable" >> "$GITHUB_OUTPUT"
+          fi
+        fi
+
+        # Copy markdown summary for PR comment artifact
+        if [ -f "govulncheck-reports/argus-summary.md" ]; then
+          cp govulncheck-reports/argus-summary.md scanner-summaries/govulncheck.md
+          cat govulncheck-reports/argus-summary.md >> "$GITHUB_STEP_SUMMARY"
+        fi
+
+        exit $SCAN_EXIT
+
+    - name: Upload SARIF to GitHub Security
+      if: inputs.enable_code_security == 'true' && always() && github.actor != 'nektos/act' && hashFiles('govulncheck-reports/argus-results.sarif') != ''
+      uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
+      with:
+        sarif_file: govulncheck-reports/argus-results.sarif
+        category: govulncheck
+      continue-on-error: true
+
+    - name: Upload govulncheck reports
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      with:
+        name: govulncheck-reports-${{ inputs.job_id }}
+        path: govulncheck-reports/
+        retention-days: 30
+      continue-on-error: true
+
+    - name: Upload scanner summary
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      with:
+        name: scanner-summary-govulncheck-${{ inputs.job_id }}
+        path: scanner-summaries/govulncheck.md
+        retention-days: 7
+      continue-on-error: true
+
+    - name: Comment PR with govulncheck results
+      if: github.event_name == 'pull_request' && inputs.post_pr_comment == 'true'
+      uses: huntridge-labs/argus/.github/actions/comment-pr@1.4.0
+      with:
+        summary_file: scanner-summaries/govulncheck.md
+        comment_marker: govulncheck-scanner-comment-marker
+        title: '🐹 govulncheck Go Vulnerability Results'
+        fallback_message: 'No govulncheck results available'

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -46,6 +46,19 @@
     },
     {
       "customType": "regex",
+      "description": "govulncheck version in Dockerfiles",
+      "managerFilePatterns": [
+        "docker/Dockerfile.*"
+      ],
+      "matchStrings": [
+        "ARG GOVULNCHECK_VERSION=(?<currentValue>v[\\d.]+)"
+      ],
+      "depNameTemplate": "golang.org/x/vuln",
+      "packageNameTemplate": "golang.org/x/vuln",
+      "datasourceTemplate": "go"
+    },
+    {
+      "customType": "regex",
       "description": "Grype version in Dockerfiles",
       "managerFilePatterns": [
         "docker/Dockerfile.*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,6 +235,7 @@ jobs:
             "scanner-supply-chain:docker/Dockerfile.supply-chain:SCANNER_SUPPLY_CHAIN"
             "cli:docker/Dockerfile.cli:CLI"
             "scanner-mumps:docker/Dockerfile.mumps:SCANNER_MUMPS"
+            "scanner-govulncheck:docker/Dockerfile.govulncheck:SCANNER_GOVULNCHECK"
           )
 
           # Single source of truth: export the bare image names so the

--- a/.github/workflows/test-actions.yml
+++ b/.github/workflows/test-actions.yml
@@ -1054,6 +1054,61 @@ jobs:
           STEPS_SCAN_OUTPUTS_HIGH_COUNT: ${{ steps.scan.outputs.high_count }}
           STEPS_SCAN_OUTPUTS_LICENSE_VIOLATIONS: ${{ steps.scan.outputs.license_violations }}
 
+  test-govulncheck:
+    name: Dependencies / govulncheck
+    runs-on: ubuntu-latest
+    if: (github.event_name == 'workflow_dispatch' && (inputs.test_group == 'all' || inputs.test_group == 'dependencies') || github.event_name != 'workflow_dispatch') && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):'))
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Run govulncheck scanner
+        id: scan
+        uses: ./.github/actions/scanner-govulncheck
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Pinned intentionally-vulnerable Go module fixture with a known
+          # REACHABLE advisory (GO-2022-1059, reached via a call to
+          # language.ParseAcceptLanguage). This exercises govulncheck's
+          # call-graph reachability end to end — the whole point of the
+          # scanner — not just presence-based detection.
+          scan_path: 'tests/fixtures/test-apps/go-app'
+          post_pr_comment: 'false'
+          enable_code_security: ${{ env.ENABLE_CODE_SECURITY }}
+          # Keep the job green regardless of severity (Go advisories often
+          # lack a CVSS, so the reachable finding is UNKNOWN); we assert on
+          # the finding count instead.
+          fail_on_severity: 'none'
+
+      - name: Verify scan detected the reachable vulnerability
+        shell: bash
+        run: |
+          {
+            echo "## govulncheck Scanner Test Results"
+            echo "✅ govulncheck scanner executed successfully"
+            echo ""
+            echo "**Total findings:** ${STEPS_SCAN_OUTPUTS_TOTAL_COUNT}"
+            echo "**Scan status:** ${STEPS_SCAN_OUTPUTS_SCAN_STATUS}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # The fixture pins a dependency with a known reachable advisory, so
+          # govulncheck must surface at least one finding. Zero means the scan
+          # didn't actually analyze the Go module (Go/govulncheck not set up,
+          # or reachability silently no-op'd) — the exact regression this
+          # E2E guards against.
+          if [ "${STEPS_SCAN_OUTPUTS_TOTAL_COUNT:-0}" -lt 1 ]; then
+            echo "::error::govulncheck reported 0 findings against the vulnerable Go fixture — expected >= 1 (GO-2022-1059)."
+            exit 1
+          fi
+        env:
+          STEPS_SCAN_OUTPUTS_TOTAL_COUNT: ${{ steps.scan.outputs.total_count }}
+          STEPS_SCAN_OUTPUTS_SCAN_STATUS: ${{ steps.scan.outputs.scan_status }}
+
   # ============================================================================
   # Summary Generators
   # Tests: linting-summary
@@ -1347,6 +1402,7 @@ jobs:
       - test-supply-chain
       - test-osv
       - test-dependency-review
+      - test-govulncheck
       - test-linting-summary
       - test-parse-container-config
       - test-parse-zap-config
@@ -1380,6 +1436,7 @@ jobs:
           NEEDS_TEST_SUPPLY_CHAIN_RESULT: ${{ needs.test-supply-chain.result }}
           NEEDS_TEST_OSV_RESULT: ${{ needs.test-osv.result }}
           NEEDS_TEST_DEPENDENCY_REVIEW_RESULT: ${{ needs.test-dependency-review.result }}
+          NEEDS_TEST_GOVULNCHECK_RESULT: ${{ needs.test-govulncheck.result }}
           NEEDS_TEST_LINTING_SUMMARY_RESULT: ${{ needs.test-linting-summary.result }}
           NEEDS_TEST_PARSE_CONTAINER_CONFIG_RESULT: ${{ needs.test-parse-container-config.result }}
           NEEDS_TEST_PARSE_ZAP_CONFIG_RESULT: ${{ needs.test-parse-zap-config.result }}
@@ -1410,6 +1467,7 @@ jobs:
             echo "| Supply Chain | ${{ needs.test-supply-chain.result == 'success' && '✅' || '⚠️' }} ${NEEDS_TEST_SUPPLY_CHAIN_RESULT} |"
             echo "| OSV Dependencies | ${{ needs.test-osv.result == 'success' && '✅' || '⚠️' }} ${NEEDS_TEST_OSV_RESULT} |"
             echo "| Dependency Review | ${{ needs.test-dependency-review.result == 'success' && '✅' || '⚠️' }} ${NEEDS_TEST_DEPENDENCY_REVIEW_RESULT} |"
+            echo "| govulncheck (Go Dependencies) | ${{ needs.test-govulncheck.result == 'success' && '✅' || '⚠️' }} ${NEEDS_TEST_GOVULNCHECK_RESULT} |"
             echo "| Linting Summary | ${{ needs.test-linting-summary.result == 'success' && '✅' || '⚠️' }} ${NEEDS_TEST_LINTING_SUMMARY_RESULT} |"
             echo "| Container Config Parser | ${{ needs.test-parse-container-config.result == 'success' && '✅' || '⚠️' }} ${NEEDS_TEST_PARSE_CONTAINER_CONFIG_RESULT} |"
             echo "| ZAP Config Parser | ${{ needs.test-parse-zap-config.result == 'success' && '✅' || '⚠️' }} ${NEEDS_TEST_PARSE_ZAP_CONFIG_RESULT} |"
@@ -1452,6 +1510,7 @@ jobs:
       - test-supply-chain
       - test-osv
       - test-dependency-review
+      - test-govulncheck
       - test-linting-summary
       - test-parse-container-config
       - test-parse-zap-config

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,11 @@ repos:
         exclude: ^(docs)
       - id: check-case-conflict
       - id: check-json
-        exclude: ^(tests/invalid\.json)$
+        # govulncheck emits a *stream* of concatenated JSON objects (config,
+        # progress, osv, finding) rather than one document — these fixtures
+        # capture that verbatim so the stream parser is exercised, so they are
+        # intentionally not valid single-document JSON.
+        exclude: ^(tests/invalid\.json|tests/fixtures/scanner-outputs/govulncheck/.*\.json)$
       - id: detect-private-key
         exclude: ^(tests/secrets_test\.py|argus/tests/core/test_redact\.py)$
       - id: mixed-line-ending
@@ -30,7 +34,9 @@ repos:
         # verbatim from `argus scan`; re-emitting them through
         # json.dump(ensure_ascii=True) escapes em-dashes / non-ASCII
         # and makes them diverge from real argus output.
-        exclude: ^(docs/images/.*\.json|tests/invalid\.json)$
+        # govulncheck stream fixtures (concatenated JSON objects) must not be
+        # reformatted as a single document — see check-json above.
+        exclude: ^(docs/images/.*\.json|tests/invalid\.json|tests/fixtures/scanner-outputs/govulncheck/.*\.json)$
   # renovate: datasource=github-tags depName=pre-commit/pygrep-hooks versioning=semver
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0  # Use the ref you want to point at

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -449,7 +449,7 @@ See `CONTRIBUTING.md` for the complete composite actions development guide. Key 
 |----------|---------|---------------|
 | **SAST** | scanner-codeql<br>scanner-bandit<br>scanner-gosec<br>scanner-opengrep<br>scanner-mumps | Multi-language<br>Python<br>Go<br>Pattern-based<br>MUMPS / M (28 rules: M001-M007 security, M101-M102 + M201-M219 diagnostics — mHawk taint-sink parity + 21 diagnostics) |
 | **Secrets** | scanner-gitleaks | Git history & files |
-| **Dependencies** | scanner-osv<br>scanner-dependency-review | OSV database<br>PR diff analysis & license compliance |
+| **Dependencies** | scanner-osv<br>scanner-govulncheck<br>scanner-dependency-review | OSV database<br>Go reachability-aware (govulncheck — only reports vulns whose symbol is actually called)<br>PR diff analysis & license compliance |
 | **Infrastructure** | scanner-trivy-iac<br>scanner-checkov | Terraform, K8s, etc.<br>Multi-framework |
 | **Container** | scanner-container | Trivy + Grype + Syft |
 | **Malware** | scanner-clamav | File scanning |

--- a/argus.yml
+++ b/argus.yml
@@ -85,6 +85,9 @@ containers:
     - dockerfile: docker/Dockerfile.mumps
       context: .
       name: scanner-mumps
+    - dockerfile: docker/Dockerfile.govulncheck
+      context: .
+      name: scanner-govulncheck
   scanners: [trivy, grype, syft]
 
 reporting:

--- a/argus/containers.py
+++ b/argus/containers.py
@@ -83,6 +83,16 @@ CUSTOM_IMAGES = {
     # + release digest. The digest pin below is still the content-hash
     # gate the manifest check verifies.
     "mumps": "ghcr.io/huntridge-labs/argus/scanner-mumps:1.9.1@sha256:00be506f7617cc1dbc98f4190d682bdd10f3d347daf2cfac5ee0c9cc2f84bd3f",
+    # govulncheck — reachability-aware Go vuln scanner. There is no
+    # official govulncheck image (upstream ships it via
+    # ``go install golang.org/x/vuln/cmd/govulncheck``), so argus builds
+    # and publishes its own from docker/Dockerfile.govulncheck (golang
+    # base + pinned govulncheck). PRE-PUBLISH PLACEHOLDER: the digest
+    # below is a zero placeholder; the release pipeline builds the image,
+    # then release-it rewrites this line to the real release digest. Until
+    # that first publish, run the scanner with a locally-installed
+    # govulncheck — the SDK prefers the local binary when present.
+    "govulncheck": "ghcr.io/huntridge-labs/argus/scanner-govulncheck:1.9.1@sha256:0000000000000000000000000000000000000000000000000000000000000000",
 }
 
 

--- a/argus/containers.py
+++ b/argus/containers.py
@@ -113,6 +113,35 @@ def get_image(scanner_name: str) -> str:
     return OFFICIAL_IMAGES.get(key, CUSTOM_IMAGES.get(key, ""))
 
 
+# Sentinel digest for a custom image argus builds but hasn't published yet.
+# A CUSTOM_IMAGES entry pinned to this all-zeros digest is a *pre-publish
+# placeholder*: the release pipeline builds the image on first release and the
+# release-it regex bumper rewrites the line to the real digest. Until then,
+# consumers must treat the image as "not available" — the scanner advertises no
+# container image (so ``auto`` runs the local tool), version verification is
+# skipped (the argus image tag is not the tool's own version), and CI
+# image-manifest / smoke checks skip it rather than failing on a digest that
+# intentionally can't resolve. When the real digest lands, every path
+# reactivates automatically with no further code change.
+PLACEHOLDER_DIGEST = "sha256:" + "0" * 64
+
+
+def is_placeholder_image(image: str) -> bool:
+    """True if *image* pins the unpublished-image placeholder digest."""
+    return bool(image) and image.endswith("@" + PLACEHOLDER_DIGEST)
+
+
+def published_image(scanner_name: str) -> str:
+    """Return the scanner's container image, or ``""`` if it isn't published.
+
+    Wraps :func:`get_image` so a scanner pinned to the placeholder digest
+    advertises no image and callers fall back to the local tool until the
+    release pipeline writes the real digest.
+    """
+    image = get_image(scanner_name)
+    return "" if is_placeholder_image(image) else image
+
+
 def expected_version(container_image: str) -> str | None:
     """Extract the expected tool version from a container image tag.
 
@@ -140,8 +169,13 @@ def get_expected_version(scanner_name: str) -> str | None:
 
     Convenience wrapper that resolves the scanner name to its container
     image via :func:`get_image`, then delegates to :func:`expected_version`.
+
+    Returns ``None`` for an unpublished placeholder image — there is no real
+    image (hence no pinned tool version) to verify a local install against yet.
     """
     image = get_image(scanner_name)
+    if is_placeholder_image(image):
+        return None
     return expected_version(image)
 
 

--- a/argus/containers.py
+++ b/argus/containers.py
@@ -87,11 +87,14 @@ CUSTOM_IMAGES = {
     # official govulncheck image (upstream ships it via
     # ``go install golang.org/x/vuln/cmd/govulncheck``), so argus builds
     # and publishes its own from docker/Dockerfile.govulncheck (golang
-    # base + pinned govulncheck). PRE-PUBLISH PLACEHOLDER: the digest
-    # below is a zero placeholder; the release pipeline builds the image,
-    # then release-it rewrites this line to the real release digest. Until
-    # that first publish, run the scanner with a locally-installed
-    # govulncheck — the SDK prefers the local binary when present.
+    # base + pinned govulncheck), wired into the release ``IMAGES`` matrix
+    # like every other custom image. PRE-PUBLISH PLACEHOLDER: the digest
+    # below stays all-zeros until the first release builds the image and
+    # scripts/release_it/inject_image_digests.py writes the real digest
+    # here (release-it bumps the tag; the injector writes the digest).
+    # While it's a placeholder, ``published_image`` reports no image so the
+    # scanner runs the locally-installed govulncheck (see GovulncheckScanner);
+    # the container path activates automatically once the real digest lands.
     "govulncheck": "ghcr.io/huntridge-labs/argus/scanner-govulncheck:1.9.1@sha256:0000000000000000000000000000000000000000000000000000000000000000",
 }
 

--- a/argus/core/scanner_template.py
+++ b/argus/core/scanner_template.py
@@ -91,6 +91,7 @@ def run_subprocess_scan(
     *,
     output_filename: str = "results.json",
     timeout: float | None = None,
+    cwd: str | None = None,
 ) -> ScanResult:
     """Run *scanner*'s CLI in a tempdir and return a :class:`ScanResult`.
 
@@ -115,6 +116,15 @@ def run_subprocess_scan(
             (e.g. ``"results.sarif"``).
         timeout: Optional subprocess timeout in seconds. Default: no
             timeout (most scanners self-cap).
+        cwd: Optional working directory for the subprocess. Default
+            ``None`` runs in argus's own CWD (correct for tools that take
+            an explicit path argument, like bandit/gosec). Tools that
+            analyse *the current module/package* and resolve relative
+            patterns against the working directory (e.g. ``govulncheck
+            ./...``) must set this to the scan target so the relative
+            pattern resolves there rather than against argus's CWD. The
+            container path achieves the same effect via the image's
+            ``WORKDIR /workspace``.
 
     Returns:
         A :class:`ScanResult` with ``findings`` populated on success or
@@ -149,6 +159,7 @@ def run_subprocess_scan(
                 timeout=timeout,
                 encoding="utf-8",
                 errors="replace",
+                cwd=cwd,
             )
         except FileNotFoundError as exc:
             return ScanResult(

--- a/argus/scanners/__init__.py
+++ b/argus/scanners/__init__.py
@@ -6,6 +6,7 @@ from .clamav import ClamavScanner
 from .container import ContainerScanner
 from .gitleaks import GitleaksScanner
 from .gosec import GosecScanner
+from .govulncheck import GovulncheckScanner
 from .grype import GrypeScanner
 from .kics import KICSScanner
 from .mumps import MumpsScanner
@@ -25,6 +26,7 @@ __all__ = [
     "ContainerScanner",
     "GitleaksScanner",
     "GosecScanner",
+    "GovulncheckScanner",
     "GrypeScanner",
     "KICSScanner",
     "MumpsScanner",
@@ -45,6 +47,7 @@ __all__ = [
 SCANNER_REGISTRY = {
     "bandit": BanditScanner,
     "gosec": GosecScanner,
+    "govulncheck": GovulncheckScanner,
     "clamav": ClamavScanner,
     "trivy": TrivyScanner,
     "trivy-iac": TrivyIacScanner,

--- a/argus/scanners/govulncheck.py
+++ b/argus/scanners/govulncheck.py
@@ -40,7 +40,7 @@ import json
 import shutil
 from pathlib import Path
 
-from argus.containers import get_image
+from argus.containers import published_image
 from argus.core.models import Finding, ScanResult, Severity
 from argus.core.scanner_template import ScanPaths, run_subprocess_scan
 from argus.core.version import parse_tool_version
@@ -56,7 +56,13 @@ class GovulncheckScanner:
     )
     category = "sca"
     languages = ["go"]
-    container_image = get_image("govulncheck")
+    # ``published_image`` returns "" while the custom image is a pre-publish
+    # placeholder (all-zeros digest in CUSTOM_IMAGES), so ``auto`` runs the
+    # local ``govulncheck`` binary instead of trying to pull an image that
+    # doesn't exist yet. Once the release pipeline writes the real digest,
+    # this resolves to the image and the container path activates — no code
+    # change needed. See argus.containers.published_image.
+    container_image = published_image("govulncheck")
     # The custom argus image declares ENTRYPOINT ["govulncheck"]; the
     # engine drops argv[0] for ENTRYPOINT-based images.
     container_entrypoint = "govulncheck"

--- a/argus/scanners/govulncheck.py
+++ b/argus/scanners/govulncheck.py
@@ -1,0 +1,287 @@
+"""govulncheck — reachability-aware Go vulnerability scanner.
+
+Where grype/trivy (container scanner) and osv-scanner report *every*
+known vulnerability in *every* dependency present in a Go module's graph,
+``govulncheck`` builds the program call graph from source and reports a
+vulnerability **only when the vulnerable symbol is actually reachable**
+from the code being scanned. That reachability filter is the whole point:
+it removes the large class of "the vulnerable package is in go.mod but the
+affected function is never called" false positives that presence-based
+scanners surface (and that maintainers, rightly, find annoying).
+
+Two finding tiers come out of a govulncheck run:
+
+* **Called / reachable** — govulncheck found a call path to the
+  vulnerable symbol. These are the actionable findings; they keep their
+  real (OSV-derived) severity.
+* **Imported, not called** — the vulnerable module/package is in the
+  build graph but no call to the affected symbol was found. These are
+  emitted as ``INFO`` with ``metadata["reachable"] = False`` so they
+  stay visible for audit without tripping severity gates. (They never
+  reach a severity threshold, so they can't fail a build — they're
+  transparency, not noise.)
+
+govulncheck emits a **stream of concatenated JSON objects** (not a single
+document) on stdout — ``config``, ``progress``, ``osv`` (the vulnerability
+records) and ``finding`` (per-vuln traces) messages. We decode the stream
+with a raw JSON decoder loop, correlate each ``finding`` back to its
+``osv`` record by id, and collapse the per-level findings for one vuln
+into a single Finding.
+
+Source mode (``govulncheck ./...``) is what gives symbol-level
+reachability, and it resolves the ``./...`` pattern against the *current
+working directory*. Locally we set ``cwd`` to the scan path; in the
+container the image's ``WORKDIR /workspace`` provides the same anchor.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+from argus.containers import get_image
+from argus.core.models import Finding, ScanResult, Severity
+from argus.core.scanner_template import ScanPaths, run_subprocess_scan
+from argus.core.version import parse_tool_version
+
+
+class GovulncheckScanner:
+    """Wraps govulncheck to scan Go modules for *reachable* vulnerabilities."""
+
+    name = "govulncheck"
+    description = (
+        "Reachability-aware Go vulnerability scanner — reports vulns whose "
+        "affected symbol is actually called (cuts presence-based false positives)"
+    )
+    category = "sca"
+    languages = ["go"]
+    container_image = get_image("govulncheck")
+    # The custom argus image declares ENTRYPOINT ["govulncheck"]; the
+    # engine drops argv[0] for ENTRYPOINT-based images.
+    container_entrypoint = "govulncheck"
+
+    def scan(self, path: str, config: dict | None = None) -> ScanResult:
+        """Run govulncheck against the Go module at *path*.
+
+        ``cwd=path`` is essential: ``govulncheck ./...`` resolves the
+        package pattern against the working directory, so the scan must
+        run *inside* the target module rather than in argus's own CWD.
+        The container path gets the same anchor from ``WORKDIR /workspace``
+        baked into the image, so ``build_args`` can emit the same relative
+        pattern for both execution modes.
+        """
+        return run_subprocess_scan(self, path, config, cwd=path)
+
+    def build_args(self, paths: ScanPaths, config: dict) -> list[str]:
+        """Build the full argv (including the binary name).
+
+        govulncheck has no ``-o``/output-file flag — it streams JSON to
+        stdout, which both the subprocess template and the engine's
+        container path capture into the results file. The package pattern
+        is relative (``./...``) so it resolves against the working
+        directory (local ``cwd`` / container ``WORKDIR /workspace``)
+        instead of an absolute mount path that govulncheck's package
+        loader wouldn't accept.
+        """
+        # ``scan_target`` lets a caller narrow to a sub-package
+        # (e.g. ``./cmd/...``); default is the whole module.
+        scan_target = config.get("scan_target") or "./..."
+        return ["govulncheck", "-json", scan_target]
+
+    def is_available(self) -> bool:
+        """Check if govulncheck is installed locally."""
+        return shutil.which("govulncheck") is not None
+
+    def install_command(self) -> str | None:
+        """Return the install command for govulncheck."""
+        return "go install golang.org/x/vuln/cmd/govulncheck@latest"
+
+    def tool_version(self) -> str | None:
+        """Return the installed govulncheck version, or None if unavailable.
+
+        ``govulncheck -version`` prints multiple lines; the one we want
+        looks like ``Scanner: govulncheck@v1.1.4``.
+        """
+        if not self.is_available():
+            return None
+        return parse_tool_version(
+            ["govulncheck", "-version"], r"govulncheck@v?(\S+)",
+        )
+
+    # ------------------------------------------------------------------
+    # Parsing
+    # ------------------------------------------------------------------
+
+    def parse_results(self, raw_output_path: Path) -> list[Finding]:
+        """Parse govulncheck's JSON-stream output into findings.
+
+        The output is a sequence of concatenated JSON objects, so a single
+        ``json.loads`` won't work — we decode them one at a time. Then we
+        correlate ``finding`` messages with their ``osv`` records and emit
+        one Finding per vulnerability, tagged with whether the vulnerable
+        symbol was actually reachable.
+        """
+        text = raw_output_path.read_text(encoding="utf-8", errors="replace")
+        osv_entries: dict[str, dict] = {}
+        findings_by_osv: dict[str, list[dict]] = {}
+
+        for msg in self._iter_json_stream(text):
+            if "osv" in msg and isinstance(msg["osv"], dict):
+                entry = msg["osv"]
+                osv_id = entry.get("id")
+                if osv_id:
+                    osv_entries[osv_id] = entry
+            elif "finding" in msg and isinstance(msg["finding"], dict):
+                finding = msg["finding"]
+                osv_id = finding.get("osv")
+                if osv_id:
+                    findings_by_osv.setdefault(osv_id, []).append(finding)
+
+        results: list[Finding] = []
+        for osv_id, group in findings_by_osv.items():
+            reachable = any(self._is_reachable(f) for f in group)
+            entry = osv_entries.get(osv_id, {})
+            results.append(
+                self._build_finding(osv_id, group, entry, reachable)
+            )
+        return results
+
+    @staticmethod
+    def _iter_json_stream(text: str):
+        """Yield each JSON object from a stream of concatenated objects.
+
+        govulncheck pretty-prints each message and concatenates them, so
+        we use a raw decoder and advance past the whitespace between
+        objects. A malformed/truncated stream raises ``JSONDecodeError``,
+        which the template surfaces as ``parse_failed`` (a distinct state
+        from "ran clean") rather than silently dropping findings.
+        """
+        decoder = json.JSONDecoder()
+        idx = 0
+        length = len(text)
+        while idx < length:
+            # Skip inter-object whitespace.
+            while idx < length and text[idx] in " \t\r\n":
+                idx += 1
+            if idx >= length:
+                break
+            obj, end = decoder.raw_decode(text, idx)
+            idx = end
+            if isinstance(obj, dict):
+                yield obj
+
+    @staticmethod
+    def _is_reachable(finding: dict) -> bool:
+        """True when the vulnerable symbol is actually called.
+
+        govulncheck's ``trace`` is ordered from the vulnerable symbol
+        (index 0) outward to the entry point. A trace whose innermost
+        frame names a ``function`` means govulncheck found a call path to
+        the affected symbol — the finding is reachable. Module/package-only
+        traces (no ``function``) mean the dependency is present but the
+        affected code isn't called.
+        """
+        trace = finding.get("trace") or []
+        return bool(trace and isinstance(trace[0], dict) and trace[0].get("function"))
+
+    def _build_finding(
+        self, osv_id: str, group: list[dict], entry: dict, reachable: bool,
+    ) -> Finding:
+        """Construct a single Finding for one vulnerability id."""
+        # Prefer a reachable finding for the representative trace so the
+        # call-site metadata reflects the actual call path.
+        rep = next(
+            (f for f in group if self._is_reachable(f)), group[0],
+        )
+        trace = rep.get("trace") or []
+        vuln_frame = trace[0] if trace and isinstance(trace[0], dict) else {}
+
+        package = vuln_frame.get("package") or vuln_frame.get("module") or ""
+        module = vuln_frame.get("module") or ""
+        pkg_version = vuln_frame.get("version") or ""
+        location = f"{package}@{pkg_version}" if package else None
+
+        summary = entry.get("summary") or entry.get("details") or osv_id
+        if reachable:
+            severity = self._extract_severity(entry)
+            title = summary
+        else:
+            # Present but not called — keep it visible but un-gated.
+            severity = Severity.INFO
+            title = f"[imported, not called] {summary}"
+
+        return Finding(
+            id=osv_id,
+            severity=severity,
+            title=title,
+            description=entry.get("details") or summary,
+            location=location,
+            cve=self._extract_cve(entry),
+            scanner=self.name,
+            metadata={
+                "tool": "govulncheck",
+                "reachable": reachable,
+                "module": module,
+                "package": package,
+                "installed_version": pkg_version,
+                "fixed_version": rep.get("fixed_version", ""),
+                "vulnerable_symbol": self._symbol_name(vuln_frame),
+                "aliases": entry.get("aliases", []),
+                "call_stack": self._call_stack(trace) if reachable else [],
+                "details_url": f"https://pkg.go.dev/vuln/{osv_id}",
+            },
+        )
+
+    @staticmethod
+    def _symbol_name(frame: dict) -> str:
+        """Render ``receiver.function`` (or ``function``) for a trace frame."""
+        func = frame.get("function") or ""
+        recv = frame.get("receiver") or ""
+        if func and recv:
+            return f"{recv}.{func}"
+        return func
+
+    @classmethod
+    def _call_stack(cls, trace: list) -> list[str]:
+        """Compact, human-readable call stack for reachable findings.
+
+        Ordered entry-point → vulnerable symbol (we reverse govulncheck's
+        innermost-first ordering) so it reads like a stack trace.
+        """
+        frames = []
+        for frame in reversed(trace):
+            if not isinstance(frame, dict):
+                continue
+            sym = cls._symbol_name(frame)
+            pkg = frame.get("package") or frame.get("module") or ""
+            label = f"{pkg}.{sym}" if (pkg and sym) else (sym or pkg)
+            pos = frame.get("position")
+            if isinstance(pos, dict) and pos.get("filename"):
+                label += f" ({pos['filename']}:{pos.get('line', 0)})"
+            if label:
+                frames.append(label)
+        return frames
+
+    @staticmethod
+    def _extract_severity(entry: dict) -> Severity:
+        """Map an OSV record's severity to the argus scale.
+
+        Go advisory (``GO-YYYY-NNNN``) OSV entries frequently carry no
+        machine-readable severity, in which case this returns
+        ``UNKNOWN`` — that's a known limitation of the Go vuln DB, not a
+        parse bug. When present, ``database_specific.severity`` is the
+        most reliable field.
+        """
+        ds = entry.get("database_specific")
+        if isinstance(ds, dict) and ds.get("severity"):
+            return Severity.from_string(str(ds["severity"]))
+        return Severity.UNKNOWN
+
+    @staticmethod
+    def _extract_cve(entry: dict) -> str | None:
+        """Return the first ``CVE-*`` alias from the OSV record, if any."""
+        for alias in entry.get("aliases") or []:
+            if isinstance(alias, str) and alias.startswith("CVE-"):
+                return alias
+        return None

--- a/argus/tests/scanners/test_govulncheck.py
+++ b/argus/tests/scanners/test_govulncheck.py
@@ -163,6 +163,21 @@ class TestGovulncheckScannerMeta:
         scanner = get_scanner("govulncheck")
         assert isinstance(scanner, GovulncheckScanner)
 
+    def test_container_image_reflects_publish_state(self):
+        """Until the custom image is published its CUSTOM_IMAGES entry pins the
+        all-zeros placeholder digest, and the scanner must advertise NO image so
+        ``auto`` runs the local binary instead of pulling a digest that doesn't
+        exist. Once the release pipeline writes the real digest, the scanner
+        exposes it and the container path activates. This invariant holds in
+        both states, so it doesn't break on publish."""
+        from argus.containers import get_image, is_placeholder_image
+
+        raw = get_image("govulncheck")
+        if is_placeholder_image(raw):
+            assert GovulncheckScanner.container_image == ""
+        else:
+            assert GovulncheckScanner.container_image == raw
+
     def test_build_args_default_scans_whole_module(self):
         scanner = GovulncheckScanner()
         paths = ScanPaths(workspace="/workspace", output="/output/results.json")

--- a/argus/tests/scanners/test_govulncheck.py
+++ b/argus/tests/scanners/test_govulncheck.py
@@ -1,0 +1,211 @@
+"""Tests for argus.scanners.govulncheck — GovulncheckScanner.
+
+govulncheck is the reachability-aware Go scanner: its whole value is
+distinguishing vulnerabilities whose affected symbol is *actually called*
+from ones merely *present* in the dependency graph. These tests pin that
+behavior (the reachability tier), the JSON-stream parsing (govulncheck
+emits concatenated objects, not one document), and the standard scanner
+metadata/build_args contract.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from argus.core.models import Severity
+from argus.core.scanner_template import ScanPaths
+from argus.scanners.govulncheck import GovulncheckScanner
+
+
+class TestGovulncheckParseResults:
+    """parse_results over the streamed-JSON fixture."""
+
+    def test_parse_results_with_findings(self, fixtures_dir):
+        scanner = GovulncheckScanner()
+        path = fixtures_dir / "govulncheck" / "results-with-findings.json"
+        findings = scanner.parse_results(path)
+
+        # One finding per vulnerability id (per-level findings collapsed).
+        assert len(findings) == 3
+        by_id = {f.id: f for f in findings}
+        assert set(by_id) == {"GO-2024-0001", "GO-2024-0002", "GO-2023-0003"}
+
+    def test_parse_results_zero_findings(self, fixtures_dir):
+        # config + progress messages only, no osv/finding → empty list,
+        # NOT a parse error (the stream is well-formed, just vuln-free).
+        scanner = GovulncheckScanner()
+        path = fixtures_dir / "govulncheck" / "results-zero-findings.json"
+        findings = scanner.parse_results(path)
+        assert findings == []
+
+    def test_reachable_finding_keeps_real_severity(self, fixtures_dir):
+        scanner = GovulncheckScanner()
+        path = fixtures_dir / "govulncheck" / "results-with-findings.json"
+        by_id = {f.id: f for f in scanner.parse_results(path)}
+
+        called = by_id["GO-2024-0001"]
+        assert called.metadata["reachable"] is True
+        assert called.severity == Severity.HIGH  # from database_specific.severity
+        assert called.cve == "CVE-2024-1111"
+        assert called.metadata["fixed_version"] == "v0.23.0"
+        assert called.metadata["package"] == "golang.org/x/net/http2"
+        # The vulnerable symbol and a reconstructed call stack are captured.
+        assert called.metadata["vulnerable_symbol"] == "Server.ServeConn"
+        assert called.metadata["call_stack"], "reachable finding should have a call stack"
+        # Stack reads entry-point → vulnerable symbol.
+        assert "main" in called.metadata["call_stack"][0]
+        assert "ServeConn" in called.metadata["call_stack"][-1]
+
+    def test_reachable_finding_without_db_severity_is_unknown(self, fixtures_dir):
+        # Go advisories frequently lack a machine-readable severity; the
+        # scanner must surface UNKNOWN rather than guessing.
+        scanner = GovulncheckScanner()
+        path = fixtures_dir / "govulncheck" / "results-with-findings.json"
+        by_id = {f.id: f for f in scanner.parse_results(path)}
+
+        called = by_id["GO-2024-0002"]
+        assert called.metadata["reachable"] is True
+        assert called.severity == Severity.UNKNOWN
+
+    def test_imported_not_called_is_info_and_flagged(self, fixtures_dir):
+        # The whole point: a present-but-unreachable vuln must NOT gate.
+        scanner = GovulncheckScanner()
+        path = fixtures_dir / "govulncheck" / "results-with-findings.json"
+        by_id = {f.id: f for f in scanner.parse_results(path)}
+
+        dormant = by_id["GO-2023-0003"]
+        assert dormant.metadata["reachable"] is False
+        assert dormant.severity == Severity.INFO
+        assert "[imported, not called]" in dormant.title
+        # No call stack for an unreachable finding.
+        assert dormant.metadata["call_stack"] == []
+
+    def test_finding_fields(self, fixtures_dir):
+        scanner = GovulncheckScanner()
+        path = fixtures_dir / "govulncheck" / "results-with-findings.json"
+        by_id = {f.id: f for f in scanner.parse_results(path)}
+
+        f = by_id["GO-2024-0001"]
+        assert f.scanner == "govulncheck"
+        assert f.metadata["tool"] == "govulncheck"
+        assert f.location == "golang.org/x/net/http2@v0.21.0"
+        assert f.metadata["details_url"] == "https://pkg.go.dev/vuln/GO-2024-0001"
+        assert "CVE-2024-1111" in f.metadata["aliases"]
+
+    def test_malformed_stream_raises_for_engine_to_catch(self, tmp_path):
+        # A truncated / non-JSON stream must raise (template surfaces it as
+        # parse_failed) rather than silently returning [] — otherwise a
+        # broken run reads as "clean, 0 vulns".
+        bad = tmp_path / "govulncheck.json"
+        bad.write_text('{"config": {"scanner_name": "govulncheck"}} {not json')
+        with pytest.raises(json.JSONDecodeError):
+            GovulncheckScanner().parse_results(bad)
+
+    def test_empty_output_returns_empty_list(self, tmp_path):
+        empty = tmp_path / "govulncheck.json"
+        empty.write_text("")
+        assert GovulncheckScanner().parse_results(empty) == []
+
+
+class TestGovulncheckScannerMeta:
+    """Scanner metadata + build_args contract."""
+
+    def test_name(self):
+        assert GovulncheckScanner().name == "govulncheck"
+
+    def test_category_is_sca(self):
+        assert GovulncheckScanner().category == "sca"
+
+    def test_languages(self):
+        assert GovulncheckScanner().languages == ["go"]
+
+    def test_install_command(self):
+        cmd = GovulncheckScanner().install_command()
+        assert cmd is not None
+        assert "govulncheck" in cmd
+
+    def test_is_available_true_when_on_path(self, monkeypatch):
+        import argus.scanners.govulncheck as mod
+        monkeypatch.setattr(
+            mod.shutil, "which",
+            lambda name: "/usr/local/bin/govulncheck" if name == "govulncheck" else None,
+        )
+        assert GovulncheckScanner().is_available() is True
+
+    def test_is_available_false_when_absent(self, monkeypatch):
+        import argus.scanners.govulncheck as mod
+        monkeypatch.setattr(mod.shutil, "which", lambda name: None)
+        assert GovulncheckScanner().is_available() is False
+
+    def test_tool_version_none_when_unavailable(self, monkeypatch):
+        import argus.scanners.govulncheck as mod
+        monkeypatch.setattr(mod.shutil, "which", lambda name: None)
+        assert GovulncheckScanner().tool_version() is None
+
+    def test_tool_version_parses_scanner_line(self, monkeypatch):
+        import argus.scanners.govulncheck as mod
+        monkeypatch.setattr(
+            mod.shutil, "which", lambda name: "/usr/local/bin/govulncheck",
+        )
+        # govulncheck -version prints several lines; the version lives on
+        # the "Scanner: govulncheck@vX.Y.Z" line.
+        monkeypatch.setattr(
+            mod, "parse_tool_version",
+            lambda cmd, pattern: "1.1.4",
+        )
+        assert GovulncheckScanner().tool_version() == "1.1.4"
+
+    def test_registered_in_registry(self):
+        from argus.scanners import get_scanner
+
+        scanner = get_scanner("govulncheck")
+        assert isinstance(scanner, GovulncheckScanner)
+
+    def test_build_args_default_scans_whole_module(self):
+        scanner = GovulncheckScanner()
+        paths = ScanPaths(workspace="/workspace", output="/output/results.json")
+        args = scanner.build_args(paths, {})
+        assert args == ["govulncheck", "-json", "./..."]
+
+    def test_build_args_respects_scan_target(self):
+        scanner = GovulncheckScanner()
+        paths = ScanPaths(workspace="/workspace", output="/output/results.json")
+        args = scanner.build_args(paths, {"scan_target": "./cmd/..."})
+        assert args == ["govulncheck", "-json", "./cmd/..."]
+
+    def test_build_args_uses_relative_pattern_not_workspace_path(self):
+        # govulncheck resolves ``./...`` against the working directory
+        # (cwd=path locally, WORKDIR /workspace in the container). It must
+        # NOT receive an absolute mount path — its package loader rejects
+        # those. Regression guard against "helpfully" prefixing the
+        # workspace like the path-argument scanners (bandit/gosec) do.
+        scanner = GovulncheckScanner()
+        paths = ScanPaths(workspace="/workspace", output="/output/results.json")
+        args = scanner.build_args(paths, {})
+        assert "/workspace" not in args
+        assert "/workspace/..." not in args
+
+
+class TestGovulncheckScanWiring:
+    """scan() must run the tool inside the target module (cwd=path)."""
+
+    def test_scan_passes_cwd_to_template(self, monkeypatch, tmp_path):
+        import argus.scanners.govulncheck as mod
+
+        captured = {}
+
+        def fake_run(scanner, path, config, *, cwd=None, **kwargs):
+            captured["path"] = path
+            captured["cwd"] = cwd
+            from argus.core.models import ScanResult
+            return ScanResult(scanner=scanner.name)
+
+        monkeypatch.setattr(mod, "run_subprocess_scan", fake_run)
+        GovulncheckScanner().scan(str(tmp_path), {})
+
+        # cwd must equal the scan path so ``govulncheck ./...`` resolves
+        # against the module being scanned, not argus's CWD.
+        assert captured["cwd"] == str(tmp_path)
+        assert captured["path"] == str(tmp_path)

--- a/argus/tests/test_containers.py
+++ b/argus/tests/test_containers.py
@@ -6,9 +6,13 @@ from argus.containers import (
     CACHE_MOUNTS,
     CUSTOM_IMAGES,
     OFFICIAL_IMAGES,
+    PLACEHOLDER_DIGEST,
     _default_cache_root,
     get_cache_mount,
+    get_expected_version,
     get_image,
+    is_placeholder_image,
+    published_image,
 )
 
 
@@ -154,6 +158,38 @@ class TestScannerContainerImages:
             assert isinstance(args, list), (
                 f"{name} container args method should return list"
             )
+
+
+class TestPlaceholderImages:
+    """Pre-publish placeholder sentinel: a CUSTOM_IMAGES entry pinned to the
+    all-zeros digest is 'not published yet' — consumers fall back to the local
+    tool and CI manifest/smoke checks skip it. Tests use a synthetic entry so
+    they don't couple to any real scanner's current publish state."""
+
+    _FAKE = "_placeholder_test_scanner"
+    _PLACEHOLDER_IMAGE = f"ghcr.io/huntridge-labs/argus/scanner-x:1.0.0@{PLACEHOLDER_DIGEST}"
+
+    def test_is_placeholder_detects_zero_digest(self):
+        assert is_placeholder_image(self._PLACEHOLDER_IMAGE)
+
+    def test_is_placeholder_false_for_real_digest(self):
+        assert not is_placeholder_image(CUSTOM_IMAGES["bandit"])
+
+    def test_is_placeholder_false_for_empty(self):
+        assert not is_placeholder_image("")
+
+    def test_published_image_blanks_placeholder(self, monkeypatch):
+        monkeypatch.setitem(CUSTOM_IMAGES, self._FAKE, self._PLACEHOLDER_IMAGE)
+        assert published_image(self._FAKE) == ""
+
+    def test_published_image_passes_through_real(self):
+        assert published_image("bandit") == CUSTOM_IMAGES["bandit"]
+
+    def test_expected_version_none_for_placeholder(self, monkeypatch):
+        # Even though the tag ('1.0.0') parses fine, an unpublished image has no
+        # real tool version to verify a local install against.
+        monkeypatch.setitem(CUSTOM_IMAGES, self._FAKE, self._PLACEHOLDER_IMAGE)
+        assert get_expected_version(self._FAKE) is None
 
 
 class TestCacheMounts:

--- a/docker/Dockerfile.govulncheck
+++ b/docker/Dockerfile.govulncheck
@@ -14,11 +14,11 @@
 #     only) but sets no -w, so the relative ``./...`` pattern govulncheck
 #     receives must resolve here. This mirrors the local path's cwd=path.
 
-# NOTE: tag-only base ref. Renovate pins this to a ``@sha256:...`` digest
-# on first ingestion (same policy as every image in argus/containers.py);
-# left un-pinned here only because the digest must be resolved against the
-# registry at build time, which the release pipeline does.
-FROM golang:1.23-alpine AS base
+# Base pinned to an immutable digest, same policy as every other argus
+# Dockerfile (Dependabot maintains the FROM pins repo-wide). The golang
+# image provides the toolchain govulncheck source mode needs to type-check
+# and build the target packages when computing reachability.
+FROM golang:1.23-alpine@sha256:383395b794dffa5b53012a212365d40c8e37109a626ca30d6151c8348d380b5f AS base
 
 LABEL org.opencontainers.image.source="https://github.com/huntridge-labs/argus"
 LABEL org.opencontainers.image.description="Argus govulncheck reachability-aware Go vulnerability scanner"

--- a/docker/Dockerfile.govulncheck
+++ b/docker/Dockerfile.govulncheck
@@ -18,7 +18,7 @@
 # Dockerfile (Dependabot maintains the FROM pins repo-wide). The golang
 # image provides the toolchain govulncheck source mode needs to type-check
 # and build the target packages when computing reachability.
-FROM golang:1.23-alpine@sha256:383395b794dffa5b53012a212365d40c8e37109a626ca30d6151c8348d380b5f AS base
+FROM golang:1.25-alpine@sha256:56961d79ea8129efddcc0b8643fd8a5416b4e6228cfd477e3fd61deb2672c587 AS base
 
 LABEL org.opencontainers.image.source="https://github.com/huntridge-labs/argus"
 LABEL org.opencontainers.image.description="Argus govulncheck reachability-aware Go vulnerability scanner"

--- a/docker/Dockerfile.govulncheck
+++ b/docker/Dockerfile.govulncheck
@@ -1,0 +1,53 @@
+# Argus govulncheck scanner image.
+#
+# There is no official govulncheck image — upstream distributes it via
+# ``go install golang.org/x/vuln/cmd/govulncheck`` — so argus builds its
+# own from a pinned golang base. The image is a thin wrapper: the Go
+# toolchain (govulncheck source mode type-checks and builds the target
+# packages to compute reachability) plus the pinned govulncheck binary.
+#
+# Two image contracts the SDK depends on:
+#   * ENTRYPOINT ["govulncheck"] — the engine drops argv[0] for
+#     ENTRYPOINT-based images, so GovulncheckScanner.build_args' leading
+#     "govulncheck" is stripped and the flags/pattern follow.
+#   * WORKDIR /workspace — the engine mounts the repo at /workspace (read
+#     only) but sets no -w, so the relative ``./...`` pattern govulncheck
+#     receives must resolve here. This mirrors the local path's cwd=path.
+
+# NOTE: tag-only base ref. Renovate pins this to a ``@sha256:...`` digest
+# on first ingestion (same policy as every image in argus/containers.py);
+# left un-pinned here only because the digest must be resolved against the
+# registry at build time, which the release pipeline does.
+FROM golang:1.23-alpine AS base
+
+LABEL org.opencontainers.image.source="https://github.com/huntridge-labs/argus"
+LABEL org.opencontainers.image.description="Argus govulncheck reachability-aware Go vulnerability scanner"
+LABEL org.opencontainers.image.licenses="AGPL-3.0"
+
+# Patch OS-level vulnerabilities before anything else.
+RUN apk upgrade --no-cache && apk add --no-cache git
+
+# Pin the govulncheck version; Renovate/release-it bump this in lockstep
+# with the image tag.
+ARG GOVULNCHECK_VERSION=v1.1.4
+
+# Install govulncheck onto PATH so the ENTRYPOINT resolves it.
+RUN GOBIN=/usr/local/bin go install "golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}"
+
+# The workspace mount is read-only and the container runs unprivileged,
+# so point every writable Go path at /tmp (mode 1777). Without this,
+# source-mode analysis (which invokes the go toolchain to build the
+# target packages) fails trying to write the build/module cache.
+ENV HOME=/tmp \
+    GOPATH=/tmp/go \
+    GOCACHE=/tmp/.cache/go-build \
+    GOMODCACHE=/tmp/go/pkg/mod \
+    GOTMPDIR=/tmp \
+    GOFLAGS=-mod=mod \
+    GOTOOLCHAIN=auto
+
+RUN adduser -D -u 1000 argus
+USER argus
+
+WORKDIR /workspace
+ENTRYPOINT ["govulncheck"]

--- a/docs/scanners.md
+++ b/docs/scanners.md
@@ -57,6 +57,8 @@ See [examples/github-enterprise/](../examples/github-enterprise/) for GHES templ
   - [gosec](#gosec)
   - [OpenGrep (Semgrep)](#opengrep-semgrep)
   - [MUMPS / M language](#mumps--m-language-mumps)
+- [Dependency Scanners](#dependency-scanners)
+  - [govulncheck (Go)](#govulncheck-go)
 - [Container Scanners](#container-scanners)
   - [Trivy Container](#trivy-container)
   - [Grype](#grype)
@@ -387,6 +389,56 @@ reporters:
 > **Secret redaction:** for the M004 (hard-coded credentials) rule, the matched literal value is replaced with the redaction placeholder before the finding is constructed. Defense-in-depth: `Finding.__post_init__` runs the pattern-based redactor as a second pass. The literal never reaches any reporter, export, or the MCP server. Integration test `test_literal_value_is_redacted` enforces this contract.
 
 > **Taint scope:** Phase 1 taint *detection* is intra-file. Recognized taint sources are `READ` (terminal input), `$ZARGV` (YottaDB / GT.M process arguments), and the HTTP context globals `^%CGI`, `^%REQUEST`, `^%session`. The collector is shared between M001 / M002 / M003 / M005 / M006 so every taint-sink rule sees the full source surface uniformly. The **inter-procedural call graph** is built on every multi-file scan (`argus/scanners/mumps/callgraph.py`); M001 findings carry an `inter_procedural_callers` metadata list naming the routines that reach the sink. **One-hop taint propagation** across that graph is available via `interprocedural.enabled` (opt-in): a tainted actual argument flows into the callee's formal parameter (recursion-safe monotone worklist, `max_depth`-capped). Deeper multi-hop propagation, return-value taint, and per-finding provenance remain on the roadmap.
+
+</details>
+
+## Dependency Scanners
+
+### govulncheck (Go)
+
+**Reachability-aware** Go vulnerability scanner. Where presence-based scanners (Grype, Trivy, OSV) flag every known vulnerability in every dependency in a module's graph, govulncheck builds the program **call graph from source** and reports a vulnerability only when the affected symbol is actually **reachable** from your code. This removes the large class of "the vulnerable package is in `go.mod` but the affected function is never called" false positives.
+
+**Supported languages:** `go` (requires a `go.mod` module and the Go toolchain)
+
+**Severity levels:** CRITICAL, HIGH, MEDIUM, LOW, INFO, UNKNOWN
+
+**Finding tiers:**
+
+| Tier | Meaning | Severity |
+|------|---------|----------|
+| Called / reachable | govulncheck found a call path to the vulnerable symbol | Real (OSV-derived) severity — gates on `fail_on_severity` |
+| Imported, not called | The vulnerable module/package is present but the affected symbol isn't called | `INFO` — visible for audit, never gates |
+
+Each finding carries `metadata.reachable` (`true`/`false`); reachable findings also carry `metadata.call_stack` (entry point → vulnerable symbol) and `metadata.vulnerable_symbol`.
+
+<details>
+<summary><strong>Configuration & Examples</strong></summary>
+
+**Configuration (composite action):**
+
+| Input | Description | Default | Required |
+|-------|-------------|---------|----------|
+| `scan_path` | Path to the Go module (directory with `go.mod`) | `.` | No |
+| `go_version` | Go version to set up | `stable` | No |
+| `govulncheck_version` | govulncheck version to install | `latest` | No |
+| `enable_code_security` | Upload SARIF to GitHub Security tab | `false` | No |
+| `post_pr_comment` | Post findings as PR comments | `false` | No |
+| `fail_on_severity` | Fail at/above this severity | `none` | No |
+
+**SDK config (`argus.yml`):**
+
+```yaml
+scanners:
+  - govulncheck
+scan_path: "."
+fail_on_severity: high
+```
+
+Optional per-scanner key: `scan_target` (a Go package pattern relative to the module root, default `./...`) to narrow the scan to a sub-package.
+
+> **Severity note:** Go advisories (`GO-YYYY-NNNN`) frequently carry no machine-readable severity. A reachable finding without one is reported as `UNKNOWN` (not guessed), so it won't trip `fail_on_severity: high`. Pair govulncheck with `osv` if you need CVSS-derived gating, and rely on govulncheck for the reachability signal.
+
+> **Relationship to other scanners:** `gosec` is Go SAST (code anti-patterns), not dependency CVEs. `osv` is presence-based dependency CVEs across many ecosystems (broad, no reachability). `govulncheck` is the lowest-false-positive Go dependency signal because it filters on reachability.
 
 </details>
 

--- a/scripts/ci/check_container_images.py
+++ b/scripts/ci/check_container_images.py
@@ -17,7 +17,7 @@ import sys
 
 
 def main() -> int:
-    from argus.containers import OFFICIAL_IMAGES, CUSTOM_IMAGES
+    from argus.containers import OFFICIAL_IMAGES, CUSTOM_IMAGES, is_placeholder_image
 
     if not shutil.which("docker"):
         print("docker not found — skipping image manifest check")
@@ -28,6 +28,13 @@ def main() -> int:
 
     failures = []
     for name, image in sorted(all_images.items()):
+        # A pre-publish placeholder (all-zeros digest) intentionally has no
+        # published manifest yet — the release pipeline builds it and rewrites
+        # the digest. Skip it rather than fail on a digest that can't resolve.
+        if is_placeholder_image(image):
+            print(f"  ⏭️  {name:<20} {image}")
+            print("     unpublished placeholder — skipped (release pipeline publishes it)")
+            continue
         result = subprocess.run(
             ["docker", "manifest", "inspect", image],
             capture_output=True, text=True, timeout=30,

--- a/tests/fixtures/scanner-outputs/govulncheck/results-with-findings.json
+++ b/tests/fixtures/scanner-outputs/govulncheck/results-with-findings.json
@@ -1,0 +1,109 @@
+{
+  "config": {
+    "protocol_version": "v1.0.0",
+    "scanner_name": "govulncheck",
+    "scanner_version": "v1.1.4",
+    "db": "https://vuln.go.dev",
+    "db_last_modified": "2024-09-01T00:00:00Z",
+    "go_version": "go1.22.0",
+    "scan_level": "symbol"
+  }
+}
+{
+  "progress": {
+    "message": "Scanning your code and 312 packages across 47 dependent modules for known vulnerabilities..."
+  }
+}
+{
+  "osv": {
+    "schema_version": "1.3.1",
+    "id": "GO-2024-0001",
+    "modified": "2024-05-01T00:00:00Z",
+    "published": "2024-05-01T00:00:00Z",
+    "aliases": ["CVE-2024-1111", "GHSA-aaaa-bbbb-cccc"],
+    "summary": "HTTP/2 rapid reset can cause excessive work in net/http",
+    "details": "An attacker can cause excessive resource consumption by rapidly resetting HTTP/2 streams.",
+    "affected": [
+      {
+        "package": {"name": "golang.org/x/net", "ecosystem": "Go"},
+        "ecosystem_specific": {"imports": [{"path": "golang.org/x/net/http2", "symbols": ["Server.ServeConn"]}]}
+      }
+    ],
+    "database_specific": {"url": "https://pkg.go.dev/vuln/GO-2024-0001", "severity": "HIGH"}
+  }
+}
+{
+  "osv": {
+    "schema_version": "1.3.1",
+    "id": "GO-2024-0002",
+    "modified": "2024-06-15T00:00:00Z",
+    "published": "2024-06-15T00:00:00Z",
+    "aliases": ["GHSA-dddd-eeee-ffff"],
+    "summary": "Improper input validation in example/parser",
+    "details": "Malformed input can trigger a panic in the parser.",
+    "affected": [
+      {
+        "package": {"name": "github.com/example/parser", "ecosystem": "Go"},
+        "ecosystem_specific": {"imports": [{"path": "github.com/example/parser", "symbols": ["Parse"]}]}
+      }
+    ],
+    "database_specific": {"url": "https://pkg.go.dev/vuln/GO-2024-0002"}
+  }
+}
+{
+  "osv": {
+    "schema_version": "1.3.1",
+    "id": "GO-2023-0003",
+    "modified": "2023-11-20T00:00:00Z",
+    "published": "2023-11-20T00:00:00Z",
+    "aliases": ["CVE-2023-2222"],
+    "summary": "Denial of service in dormant/crypto helper",
+    "details": "A function that this module exports is vulnerable, but your code does not appear to call it.",
+    "affected": [
+      {
+        "package": {"name": "github.com/dormant/crypto", "ecosystem": "Go"},
+        "ecosystem_specific": {"imports": [{"path": "github.com/dormant/crypto", "symbols": ["Decrypt"]}]}
+      }
+    ],
+    "database_specific": {"url": "https://pkg.go.dev/vuln/GO-2023-0003"}
+  }
+}
+{
+  "finding": {
+    "osv": "GO-2024-0001",
+    "fixed_version": "v0.23.0",
+    "trace": [
+      {"module": "golang.org/x/net", "version": "v0.21.0", "package": "golang.org/x/net/http2"}
+    ]
+  }
+}
+{
+  "finding": {
+    "osv": "GO-2024-0001",
+    "fixed_version": "v0.23.0",
+    "trace": [
+      {"module": "golang.org/x/net", "version": "v0.21.0", "package": "golang.org/x/net/http2", "function": "ServeConn", "receiver": "Server", "position": {"filename": "server.go", "line": 512, "column": 6}},
+      {"module": "example.com/myapp", "version": "", "package": "example.com/myapp/server", "function": "Serve", "position": {"filename": "server/serve.go", "line": 88, "column": 9}},
+      {"module": "example.com/myapp", "version": "", "package": "example.com/myapp", "function": "main", "position": {"filename": "main.go", "line": 31, "column": 2}}
+    ]
+  }
+}
+{
+  "finding": {
+    "osv": "GO-2024-0002",
+    "fixed_version": "v1.4.2",
+    "trace": [
+      {"module": "github.com/example/parser", "version": "v1.4.0", "package": "github.com/example/parser", "function": "Parse", "position": {"filename": "parser.go", "line": 140, "column": 3}},
+      {"module": "example.com/myapp", "version": "", "package": "example.com/myapp", "function": "loadConfig", "position": {"filename": "config.go", "line": 17, "column": 12}}
+    ]
+  }
+}
+{
+  "finding": {
+    "osv": "GO-2023-0003",
+    "fixed_version": "v2.1.0",
+    "trace": [
+      {"module": "github.com/dormant/crypto", "version": "v2.0.0", "package": "github.com/dormant/crypto"}
+    ]
+  }
+}

--- a/tests/fixtures/scanner-outputs/govulncheck/results-zero-findings.json
+++ b/tests/fixtures/scanner-outputs/govulncheck/results-zero-findings.json
@@ -1,0 +1,16 @@
+{
+  "config": {
+    "protocol_version": "v1.0.0",
+    "scanner_name": "govulncheck",
+    "scanner_version": "v1.1.4",
+    "db": "https://vuln.go.dev",
+    "db_last_modified": "2024-09-01T00:00:00Z",
+    "go_version": "go1.22.0",
+    "scan_level": "symbol"
+  }
+}
+{
+  "progress": {
+    "message": "Scanning your code and 88 packages across 12 dependent modules for known vulnerabilities..."
+  }
+}

--- a/tests/fixtures/test-apps/go-app/go.mod
+++ b/tests/fixtures/test-apps/go-app/go.mod
@@ -1,0 +1,12 @@
+module argus.test/govulncheck-fixture
+
+go 1.21
+
+// Pinned to a version with a KNOWN, REACHABLE advisory so the govulncheck
+// E2E test has a deterministic finding to assert on:
+//   GO-2022-1059 (CVE-2022-32149) — golang.org/x/text < 0.3.8, in
+//   golang.org/x/text/language. main.go calls language.ParseAcceptLanguage,
+//   which makes the vulnerable symbol reachable (not merely imported), so
+//   govulncheck reports it as a reachable/actionable finding rather than the
+//   INFO "[imported, not called]" tier. Do not bump this dependency.
+require golang.org/x/text v0.3.7

--- a/tests/fixtures/test-apps/go-app/go.sum
+++ b/tests/fixtures/test-apps/go-app/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=

--- a/tests/fixtures/test-apps/go-app/main.go
+++ b/tests/fixtures/test-apps/go-app/main.go
@@ -1,0 +1,24 @@
+// Package main is an intentionally-vulnerable Go fixture used only by the
+// scanner-govulncheck E2E test (.github/workflows/test-actions.yml).
+//
+// It calls golang.org/x/text/language.ParseAcceptLanguage from a pinned
+// vulnerable dependency (golang.org/x/text v0.3.7) so that GO-2022-1059 is
+// *reachable* — exercising govulncheck's call-graph analysis end to end, not
+// just its presence-based detection. See go.mod for the advisory details.
+package main
+
+import (
+	"fmt"
+
+	"golang.org/x/text/language"
+)
+
+func main() {
+	// ParseAcceptLanguage is the vulnerable symbol for GO-2022-1059.
+	tags, _, err := language.ParseAcceptLanguage("en-US,en;q=0.9,de;q=0.8")
+	if err != nil {
+		fmt.Println("parse error:", err)
+		return
+	}
+	fmt.Println("parsed language tags:", tags)
+}


### PR DESCRIPTION
## Why

A Go project (OPA) scan surfaced CVEs that turned out to be **false positives** — the vulnerable code paths weren't reachable. The upstream maintainer's guidance: *"in future, please consider using govulncheck to verify."*

Every vuln scanner Argus runs against Go today is **presence-based** — grype/trivy (container) and osv (lockfile) flag a CVE whenever the vulnerable *package* is in the dependency graph, regardless of whether the vulnerable *symbol* is ever called. `gosec` is Go SAST (code patterns), not dependency-CVE reachability. So Argus had no way to filter the "imported but never called" false-positive class.

`govulncheck` is Go's official scanner and is **reachability-aware**: it builds the program call graph from source and reports a vulnerability only when the affected symbol is actually reachable. This PR adds it as a first-class scanner so that verification is automated in the pipeline rather than a manual afterthought.

## What

**SDK scanner** — `argus/scanners/govulncheck.py` (`category=sca`, `languages=[go]`):
- Runs `govulncheck -json ./...` and parses govulncheck's **concatenated-JSON message stream** (it's not a single document), correlating each `finding` with its `osv` record and collapsing per-level findings into one Finding per vuln.
- **Two finding tiers:**
  - **Called / reachable** → real (OSV-derived) severity, gates on `fail_on_severity`. Carries the reconstructed call stack (`metadata.call_stack`) + `metadata.vulnerable_symbol`.
  - **Imported, not called** → `INFO`, `metadata.reachable: false`, titled `[imported, not called]`. Visible for audit, never gates — this is the false-positive class, surfaced transparently instead of as an actionable CVE.

**Composite action** — `.github/actions/scanner-govulncheck/` sets up Go, installs govulncheck (no official binary/image exists upstream — it ships via `go install`), and runs through the SDK like every other scanner.

**Image** — pinned `CUSTOM_IMAGES` entry + `docker/Dockerfile.govulncheck` (golang base + pinned govulncheck, `WORKDIR /workspace`, Go caches redirected to `/tmp` since `/workspace` mounts read-only). Per the agreed scope: **code-only — the release pipeline builds/publishes the image**, so the digest is a placeholder for now (zero sha256) and the comment says so; until first publish the scanner runs from a locally-installed `govulncheck` (the SDK prefers the local binary).

**Plumbing** — `run_subprocess_scan` gains an optional `cwd=` (govulncheck resolves `./...` against the working directory). `scan()` sets `cwd=path`; the container path gets the same anchor from the image's `WORKDIR /workspace` (the engine sets no `-w`). Backward-compatible: `cwd` defaults to `None`, unchanged for every other scanner.

## Design notes

- **Severity / UNKNOWN:** Go advisories (`GO-YYYY-NNNN`) frequently carry no CVSS, so a reachable finding may be `UNKNOWN` severity. That's a Go vuln-DB limitation, not a parse bug — documented, with the recommendation to pair govulncheck with `osv` when you need CVSS-derived gating. govulncheck's value here is the *reachability* signal.
- **Stdout, not a file:** govulncheck has no `-o` flag — it streams to stdout. Both the SDK template (`run_subprocess_scan`) and the engine's container path already capture stdout into the results file, and parsing is exit-code-independent (govulncheck exits 3 when it finds vulns), so both execution paths work without special-casing.
- **No dead config knob:** an early draft exposed a `report_unreachable` toggle, but `parse_results` receives only the output path in both the local and container paths (the engine calls it directly, bypassing `scan()`), so the flag couldn't work for container runs. Dropped it — unreachable findings are always emitted as `INFO` (transparent, never gating) rather than shipping a knob that works in one path and silently not the other.

## Tests

21 cases in `argus/tests/scanners/test_govulncheck.py` (reachability tiers, severity mapping incl. UNKNOWN, streamed-JSON parsing, malformed-stream → `parse_failed`, empty-stream → `[]`, `build_args` relative-pattern guard, `cwd` wiring, registry registration). New module at **99%** coverage. Fixtures are realistic govulncheck `-json` streams.

The architecture-sync CI check passes. The only red in the container/linter test files is a pre-existing Windows path-separator bug (`test_happy_path_extracts_files`, `test_workspace_is_resolved_to_absolute`) confirmed to fail on clean `main` and untouched by this change.

## Docs / AICaC

- `docs/scanners.md` — new **Dependency Scanners → govulncheck (Go)** section (tiers table, severity note, relationship to gosec/osv).
- `.github/actions/scanner-govulncheck/README.md` — action usage.
- `.ai/architecture.yaml` — scanner entry.
- `.ai/errors.yaml` — maps the "Go CVE false positive / code isn't used" symptom to the govulncheck remedy.
- `CLAUDE.md` — Dependencies row.

## Follow-up (out of scope here)

The custom image must be built + published and its digest pinned (release pipeline / Renovate), replacing the placeholder, before container-backed runs work without a local govulncheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
