### PR TITLE
fix(container): fail fast on unresolved registry_auth credentials

### DIFF
--- a/.ai/errors.yaml
+++ b/.ai/errors.yaml
@@ -242,6 +242,40 @@ error_patterns:
         glpat-, etc.) at config-load time so the leak is caught
         before the scan runs.
 
+  - pattern: "registry_auth\\[.*\\]: (username|password) unresolved|UNAUTHORIZED.*~90s into the scan"
+    category: container-scanning
+    context: |
+      A ``registry_auth`` entry (or the top-level
+      ``registry_username``/``registry_password`` shortcut) references a
+      credential via ``password_env``/``username_env`` whose environment
+      variable is unset or empty. Previously argus logged a WARNING to
+      ``argus.log`` only, then proceeded — the sub-scanner container ran
+      for 60–90s and failed with an opaque ``UNAUTHORIZED: authentication
+      required`` from grype/trivy, with nothing on stderr to explain why.
+
+    root_cause: |
+      ``_resolve_registry_auth`` resolves credentials and warns on an
+      unresolved one, but the warning went to the file logger and the
+      scan was never gated on it. The real failure surfaced much later,
+      one layer down, as an upstream-tool auth error unrelated to the
+      actual cause (the missing env var).
+
+    solution:
+      steps:
+        - "``scan_image`` now calls ``validate_registry_auth(config, image_ref)`` for remote pulls *before* any sub-scanner container starts."
+        - "A configured-but-unresolved credential raises ``RegistryAuthError`` naming the registry scope and the unset env var."
+        - "``ContainerEngine._process_target`` re-raises ``RegistryAuthError`` (it is NOT recorded as a per-target scan_error) so the run aborts fast."
+        - "The CLI surfaces the two-line message on stderr and exits non-zero."
+      note: |
+        Local images (built this run, or already present in the docker
+        daemon) skip the gate — they are scanned from the daemon source
+        and never touch a registry. Anonymous pulls (nothing configured)
+        and token-only auth (username intentionally omitted) are not
+        gated. The matched ``registry_auth`` entry is selected by the
+        same longest-path-prefix rule as resolution.
+
+    reference: "argus/container/scanner.py::validate_registry_auth / RegistryAuthError — issue #253"
+
   # ==============================================================================
   # PR COMMENT ERRORS
   # ==============================================================================

