### PR TITLE
fix(release): single-source promoted image list so all scanners get tagged

### DIFF
--- a/.ai/errors.yaml
+++ b/.ai/errors.yaml
@@ -301,6 +301,40 @@ error_patterns:
       note: "Do NOT remove persist-credentials: false — fix the remote URL instead"
       reference: "PR #86"
 
+  - pattern: "manifest unknown|<scanner>:<version> failed manifest check|pinned image tag does not resolve after release"
+    category: release
+    context: |
+      A scanner image is pinned in argus/containers.py as
+      ``<image>:<version>@sha256:<digest>`` but the ``:<version>`` /
+      ``:latest`` tag does not exist on GHCR — ``docker manifest
+      inspect`` returns "manifest unknown". The image *content* (the
+      digest) exists, often only under the transient ``build-<sha>-<run>``
+      tag. Surfaces as the Unit Tests manifest check failing (it runs on
+      a single Python matrix leg), frequently first noticed on an
+      unrelated PR rather than at release time.
+
+    root_cause: |
+      The Release workflow builds once with a ``build-<sha>`` tag, then
+      re-tags to ``:<VERSION>`` + ``:latest``. The build, promote, cosign,
+      and release-notes steps each carried their OWN hardcoded image list.
+      When scanner-mumps was added it was put in the build + cosign lists
+      but missed from the promote loop, so it was built and signed but
+      never tagged ``:<VERSION>``. The release-it after:bump hook still
+      pinned containers.py to the (valid) digest, so the pin pointed at a
+      tag that was never pushed. The ``chore(release):`` commit skips the
+      Unit Tests workflow, so the manifest check never ran post-release.
+
+    solution:
+      steps:
+        - "Single-source the image set: build IMAGE_NAMES once from the IMAGES array and export via $GITHUB_ENV; promote/cosign/notes all iterate IMAGE_NAMES (no parallel hardcoded lists)."
+        - "Add a 'Verify pinned image manifests resolve' step to release.yml (runs python -m scripts.ci.check_container_images after promotion, before publish) so a missing promotion fails the release immediately."
+        - "Immediate remediation for an already-shipped miss: re-tag the existing digest with oras (manifest-only, no rebuild): oras tag <repo>@sha256:<digest> <version> latest — the digest is already cosign-signed, so signatures stay valid."
+      note: |
+        cosign signs by digest, so a missing :<VERSION> tag does NOT fail
+        the signing step — the manifest check is what catches it. Keep the
+        single IMAGE_NAMES source so adding a scanner can't drift again.
+      reference: "argus/containers.py + .github/workflows/release.yml (promote/cosign/notes loops) + scripts/ci/check_container_images.py"
+
   # ==============================================================================
   # WORKFLOW ERRORS
   # ==============================================================================

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,6 +236,21 @@ jobs:
             "cli:docker/Dockerfile.cli:CLI"
             "scanner-mumps:docker/Dockerfile.mumps:SCANNER_MUMPS"
           )
+
+          # Single source of truth: export the bare image names so the
+          # promote / cosign / release-notes steps below all iterate the
+          # SAME set as the build. Adding a scanner to IMAGES now
+          # propagates everywhere — previously those steps carried their
+          # own hardcoded lists, and a missing entry shipped a release
+          # with an unpromoted image (scanner-mumps had no :VERSION tag,
+          # breaking its pin in argus/containers.py).
+          IMAGE_NAMES=""
+          for entry in "${IMAGES[@]}"; do
+            IFS=':' read -r NAME _ _ <<< "$entry"
+            IMAGE_NAMES="${IMAGE_NAMES:+${IMAGE_NAMES} }${NAME}"
+          done
+          echo "IMAGE_NAMES=${IMAGE_NAMES}" >> "$GITHUB_ENV"
+
           for entry in "${IMAGES[@]}"; do
             IFS=':' read -r IMAGE DOCKERFILE KEY <<< "$entry"
             FULL_REF="${IMAGE_REGISTRY}/${IMAGE}:${BUILD_TAG}"
@@ -315,7 +330,7 @@ jobs:
         if: env.RELEASED == 'true'
         run: |
           set -euo pipefail
-          for IMAGE in scanner-bandit scanner-opengrep scanner-supply-chain cli; do
+          for IMAGE in ${IMAGE_NAMES}; do
             SRC="${IMAGE_REGISTRY}/${IMAGE}:${BUILD_TAG}"
             docker buildx imagetools create \
               --tag "${IMAGE_REGISTRY}/${IMAGE}:${VERSION}" \
@@ -336,12 +351,38 @@ jobs:
         if: env.RELEASED == 'true'
         run: |
           set -euo pipefail
-          cosign sign --yes "${IMAGE_REGISTRY}/scanner-bandit@${SCANNER_BANDIT_DIGEST}"
-          cosign sign --yes "${IMAGE_REGISTRY}/scanner-opengrep@${SCANNER_OPENGREP_DIGEST}"
-          cosign sign --yes "${IMAGE_REGISTRY}/scanner-supply-chain@${SCANNER_SUPPLY_CHAIN_DIGEST}"
-          cosign sign --yes "${IMAGE_REGISTRY}/cli@${CLI_DIGEST}"
-          cosign sign --yes "${IMAGE_REGISTRY}/scanner-mumps@${SCANNER_MUMPS_DIGEST}"
+          # Same source as build/promote. The per-image digest captured at
+          # build time lives in env var <KEY>_DIGEST, where KEY is the
+          # image name upper-cased with '-' → '_' (scanner-mumps →
+          # SCANNER_MUMPS), matching the IMAGES array keys above.
+          for IMAGE in ${IMAGE_NAMES}; do
+            KEY=$(echo "${IMAGE}" | tr 'a-z-' 'A-Z_')
+            DIGEST_VAR="${KEY}_DIGEST"
+            cosign sign --yes "${IMAGE_REGISTRY}/${IMAGE}@${!DIGEST_VAR}"
+            echo "Signed ${IMAGE} @ ${!DIGEST_VAR}"
+          done
           echo "All images signed by digest"
+
+      - name: Verify pinned image manifests resolve
+        # The chore(release): commit skips the Unit Tests workflow (and the
+        # manifest check it runs), so a promotion miss used to ship
+        # undetected and only surface later on an unrelated PR. release-it
+        # has already rewritten argus/containers.py with the new version +
+        # digests; verify every pinned tag@digest actually resolves on
+        # GHCR before we build the wheel and publish to PyPI.
+        if: env.RELEASED == 'true'
+        run: |
+          set +e
+          python -m scripts.ci.check_container_images
+          rc=$?
+          set -e
+          if [ "$rc" -eq 1 ]; then
+            echo "::error::One or more pinned images failed manifest check — a release tag was likely not promoted. Aborting before publish."
+            exit 1
+          fi
+          if [ "$rc" -eq 2 ]; then
+            echo "::warning::docker unavailable — image manifest check skipped"
+          fi
 
       - name: Build wheel
         # release-it has already bumped argus/__init__.py and rewritten
@@ -388,7 +429,7 @@ jobs:
             echo "### Container Images"
             echo "| Image | Tags |"
             echo "|-------|------|"
-            for IMAGE in scanner-bandit scanner-opengrep scanner-supply-chain cli; do
+            for IMAGE in ${IMAGE_NAMES}; do
               echo "| ${IMAGE_REGISTRY}/${IMAGE} | ${VERSION}, latest |"
             done
             echo ""