--- a/argus/cli.py
+++ b/argus/cli.py
@@ -2292,7 +2292,7 @@ def _cmd_container_scan(
     that path is kept for backward compatibility with any caller that
     still bypasses ``cmd_scan``.
     """
-    from argus.container import ContainerEngine
+    from argus.container import ContainerEngine, RegistryAuthError
     from argus.reporters.container_markdown import ContainerMarkdownReporter
 
     # Configure the ``argus`` logger at the user's chosen level —
@@ -2396,6 +2396,13 @@ def _cmd_container_scan(
                 progress_callback=_make_progress_emitter(args, spinner),
             )
             summary = engine.run()
+    except RegistryAuthError as exc:
+        # Misconfigured registry credentials: surface the two-line
+        # actionable message verbatim (it already names the registry
+        # and the unset env var) rather than wrapping it. (#253)
+        print(f"Error: {exc}", file=sys.stderr)
+        finalize_manifest(manifest, exit_code=EXIT_ERROR, output_dir=output_dir)
+        return EXIT_ERROR
     except Exception as exc:
         print(f"Error: container scan failed: {exc}", file=sys.stderr)
         finalize_manifest(manifest, exit_code=EXIT_ERROR, output_dir=output_dir)

--- a/argus/container/__init__.py
+++ b/argus/container/__init__.py
@@ -5,8 +5,10 @@ from .builder import build_image
 from .scanner import (
     ContainerScanResult,
     ContainerScanSummary,
+    RegistryAuthError,
     scan_image,
     deduplicate_findings,
+    validate_registry_auth,
 )
 from .engine import ContainerEngine
 
@@ -17,7 +19,9 @@ __all__ = [
     "build_image",
     "ContainerScanResult",
     "ContainerScanSummary",
+    "RegistryAuthError",
     "scan_image",
     "deduplicate_findings",
+    "validate_registry_auth",
     "ContainerEngine",
 ]

--- a/argus/container/engine.py
+++ b/argus/container/engine.py
@@ -22,7 +22,12 @@ from .resources import (
     prune_docker_build_cache,
     remove_docker_image,
 )
-from .scanner import ContainerScanResult, ContainerScanSummary, scan_image
+from .scanner import (
+    ContainerScanResult,
+    ContainerScanSummary,
+    RegistryAuthError,
+    scan_image,
+)
 
 logger = logging.getLogger("argus.container")
 
@@ -201,6 +206,12 @@ class ContainerEngine:
                 raw_output_dir=target_raw_dir,
                 config=self.config,
             )
+        except RegistryAuthError:
+            # Misconfigured registry credentials are a fast-fail config
+            # error, not a per-target scan failure to record and skip
+            # past. Propagate so the CLI surfaces it on stderr and the
+            # whole run aborts before more time is wasted. (#253)
+            raise
         except OSError as exc:
             # Disk full, permission denied, etc.
             logger.error(

--- a/argus/container/scanner.py
+++ b/argus/container/scanner.py
@@ -17,6 +17,19 @@ from .resources import get_image_digest, is_image_local
 logger = logging.getLogger("argus.container")
 
 
+class RegistryAuthError(Exception):
+    """A configured registry credential could not be resolved at scan time.
+
+    Raised *before* any scanner container starts so the user gets a
+    fast, actionable diagnostic — naming the unset env var and the
+    registry it belongs to — instead of an opaque ``UNAUTHORIZED:
+    authentication required`` from the upstream tool 60–90 s into the
+    scan. The message is two lines (what's wrong + how to fix) and is
+    surfaced on stderr by the CLI, not buried in ``argus.log``. See
+    issue #253.
+    """
+
+
 def _normalize_image_ref(ref: str) -> str:
     """Return the ``host/path`` portion of an image ref, stripping tag + digest.
 
@@ -149,6 +162,96 @@ def _resolve_registry_auth(
         )
 
     return username, password
+
+
+def _gate_credential(
+    scope: str, label: str, source: dict, field: str, value: str | None,
+) -> None:
+    """Raise ``RegistryAuthError`` if ``field`` is configured but unresolved.
+
+    A credential counts as *configured* when the source dict carries
+    either ``<field>_env`` (env-var indirection) or a literal
+    ``<field>``. If it resolved to a falsy value (env var unset or
+    empty, or an empty literal), the pull would fail later with an
+    opaque auth error — so we fail fast here instead.
+
+    A field that is not configured at all is left alone: anonymous
+    pulls, and token-only auth where the username is intentionally
+    omitted, are both valid and must not be gated.
+    """
+    if value:
+        return
+
+    env_field = f"{field}_env"
+    if env_field in source:
+        env_name = source.get(env_field)
+        raise RegistryAuthError(
+            f"{scope}: {label} unresolved — env var {env_name} is not set.\n"
+            f"Set it before running argus or update registry_auth in "
+            f"argus.yml to reference a variable that is exported."
+        )
+    if field in source:
+        raise RegistryAuthError(
+            f"{scope}: {label} unresolved — the configured value is empty.\n"
+            f"Set a non-empty {label} or remove it to pull anonymously."
+        )
+
+
+def validate_registry_auth(
+    config: dict | None, image_ref: str | None,
+) -> None:
+    """Fail fast when a configured registry credential cannot be resolved.
+
+    Intended to run once per target *before* any scanner container is
+    invoked. Mirrors the matching logic of :func:`_resolve_registry_auth`
+    — the longest ``registry_auth`` path-prefix wins, falling back to the
+    top-level ``registry_username`` / ``registry_password`` shortcut when
+    no map entry matches — then gates each credential the matched scope
+    actually declares.
+
+    Raises :class:`RegistryAuthError` naming the registry scope and the
+    unset env var. Returns ``None`` (no exception) for anonymous pulls,
+    where nothing is configured. See issue #253.
+    """
+    if not config:
+        return
+
+    auth_map = config.get("registry_auth") or {}
+
+    best_key: str | None = None
+    if image_ref is not None:
+        normalized = _normalize_image_ref(image_ref)
+        for key in auth_map:
+            if not isinstance(key, str):
+                continue
+            if _is_path_component_prefix(key, normalized):
+                if best_key is None or len(key) > len(best_key):
+                    best_key = key
+
+    if best_key is not None:
+        entry = auth_map[best_key]
+        if not isinstance(entry, dict):
+            # Malformed entry — _resolve_registry_auth already warns and
+            # skips it. That's a config-shape problem, not an unresolved
+            # credential, so it isn't this gate's concern.
+            return
+        username, password = _resolve_user_pass(
+            entry, user_field="username", pass_field="password",
+        )
+        scope = f"registry_auth[{best_key}]"
+        _gate_credential(scope, "username", entry, "username", username)
+        _gate_credential(scope, "password", entry, "password", password)
+        return
+
+    # No map entry matched → top-level single-default shortcut.
+    username, password = _resolve_user_pass(config)
+    scope = "registry credentials"
+    _gate_credential(
+        scope, "username", config, "registry_username", username,
+    )
+    _gate_credential(
+        scope, "password", config, "registry_password", password,
+    )
 
 
 def _registry_auth_env(
@@ -499,6 +602,15 @@ def scan_image(
             "copy via the docker-daemon source (not pulling from a registry)",
             target.image_ref,
         )
+
+    # Fail fast on misconfigured registry credentials *before* spinning
+    # up any scanner container. A configured-but-unresolved credential
+    # (e.g. ``password_env`` naming an unset variable) otherwise surfaces
+    # 60–90 s later as an opaque ``UNAUTHORIZED`` from trivy/grype.
+    # Skipped for local images — they're scanned from the docker daemon
+    # and never touch a registry, so registry auth is irrelevant. (#253)
+    if not is_local:
+        validate_registry_auth(cfg, target.image_ref)
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         tmp_path = Path(tmp_dir)

--- a/argus/tests/test_container_scanner_runners.py
+++ b/argus/tests/test_container_scanner_runners.py
@@ -18,6 +18,7 @@ from unittest.mock import patch
 import pytest
 
 from argus.container.scanner import (
+    RegistryAuthError,
     _docker_env_flags,
     _is_path_component_prefix,
     _normalize_image_ref,
@@ -29,6 +30,7 @@ from argus.container.scanner import (
     _run_trivy,
     _subprocess_env,
     _validate_scanner_output,
+    validate_registry_auth,
 )
 
 
@@ -1670,3 +1672,263 @@ class TestScanImageBindsContentDigest:
 
         assert result.digest == ""
         assert "image_digest" not in result.combined_findings[0].metadata
+
+
+# ───────────────────────────────────────────────
+# Registry auth fast-fail (#253)
+# ───────────────────────────────────────────────
+#
+# Before this gate a registry_auth entry whose ``*_env`` named an unset
+# variable only produced a WARNING in argus.log; the scan proceeded and
+# the sub-scanner container failed ~90s later with an opaque
+# ``UNAUTHORIZED: authentication required``. ``validate_registry_auth``
+# now fails fast — on stderr, before any container starts — naming the
+# registry scope and the unset variable.
+
+
+class TestValidateRegistryAuth:
+    """Pure-function checks for ``validate_registry_auth``."""
+
+    def test_raises_on_map_entry_unresolved_password_env(self, monkeypatch):
+        # Mirrors the issue example exactly: username resolves, password
+        # env var is unset → fail fast naming the registry + the var.
+        monkeypatch.setenv("ARGUS_REGISTRY_USER", "svc-account")
+        monkeypatch.delenv("ARGUS_REGISTRY_PASSWORD", raising=False)
+        config = {
+            "registry_auth": {
+                "containers.va.ghe.com": {
+                    "username_env": "ARGUS_REGISTRY_USER",
+                    "password_env": "ARGUS_REGISTRY_PASSWORD",
+                },
+            },
+        }
+        with pytest.raises(RegistryAuthError) as excinfo:
+            validate_registry_auth(
+                config, "containers.va.ghe.com/org/repo:1.0",
+            )
+        msg = str(excinfo.value)
+        assert "registry_auth[containers.va.ghe.com]" in msg
+        assert "password unresolved" in msg
+        assert "ARGUS_REGISTRY_PASSWORD" in msg
+        # Second line is the actionable remediation.
+        assert "argus.yml" in msg
+
+    def test_raises_on_map_entry_unresolved_username_env(self, monkeypatch):
+        monkeypatch.delenv("IB_USER", raising=False)
+        monkeypatch.setenv("IB_TOKEN", "tok")
+        config = {
+            "registry_auth": {
+                "registry1.dso.mil": {
+                    "username_env": "IB_USER",
+                    "password_env": "IB_TOKEN",
+                },
+            },
+        }
+        with pytest.raises(RegistryAuthError) as excinfo:
+            validate_registry_auth(config, "registry1.dso.mil/org/repo:1.0")
+        msg = str(excinfo.value)
+        assert "username unresolved" in msg
+        assert "IB_USER" in msg
+
+    def test_raises_on_empty_env_var(self, monkeypatch):
+        # Set-but-empty counts as unresolved (the upstream pull would
+        # still fail). ``not username`` covers "" the same as None.
+        monkeypatch.setenv("IB_USER", "")
+        config = {
+            "registry_auth": {
+                "registry1.dso.mil": {"username_env": "IB_USER"},
+            },
+        }
+        with pytest.raises(RegistryAuthError):
+            validate_registry_auth(config, "registry1.dso.mil/org/repo:1.0")
+
+    def test_raises_on_top_level_unresolved(self, monkeypatch):
+        # No map match → top-level single-default shortcut is gated too.
+        monkeypatch.delenv("REG_PASS", raising=False)
+        config = {"registry_password_env": "REG_PASS"}
+        with pytest.raises(RegistryAuthError) as excinfo:
+            validate_registry_auth(config, "ghcr.io/org/app:1.0")
+        assert "REG_PASS" in str(excinfo.value)
+
+    def test_top_level_gated_when_image_ref_none(self, monkeypatch):
+        # Helper-level callers may pass image_ref=None; the top-level
+        # shortcut still needs gating.
+        monkeypatch.delenv("REG_PASS", raising=False)
+        config = {"registry_password_env": "REG_PASS"}
+        with pytest.raises(RegistryAuthError):
+            validate_registry_auth(config, None)
+
+    def test_no_raise_when_creds_resolve(self, monkeypatch):
+        monkeypatch.setenv("IB_USER", "u")
+        monkeypatch.setenv("IB_TOKEN", "p")
+        config = {
+            "registry_auth": {
+                "registry1.dso.mil": {
+                    "username_env": "IB_USER",
+                    "password_env": "IB_TOKEN",
+                },
+            },
+        }
+        # No exception.
+        validate_registry_auth(config, "registry1.dso.mil/org/repo:1.0")
+
+    def test_no_raise_for_anonymous_pull(self):
+        # Nothing configured → anonymous is a valid mode, not an error.
+        validate_registry_auth({}, "docker.io/library/nginx:latest")
+        validate_registry_auth(None, "docker.io/library/nginx:latest")
+
+    def test_no_raise_when_unconfigured_field_omitted(self, monkeypatch):
+        # Token-only auth: only password is configured (and resolves);
+        # the absent username must NOT be gated.
+        monkeypatch.setenv("IB_TOKEN", "p")
+        monkeypatch.delenv("IB_USER", raising=False)
+        config = {
+            "registry_auth": {
+                "registry1.dso.mil": {"password_env": "IB_TOKEN"},
+            },
+        }
+        validate_registry_auth(config, "registry1.dso.mil/org/repo:1.0")
+
+    def test_no_raise_when_no_entry_matches_image(self, monkeypatch):
+        # A configured-but-unresolved entry for a *different* registry
+        # must not gate a pull from an unrelated registry.
+        monkeypatch.delenv("IB_TOKEN", raising=False)
+        config = {
+            "registry_auth": {
+                "registry1.dso.mil": {"password_env": "IB_TOKEN"},
+            },
+        }
+        validate_registry_auth(config, "ghcr.io/org/app:1.0")
+
+    def test_malformed_entry_is_not_gated(self, monkeypatch):
+        # Non-mapping entry is a config-shape problem handled (warned)
+        # elsewhere — not an unresolved-credential failure.
+        config = {"registry_auth": {"registry1.dso.mil": "not-a-mapping"}}
+        validate_registry_auth(config, "registry1.dso.mil/org/repo:1.0")
+
+    def test_longest_prefix_entry_is_the_one_gated(self, monkeypatch):
+        # The more-specific entry wins; its unresolved cred is what
+        # fails, even though the broader entry resolves fine.
+        monkeypatch.setenv("BROAD_USER", "u")
+        monkeypatch.setenv("BROAD_PASS", "p")
+        monkeypatch.delenv("RESTRICTED_PASS", raising=False)
+        config = {
+            "registry_auth": {
+                "registry1.dso.mil": {
+                    "username_env": "BROAD_USER",
+                    "password_env": "BROAD_PASS",
+                },
+                "registry1.dso.mil/ironbank/restricted": {
+                    "username_env": "BROAD_USER",
+                    "password_env": "RESTRICTED_PASS",
+                },
+            },
+        }
+        with pytest.raises(RegistryAuthError) as excinfo:
+            validate_registry_auth(
+                config, "registry1.dso.mil/ironbank/restricted/repo:1.0",
+            )
+        assert "ironbank/restricted" in str(excinfo.value)
+        assert "RESTRICTED_PASS" in str(excinfo.value)
+
+
+class TestScanImageFailsFastOnRegistryAuth:
+    """``scan_image`` gates remote pulls before any sub-scanner runs."""
+
+    def _stub_runners(self, monkeypatch):
+        """Record whether the sub-scanner runners are ever reached."""
+        from argus.container import scanner as scanner_mod
+
+        called: dict = {"trivy": False, "grype": False}
+
+        def fake_trivy(*_a, **_kw):
+            called["trivy"] = True
+            return []
+
+        def fake_grype(*_a, **_kw):
+            called["grype"] = True
+            return []
+
+        monkeypatch.setattr(scanner_mod, "_run_trivy", fake_trivy)
+        monkeypatch.setattr(scanner_mod, "_run_grype", fake_grype)
+        return called
+
+    def test_remote_unresolved_raises_before_subscanners(
+        self, monkeypatch,
+    ):
+        from argus.container import scanner as scanner_mod
+        from argus.container.scanner import scan_image
+        from argus.container.discovery import ContainerTarget
+
+        called = self._stub_runners(monkeypatch)
+        monkeypatch.setattr(scanner_mod, "is_image_local", lambda ref: False)
+        monkeypatch.delenv("ARGUS_REGISTRY_PASSWORD", raising=False)
+
+        config = {
+            "registry_auth": {
+                "ghcr.io": {"password_env": "ARGUS_REGISTRY_PASSWORD"},
+            },
+        }
+        target = ContainerTarget(name="web", image_ref="ghcr.io/org/web:1.0")
+
+        with pytest.raises(RegistryAuthError):
+            scan_image(target, scanners=("trivy", "grype"), sbom=False, config=config)
+
+        # The whole point: we never spent 60–90s in a doomed pull.
+        assert called["trivy"] is False
+        assert called["grype"] is False
+
+    def test_local_image_skips_registry_auth_gate(self, monkeypatch):
+        # Image present in the daemon → scanned from docker source, no
+        # registry pull, so a missing registry cred must NOT block it.
+        from argus.container import scanner as scanner_mod
+        from argus.container.scanner import scan_image
+        from argus.container.discovery import ContainerTarget
+
+        called = self._stub_runners(monkeypatch)
+        monkeypatch.setattr(scanner_mod, "is_image_local", lambda ref: True)
+        monkeypatch.delenv("ARGUS_REGISTRY_PASSWORD", raising=False)
+
+        config = {
+            "registry_auth": {
+                "ghcr.io": {"password_env": "ARGUS_REGISTRY_PASSWORD"},
+            },
+        }
+        target = ContainerTarget(name="web", image_ref="ghcr.io/org/web:1.0")
+
+        # No raise; sub-scanners run against the local copy.
+        scan_image(target, scanners=("trivy", "grype"), sbom=False, config=config)
+        assert called["trivy"] is True
+        assert called["grype"] is True
+
+
+class TestEngineDoesNotSwallowRegistryAuthError:
+    """``_process_target`` re-raises the fast-fail instead of recording it."""
+
+    def _engine(self):
+        from argus.container.engine import ContainerEngine
+        return ContainerEngine({})
+
+    def _remote_target(self):
+        from argus.container.discovery import ContainerTarget
+        return ContainerTarget(name="web", image_ref="ghcr.io/org/web:1.0")
+
+    def test_registry_auth_error_propagates(self, monkeypatch):
+        monkeypatch.setattr(
+            "argus.container.engine.scan_image",
+            lambda *a, **kw: (_ for _ in ()).throw(
+                RegistryAuthError("registry_auth[ghcr.io]: password unresolved"),
+            ),
+        )
+        with pytest.raises(RegistryAuthError):
+            self._engine()._process_target(self._remote_target())
+
+    def test_generic_error_still_recorded(self, monkeypatch):
+        # Contrast: ordinary scan failures are still caught and turned
+        # into a per-target scan_error (existing behavior preserved).
+        monkeypatch.setattr(
+            "argus.container.engine.scan_image",
+            lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+        result = self._engine()._process_target(self._remote_target())
+        assert "Scan failed" in result.scan_error


### PR DESCRIPTION
## Description
A `registry_auth` entry (or the top-level `registry_username`/`registry_password` shortcut) whose `*_env` reference points at an unset or empty environment variable used to only emit a WARNING to `argus.log`, then proceed. The scanner container ran for 60–90s and failed with an opaque `UNAUTHORIZED: authentication required` from grype/trivy — nothing on stderr explained the real cause. This makes argus fail fast, on stderr, before any scanner container starts.

## Changes Made
- [ ] Added new scanner/workflow
- [ ] Modified existing scanner/workflow
- [ ] Updated documentation
- [x] Fixed bug
- [ ] Other (please specify)

### Details
- **Affected:** container scanning path (`argus/container/scanner.py`, `engine.py`, CLI container command). Applies to both `argus scan container --image …` and the `containers:` block of `argus scan --config argus.yml`.
- **New:** `validate_registry_auth(config, image_ref)` + `RegistryAuthError`. Called from `scan_image()` for remote pulls, before any sub-scanner container is invoked. A configured-but-unresolved credential raises `RegistryAuthError` naming the registry scope and the unset env var:
  ```
  Error: registry_auth[containers.va.ghe.com]: password unresolved — env var ARGUS_REGISTRY_PASSWORD is not set.
  Set it before running argus or update registry_auth in argus.yml to reference a variable that is exported.
  ```
- `ContainerEngine._process_target` re-raises `RegistryAuthError` (it is **not** recorded as a per-target `scan_error`) so the whole run aborts fast; the CLI surfaces the two-line message on stderr and exits non-zero.
- **Scope guards:** local images (built this run, or already present in the docker daemon) skip the gate — they scan from the daemon source and never touch a registry. Anonymous pulls and token-only auth (username intentionally omitted) are not gated. The matched entry uses the same longest-path-prefix rule as resolution.
- **No breaking changes:** the `_resolve_registry_auth` resolver contract (returns `(None, None)` + WARNING on an unresolved map entry) is unchanged; the new gate is additive.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results
Added `TestValidateRegistryAuth`, `TestScanImageFailsFastOnRegistryAuth`, and `TestEngineDoesNotSwallowRegistryAuthError` to `argus/tests/test_container_scanner_runners.py` — covering map-entry and top-level unresolved creds, the issue's exact message format, empty-string env vars, anonymous/token-only/no-match pass-throughs, longest-prefix selection, the fast-fail-before-sub-scanners guarantee, the local-image skip, and engine propagation (vs. generic errors still recorded).

```
argus/tests/test_container_scanner_runners.py — 88 passed
Full SDK suite — 3864 passed (3 pre-existing browser-viewer failures unrelated to this change, identical on main)
```

## Security Considerations
- [ ] No security impact
- [x] Security enhancement
- [ ] Potential security implications (explain below)

### Security Details
Reinforces the existing privilege-misuse guard: an unresolved credential for a registry the operator explicitly scoped no longer silently degrades to an anonymous pull that produces misleading `0 findings`/opaque-auth-error output. Failing fast keeps a misconfiguration from masquerading as a clean scan. No credential values are emitted — only the env-var *name* and the registry key appear in the message.

## AI Context Updates (.ai/)
- [ ] `.ai/architecture.yaml` updated (if components/structure changed)
- [ ] `.ai/workflows.yaml` updated (if commands/tasks changed)
- [ ] `.ai/decisions.yaml` updated (if design decision made)
- [x] `.ai/errors.yaml` updated (if common error addressed)
- [ ] N/A - No .ai/ updates needed

## Checklist
- [x] Code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Closes #253