--- a/argus/containers.py
+++ b/argus/containers.py
@@ -39,7 +39,7 @@ OFFICIAL_IMAGES = {
     # the eslint entry.
     "kics": "checkmarx/kics:latest@sha256:3e5a268eb8adda2e5a483c9359ddfc4cd520ab856a7076dc0b1d8784a37e2602",
     "osv-scanner": "ghcr.io/google/osv-scanner:v2.3.6@sha256:2e07e642463100474fc5e214b66e6beccbd6bfa63dd3fbf047b3f755e78a6cfe",
-    "zap": "ghcr.io/zaproxy/zaproxy:2.17.0@sha256:2ec1d5d5b44d55cfd02ba9b89cd26852f06d92b7fc0ce9f064b9463babc73074",
+    "zap": "ghcr.io/zaproxy/zaproxy:2.17.0@sha256:7c2f8afc893e4e4000be8ad3fd22013fc36e5cce59359349f5a2d45626e2ccb9",
     # promptfoo LLM red-team / eval. Opt-in scanner; requires provider
     # API keys + network at scan time. Pinned to an immutable version tag
     # + digest (Renovate-managed), like every other image here — the


### PR DESCRIPTION
## Description
The release workflow built every scanner image but the **promote**, **cosign**, and **release-notes** steps each carried their own hardcoded image list. `scanner-mumps` was added to the build + cosign lists but missed from the promote loop, so 1.4.0 shipped with the mumps image built and signed but **never tagged `:1.4.0` / `:latest`**. The `release-it` hook still pinned `argus/containers.py` to the (valid) digest, leaving the pin pointing at a tag that was never pushed — which surfaced as `manifest unknown` in the image manifest check (first seen on an unrelated PR, #255).

This PR fixes the root cause (list drift), adds a release-time guard, and re-pins `zap` (a separate upstream tag drift that was failing the same check).

## Changes Made
- [ ] Added new scanner/workflow
- [x] Modified existing scanner/workflow
- [ ] Updated documentation
- [x] Fixed bug
- [ ] Other (please specify)

### Details
1. **Single source of truth (`release.yml`).** `IMAGE_NAMES` is derived once from the canonical `IMAGES` array and exported via `$GITHUB_ENV`. The promote, cosign, and release-notes steps now all iterate that one list, so adding a scanner can't drift again. cosign derives each image's digest env var (`<KEY>_DIGEST`) from the name (`scanner-mumps` → `SCANNER_MUMPS`).
2. **Fail-fast verification (`release.yml`).** New "Verify pinned image manifests resolve" step runs `python -m scripts.ci.check_container_images` after promotion and **before** the wheel build / PyPI publish. The `chore(release):` commit skips the Unit Tests workflow (and its manifest check), so a promotion miss previously shipped undetected; the release now aborts if any pinned `tag@digest` doesn't resolve.
3. **Re-pin `zap` (`argus/containers.py`).** `ghcr.io/zaproxy/zaproxy` re-pushed `:2.17.0` to a new digest (rebuilt 2026-06-12 — same version, official repo, same amd64+arm64 manifest; a routine base-image refresh). The old pinned digest still resolves, but `docker manifest inspect tag@digest` cross-verifies the tag and now mismatches, failing the check on every PR. Re-pinned to the current digest (`7c2f8afc…`) so tag and digest agree. This is what Renovate does on a digest drift; done by hand because the re-push landed mid-cycle and was blocking CI.

No breaking changes: same images built/signed; only promote+notes coverage is corrected and the lists unified.

### Out-of-band remediation (already done)
`scanner-mumps:1.4.0` and `:latest` were restored by re-tagging the existing signed digest (`oras tag …@sha256:393a58b… 1.4.0 latest`) — manifest-only, no rebuild, signature intact — so **1.4.0 users are unblocked now**. This PR prevents recurrence.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results
- `actionlint .github/workflows/release.yml` → clean. `zizmor` findings identical to `main` (none introduced).
- `python -m scripts.ci.check_container_images` → **All images resolve** (mumps ✅, zap ✅).
- `argus/tests/test_containers.py` → 25 passed.

## Security Considerations
- [ ] No security impact
- [x] Security enhancement
- [ ] Potential security implications (explain below)

### Security Details
Closes a supply-chain integrity gap where a released image could be built and signed but left unpromoted, leaving the SDK's pinned reference pointing at a non-existent tag. The new pre-publish manifest verification ensures every pinned `tag@digest` resolves before the wheel ships. The zap re-pin keeps a digest-pinned dependency aligned with its current upstream build (vetted: official repo, multi-arch, same version, recent rebuild). cosign continues signing by digest, so signatures stay valid regardless of tagging.

## AI Context Updates (.ai/)
- [x] `.ai/errors.yaml` updated (if common error addressed)
- [ ] N/A - No .ai/ updates needed

## Checklist
- [x] Code follows project style guidelines
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Surfaced by the manifest check on #255. No separate tracked issue for the release-promotion gap.

## Merge ordering note
#255 (registry-auth) still carries the **old** zap pin, so its manifest check will stay red until it picks up this fix. Merge this PR to `main` first, then rebase/merge `main` into #255 and it goes green.
