### PR TITLE
fix(scanner-container-summary): deprecate and forward to security-summary

### DIFF
--- a/.ai/decisions.yaml
+++ b/.ai/decisions.yaml
@@ -2528,6 +2528,13 @@ decisions:
         .github/workflows/container-scan-from-config.yml,
         examples/workflows/actions-container-scan-matrix.yml — migrated the
         summary step to security-summary.
+      - The two workflows that invoke ``argus scan`` inline
+        (container-scan.yml, container-scan-from-config.yml) now write to a
+        fixed --output-dir --no-timestamp and publish the per-container
+        markdown as a ``scanner-summary-container-<name>`` artifact before
+        the summary job, so security-summary has something to stitch instead
+        of silently producing an empty report. (Consumers that use the
+        scanner-container composite action already upload these.)
       - READMEs (.github/actions/README.md catalog +
         scanner-container-summary/README.md) marked deprecated.
 

--- a/.ai/decisions.yaml
+++ b/.ai/decisions.yaml
@@ -2465,3 +2465,73 @@ decisions:
       - ADR-014  # Third-party images stay SHA-pinned via Renovate (same pinDigests philosophy for actions)
     pr_references:
       - "(moves github-actions updates from Dependabot to Renovate; closes #196; supersedes the #218 ignore-self-refs attempt)"
+
+  - id: ADR-030
+    title: "Deprecate scanner-container-summary in favor of security-summary"
+    date: "2026-06-12"
+    status: accepted
+
+    context: |
+      The Phase 3 thin-wrapper migration rewrote scanner-container to call
+      the Argus SDK (``argus scan container``) directly and emit a
+      per-container markdown summary artifact (``scanner-summary-container-*``).
+      The bespoke parse/summary scripts (parse_trivy_results.py,
+      parse_grype_results.py, generate_container_summary.py) were removed as
+      dead code in that cleanup. But scanner-container-summary — the action
+      that combines parallel/matrix container results — still shelled out to
+      those deleted scripts, and still downloaded the obsolete
+      ``container-scan-results-*`` artifact name. It therefore crashed with
+      "No such file or directory" at 1.4.0 and 1.4.1 (issue #251). Meanwhile
+      security-summary already does exactly this job the SDK way: it
+      downloads ``scanner-summary-*`` artifacts (which include
+      ``scanner-summary-container-*``), stitches them via its own
+      generate_summary.py, renders a status table, and posts a PR comment.
+      Two aggregators, one broken and redundant.
+
+    decision: |
+      Deprecate scanner-container-summary and converge on security-summary as
+      the single combined-summary aggregator. scanner-container-summary
+      becomes a thin compatibility shim that emits a deprecation warning and
+      forwards to security-summary scoped to ``scanner-summary-container-*``
+      (preserving the container-specific title and PR comment marker), so
+      existing ``@<version>`` pins keep working. Internal consumers
+      (container-scan.yml, container-scan-from-config.yml) and the published
+      example migrate directly to security-summary. The shim is slated for
+      removal in a future major release.
+
+    alternatives:
+      - option: "Resurrect the deleted parse/summary scripts"
+        rejected_because: |
+          They parsed raw trivy/grype JSON in the pre-SDK format; the SDK now
+          emits canonical results + markdown, so the old scripts no longer
+          match the artifact contract. Re-adding them would reintroduce a
+          parallel, drift-prone implementation of what the SDK already does.
+      - option: "Repair scanner-container-summary as a standalone aggregator"
+        rejected_because: |
+          Keeps two near-identical aggregators to maintain. security-summary
+          already covers the container case via its scanner-summary-* pattern.
+
+    consequences:
+      positive:
+        - "The combined container summary works again (forwards to the maintained security-summary path)."
+        - "One aggregator to maintain; no duplicated stitching logic."
+        - "External consumers pinned to scanner-container-summary keep working via the shim (no hard break)."
+      negative:
+        - "scanner-container-summary's declared outputs (total_vulnerabilities, etc.) are dropped — they never functioned (the action crashed) and security-summary does not expose per-severity counts."
+        - "A future major release must remove the shim; consumers must migrate to security-summary before then."
+
+    implementation: |
+      - .github/actions/scanner-container-summary/action.yml — replaced the
+        deleted-script invocation with a deprecation warning + a forward to
+        security-summary (summary_pattern: scanner-summary-container-*).
+      - .github/workflows/container-scan.yml,
+        .github/workflows/container-scan-from-config.yml,
+        examples/workflows/actions-container-scan-matrix.yml — migrated the
+        summary step to security-summary.
+      - READMEs (.github/actions/README.md catalog +
+        scanner-container-summary/README.md) marked deprecated.
+
+    related:
+      - ADR-027  # Build-once-promote release pipeline (where 1.4.x was cut)
+    pr_references:
+      - "(deprecates scanner-container-summary; fixes the dangling deleted-script refs; closes #251)"

--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -30,7 +30,7 @@ This directory contains reusable composite actions for security scanning. Each a
 | Action | Description | Language/Type | Documentation |
 |--------|-------------|---------------|---------------|
 | [scanner-container](scanner-container/) | Multi-scanner container security | Container images | [README](scanner-container/README.md) |
-| [scanner-container-summary](scanner-container-summary/) | Aggregate parallel container scan results | Container images | [README](scanner-container-summary/README.md) |
+| [scanner-container-summary](scanner-container-summary/) | **Deprecated** — forwards to [security-summary](security-summary/); use that instead | Container images | [README](scanner-container-summary/README.md) |
 
 ### Web Application Security
 

--- a/.github/actions/scanner-container-summary/README.md
+++ b/.github/actions/scanner-container-summary/README.md
@@ -5,330 +5,49 @@
 > [`security-summary`](../security-summary/), scoped to the per-container scan
 > summaries that `scanner-container` emits (`scanner-summary-container-*`). It
 > remains only so existing `@<version>` pins keep working and will be removed in
-> a future major release. Migrate to:
->
-> ```yaml
-> - uses: huntridge-labs/argus/.github/actions/security-summary@1.4.1
->   with:
->     summary_pattern: 'scanner-summary-container-*'
->     title: '🐳 Container Security Scan Results'
-> ```
+> a future major release.
 >
 > Why: the parse/summary scripts this action depended on were removed during the
 > Phase 3 thin-wrapper migration (the SDK-backed `scanner-container` now produces
 > the per-container summary directly), which broke the combined summary at
 > 1.4.0 / 1.4.1 (issue #251). `security-summary` is the canonical aggregator.
 
-Aggregate and deduplicate results from parallel container scans into a unified summary.
+## Migration
 
-## Overview
-
-This action is designed to work with matrix-based container scanning workflows. When you scan multiple containers or use multiple scanners in parallel, this action:
-- ✅ Downloads all scan artifacts
-- ✅ Deduplicates vulnerabilities across scanners
-- ✅ Generates a unified summary with rich formatting
-- ✅ Posts results as PR comments
-- ✅ Creates combined artifacts for reporting
-
-## Usage
-
-### Basic Example with Matrix Scanning
-
-```yaml
-jobs:
-  # Step 1: Scan containers in parallel
-  container-scan:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        image:
-          - { ref: 'nginx:latest', name: 'web' }
-          - { ref: 'postgres:15', name: 'db' }
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Scan container
-        uses: huntridge-labs/argus/.github/actions/scanner-container@1.4.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          image_ref: ${{ matrix.image.ref }}
-          scan_name: ${{ matrix.image.name }}
-          skip_summary: true  # Important: skip individual summaries
-
-  # Step 2: Generate combined summary
-  summary:
-    needs: container-scan
-    if: always()  # Run even if some scans fail
-    runs-on: ubuntu-latest
-    steps:
-      - name: Generate combined summary
-        uses: huntridge-labs/argus/.github/actions/scanner-container-summary@1.4.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          post_pr_comment: true
-```
-
-### Advanced Example with Config-Driven Scanning
-
-```yaml
-jobs:
-  # Parse container configuration
-  setup:
-    runs-on: ubuntu-latest
-    outputs:
-      scan_matrix: ${{ steps.parse.outputs.scan_matrix }}
-    steps:
-      - uses: actions/checkout@v6
-      - uses: huntridge-labs/argus/.github/actions/parse-container-config@1.4.1
-        id: parse
-        with:
-          config_file: 'container-config.yml'
-
-  # Scan in parallel
-  scan:
-    needs: setup
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.setup.outputs.scan_matrix) }}
-    steps:
-      - uses: huntridge-labs/argus/.github/actions/scanner-container@1.4.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          image_ref: ${{ matrix.image }}
-          scan_name: ${{ matrix.name }}
-          scanners: ${{ matrix.scanner }}
-          skip_summary: true
-
-  # Aggregate results
-  summary:
-    needs: scan
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - uses: huntridge-labs/argus/.github/actions/scanner-container-summary@1.4.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-```
-
-## Inputs
-
-| Input | Description | Required | Default |
-|-------|-------------|----------|---------|
-| `artifact_pattern` | Pattern to match scan artifacts | No | `container-scan-results-*` |
-| `post_pr_comment` | Post combined results as PR comment | No | `true` |
-
-## Outputs
-
-| Output | Description |
-|--------|-------------|
-| `total_vulnerabilities` | Total unique vulnerabilities across all containers |
-| `critical_count` | Number of critical vulnerabilities |
-| `high_count` | Number of high severity vulnerabilities |
-| `containers_scanned` | Number of containers scanned |
-
-## Features
-
-### Vulnerability Deduplication
-
-When multiple scanners detect the same vulnerability:
-- Deduplicates based on CVE ID
-- Keeps the highest severity reported
-- Shows which scanners detected each issue
-
-### Rich Summary Output
-
-Generates comprehensive summaries with:
-- 📊 Overall vulnerability statistics
-- 🐳 Per-container breakdowns
-- 🔍 Detailed finding tables
-- 📈 Severity distribution
-- 🔗 Clickable links to artifacts
-
-### PR Comments
-
-Automatically posts (or updates) PR comments with:
-- Combined vulnerability counts
-- Container-by-container breakdown
-- Links to full reports
-- Timestamp of last update
-
-## How It Works
-
-1. **Artifact Collection**: Downloads all artifacts matching the pattern
-2. **Parsing**: Extracts vulnerability data from JSON reports
-3. **Deduplication**: Merges findings from multiple scanners
-4. **Summary Generation**: Creates formatted markdown summaries
-5. **Upload**: Saves combined summary as artifact
-6. **PR Comment**: Posts results to pull request
-
-## Reports Generated
-
-The action generates:
-- `container.md` - Combined markdown summary
-- `container-summary.json` - Structured data (if available)
-
-These are uploaded as artifact: `container-scan-summary`
-
-## Examples
-
-### Custom Artifact Pattern
-
-If your scan artifacts use a different naming pattern:
-
-```yaml
-- uses: huntridge-labs/argus/.github/actions/scanner-container-summary@1.4.1
-  env:
-    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  with:
-    artifact_pattern: 'my-scan-results-*'
-```
-
-### Disable PR Comments
-
-```yaml
-- uses: huntridge-labs/argus/.github/actions/scanner-container-summary@1.4.1
-  env:
-    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  with:
-    post_pr_comment: false
-```
-
-### Use Outputs for Gating
-
-```yaml
-- name: Generate summary
-  id: summary
-  uses: huntridge-labs/argus/.github/actions/scanner-container-summary@1.4.1
-  env:
-    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-- name: Check vulnerability threshold
-  run: |
-    if [ "${{ steps.summary.outputs.critical_count }}" -gt 0 ]; then
-      echo "❌ Found ${{ steps.summary.outputs.critical_count }} critical vulnerabilities"
-      exit 1
-    fi
-    echo "✅ No critical vulnerabilities found"
-```
-
-## Important Notes
-
-### Skip Individual Summaries
-
-When using matrix scanning, set `skip_summary: true` in the scanner-container action to avoid duplicate summaries:
-
-```yaml
-- uses: huntridge-labs/argus/.github/actions/scanner-container@1.4.1
-  with:
-    skip_summary: true  # Important!
-```
-
-### Always Run Summary
-
-Use `if: always()` to ensure the summary runs even if some scans fail:
+Replace the summary job with [`security-summary`](../security-summary/), pointed
+at the per-container summary artifacts:
 
 ```yaml
 summary:
   needs: scan
-  if: always()  # Run regardless of scan results
+  if: always()
+  runs-on: ubuntu-latest
+  steps:
+    - uses: huntridge-labs/argus/.github/actions/security-summary@1.4.1
+      with:
+        summary_pattern: 'scanner-summary-container-*'
+        title: '🐳 Container Security Scan Results'
+        # optional: keep the same PR-comment thread this action used
+        comment_marker: 'container-scan-parallel-comment'
 ```
 
-### Artifact Retention
+Your scan jobs must publish a `scanner-summary-container-<name>` artifact for
+each container (the [`scanner-container`](../scanner-container/) action does this
+automatically; workflows that invoke `argus scan container` inline should write
+`--output-dir <dir> --no-timestamp` and upload `<dir>/container-scan.md` under
+that artifact name before the summary job runs).
 
-Scan artifacts are downloaded from the current workflow run. Ensure:
-- Artifacts are uploaded before summary runs
-- Artifact names match the pattern
-- Artifacts haven't expired (retention period)
+## Compatibility shim
 
-## Workflow Requirements
+While this action remains, it accepts:
 
-The summary action requires:
-- **Needs dependency**: Must run after scan jobs
-- **Always condition**: Should run even if scans fail
-- **GITHUB_TOKEN**: For PR comment posting
-- **Artifacts**: Scan results must be uploaded first
+| Input | Description | Default |
+|-------|-------------|---------|
+| `artifact_pattern` | Glob of the per-container summary artifacts to aggregate (forwarded to `security-summary`'s `summary_pattern`) | `scanner-summary-container-*` |
+| `post_pr_comment` | Post the combined results as a PR comment | `true` |
 
-## Deduplication Logic
-
-When the same CVE is found by multiple scanners:
-
-```yaml
-# Trivy finds: CVE-2024-1234 (HIGH)
-# Grype finds: CVE-2024-1234 (CRITICAL)
-
-# Result: CVE-2024-1234 (CRITICAL) - highest severity kept
-# Note: Shows detection by both scanners
-```
-
-## Performance
-
-Summary generation is fast:
-- Typical time: 10-30 seconds
-- Depends on: Number of containers and findings
-- Network: Artifact download time
-
-## Troubleshooting
-
-### No Artifacts Found
-
-If "No artifacts found" appears:
-- Verify artifact names match pattern
-- Check scan jobs completed successfully
-- Ensure artifacts were uploaded
-- Review `artifact_pattern` input
-
-### Missing Vulnerabilities
-
-If summary shows fewer vulnerabilities than expected:
-- Deduplication is working (same CVE from multiple scanners)
-- Check individual scan reports for details
-- Review deduplication logic in action logs
-
-### PR Comment Not Posted
-
-If PR comments don't appear:
-- Verify `post_pr_comment: true`
-- Check workflow has `pull-requests: write` permission
-- Ensure running on pull request event
-- Review action logs for errors
-
-### Summary Too Large
-
-If PR comment is truncated:
-- Summary auto-truncates at 262KB
-- Use artifacts for full reports
-- Consider scanning fewer containers per job
-
-## Best Practices
-
-1. **Matrix Strategy**: Scan containers in parallel for speed
-2. **Always Run**: Use `if: always()` for summary job
-3. **Skip Individual**: Set `skip_summary: true` on scanner
-4. **Fail Fast False**: Allow all scans to complete
-5. **Deduplicate**: Leverage built-in deduplication
-6. **Review Results**: Check both summary and individual reports
-
-## Related Documentation
-
-- [scanner-container](../scanner-container/README.md) - Container scanning action
-- [parse-container-config](../parse-container-config/) - Configuration parser
-- [Container Scanning Guide](../../docs/container-scanning.md)
-- [Complete Example](../../examples/actions-container-scan-matrix.yml)
-
-## Matrix Scanning Benefits
-
-Using this summary action with matrix scanning:
-- ⚡ **Faster**: Parallel execution
-- 📊 **Cleaner**: Single unified report
-- 🔍 **Better**: Deduplication across scanners
-- 💾 **Efficient**: Combined artifacts
-
-## Support
-
-- [Report Issues](https://github.com/huntridge-labs/argusissues)
-- [View Changelog](../../CHANGELOG.md)
-- [Contributing Guide](../../CONTRIBUTING.md)
+It emits a deprecation warning and forwards to `security-summary`. It no longer
+exposes the old `total_vulnerabilities` / `critical_count` / `high_count` /
+`containers_scanned` outputs (those never functioned once the underlying scripts
+were removed, and `security-summary` does not expose per-severity counts). See
+[ADR-030](../../../.ai/decisions.yaml) for the full rationale.

--- a/.github/actions/scanner-container-summary/README.md
+++ b/.github/actions/scanner-container-summary/README.md
@@ -1,5 +1,24 @@
 # Container Scanner Summary Composite Action
 
+> [!WARNING]
+> **Deprecated.** This action is now a thin compatibility shim that forwards to
+> [`security-summary`](../security-summary/), scoped to the per-container scan
+> summaries that `scanner-container` emits (`scanner-summary-container-*`). It
+> remains only so existing `@<version>` pins keep working and will be removed in
+> a future major release. Migrate to:
+>
+> ```yaml
+> - uses: huntridge-labs/argus/.github/actions/security-summary@1.4.1
+>   with:
+>     summary_pattern: 'scanner-summary-container-*'
+>     title: '🐳 Container Security Scan Results'
+> ```
+>
+> Why: the parse/summary scripts this action depended on were removed during the
+> Phase 3 thin-wrapper migration (the SDK-backed `scanner-container` now produces
+> the per-container summary directly), which broke the combined summary at
+> 1.4.0 / 1.4.1 (issue #251). `security-summary` is the canonical aggregator.
+
 Aggregate and deduplicate results from parallel container scans into a unified summary.
 
 ## Overview

--- a/.github/actions/scanner-container-summary/action.yml
+++ b/.github/actions/scanner-container-summary/action.yml
@@ -1,51 +1,33 @@
-name: 'Container Scanner Summary'
+name: 'Container Scanner Summary (deprecated)'
 description: |
-  Combines results from parallel container scans (matrixed by container+scanner) into a unified summary.
-  Use this action after a matrix job that runs scanner-container with one scanner per job.
+  DEPRECATED — use `security-summary` instead.
 
-  This action:
-  - Downloads scan artifacts from the matrix jobs
-  - Deduplicates vulnerabilities across scanners
-  - Generates a rich job summary with collapsible details
-  - Uploads a combined summary artifact
+  This action is now a thin compatibility shim that forwards to
+  `security-summary`, scoped to the per-container scan summaries the
+  SDK-backed `scanner-container` action emits (`scanner-summary-container-*`).
+  It remains only so existing `@<version>` pins keep working; it will be
+  removed in a future major release.
 
-  Example usage (parallel scanning):
-    jobs:
-      setup:
-        runs-on: ubuntu-latest
-        outputs:
-          scan_matrix: (( steps.parse.outputs.scan_matrix ))
-        steps:
-          - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-          - uses: huntridge-labs/argus/.github/actions/parse-container-config@1.4.1
-            id: parse
-            with:
-              config_file: container-config.yml
-
-      scan:
-        needs: setup
-        runs-on: ubuntu-latest
-        strategy:
-          fail-fast: false
-          matrix: (( fromJson(needs.setup.outputs.scan_matrix) ))
-        steps:
-          - uses: huntridge-labs/argus/.github/actions/scanner-container@1.4.1
-            with:
-              image_ref: (( matrix.image ))
-              container_name: (( matrix.name ))
-              scanners: (( matrix.scanner ))
-              registry_username: (( matrix.registry_username ))
-              registry_password: (( secrets[matrix.registry_auth_secret] ))
-              skip_summary: 'true'
+  Migrate to:
 
       summary:
         needs: scan
         if: always()
         runs-on: ubuntu-latest
         steps:
-          - uses: huntridge-labs/argus/.github/actions/scanner-container-summary@1.4.1
+          - uses: huntridge-labs/argus/.github/actions/security-summary@1.4.1
+            with:
+              summary_pattern: 'scanner-summary-container-*'
+              title: '🐳 Container Security Scan Results'
 
-  Note: (( )) shown above represents template syntax - use actual GitHub expressions in your workflow.
+  Background: during the Phase 3 thin-wrapper migration, `scanner-container`
+  was rewritten to call the Argus SDK (`argus scan container`) directly and
+  emit a per-container markdown summary artifact. The bespoke
+  `parse_trivy_results.py` / `parse_grype_results.py` /
+  `generate_container_summary.py` scripts this action used were removed as
+  dead code, but the references here were left dangling — which broke the
+  combined summary at 1.4.0 / 1.4.1 (issue #251). `security-summary` is the
+  canonical aggregator and already stitches `scanner-summary-*` artifacts.
 
 branding:
   icon: 'file-text'
@@ -53,72 +35,34 @@ branding:
 
 inputs:
   artifact_pattern:
-    description: 'Pattern to match scan artifacts (default: container-scan-results-*)'
+    description: |
+      Glob for the per-container summary artifacts to aggregate. Defaults to
+      the SDK-era `scanner-summary-container-*` naming emitted by
+      `scanner-container`. (The legacy `container-scan-results-*` default no
+      longer matched anything that the SDK wrapper produces.)
     required: false
-    default: 'container-scan-results-*'
+    default: 'scanner-summary-container-*'
   post_pr_comment:
     description: 'Post results as PR comment'
     required: false
     default: 'true'
 
-outputs:
-  total_vulnerabilities:
-    description: 'Total unique vulnerabilities found across all containers'
-    value: ${{ steps.summarize.outputs.total_vulns }}
-  critical_count:
-    description: 'Number of critical vulnerabilities'
-    value: ${{ steps.summarize.outputs.critical }}
-  high_count:
-    description: 'Number of high vulnerabilities'
-    value: ${{ steps.summarize.outputs.high }}
-  containers_scanned:
-    description: 'Number of containers scanned'
-    value: ${{ steps.summarize.outputs.containers_scanned }}
-
 runs:
   using: 'composite'
   steps:
-    - name: Download scan artifacts
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-      with:
-        pattern: ${{ inputs.artifact_pattern }}
-        merge-multiple: false
-      continue-on-error: true
-
-    - name: List downloaded artifacts
+    - name: Deprecation notice
       shell: bash
       run: |
-        echo "📥 Downloaded artifacts:"
-        ls -la
-        for dir in container-scan-results-*/; do
-          [ -d "$dir" ] && echo "  📁 $dir" && ls -la "$dir" 2>/dev/null || true
-        done
+        echo "::warning title=Deprecated action::scanner-container-summary is deprecated and now forwards to security-summary. Migrate to huntridge-labs/argus/.github/actions/security-summary with summary_pattern: 'scanner-summary-container-*'. This shim will be removed in a future major release."
 
-    - name: Generate combined summary
-      id: summarize
-      shell: bash
-      env:
-        TRIVY_PARSER: ${{ github.action_path }}/../scanner-container/scripts/parse_trivy_results.py
-        GRYPE_PARSER: ${{ github.action_path }}/../scanner-container/scripts/parse_grype_results.py
-        GITHUB_REPOSITORY: ${{ github.repository }}
-        GITHUB_RUN_ID: ${{ github.run_id }}
-        GITHUB_SERVER_URL: ${{ github.server_url }}
-      run: |
-        python3 "${{ github.action_path }}/../scanner-container/scripts/generate_container_summary.py" --combined
-
-    - name: Upload combined summary artifact
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+    - name: Aggregate container scan summaries
+      uses: huntridge-labs/argus/.github/actions/security-summary@1.4.1
       with:
-        name: container-scan-summary
-        path: scanner-summaries/
-        retention-days: 30
-      continue-on-error: true
-
-    - name: Post PR comment
-      if: github.event_name == 'pull_request' && inputs.post_pr_comment == 'true'
-      uses: huntridge-labs/argus/.github/actions/comment-pr@1.4.1
-      with:
-        summary_file: scanner-summaries/container.md
-        comment_marker: container-scan-parallel-comment
+        summary_pattern: ${{ inputs.artifact_pattern }}
         title: '🐳 Container Security Scan Results'
-        fallback_message: 'No container scan results available'
+        post_pr_comment: ${{ inputs.post_pr_comment }}
+        comment_marker: 'container-scan-parallel-comment'
+        # No scan_statuses passed → overall_status is "unknown" and the
+        # aggregator never fails the job, matching this action's historic
+        # non-blocking summarize-only behavior.
+        fail_on_scanner_failure: 'false'

--- a/.github/workflows/container-scan-from-config.yml
+++ b/.github/workflows/container-scan-from-config.yml
@@ -154,6 +154,9 @@ jobs:
     if: always()
     steps:
       - name: Generate container scan summary
-        uses: huntridge-labs/argus/.github/actions/scanner-container-summary@1.4.1
+        uses: huntridge-labs/argus/.github/actions/security-summary@1.4.1
         with:
+          summary_pattern: 'scanner-summary-container-*'
+          title: '🐳 Container Security Scan Results'
+          comment_marker: 'container-scan-parallel-comment'
           post_pr_comment: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}

--- a/.github/workflows/container-scan-from-config.yml
+++ b/.github/workflows/container-scan-from-config.yml
@@ -135,17 +135,47 @@ jobs:
           echo "$REGISTRY_PASSWORD" | docker login "$REGISTRY" -u "$REGISTRY_USERNAME" --password-stdin
 
       - name: Run container security scanners via argus CLI
+        id: scan
         env:
           ARGUS_IMAGE_REF: ${{ matrix.image }}
           ARGUS_SCANNERS: ${{ matrix.scanners }}
           ARGUS_FAIL_ON_SEVERITY: ${{ matrix.fail_on_severity }}
           ARGUS_ENABLE_CODE_SECURITY: ${{ matrix.enable_code_security }}
+          CONTAINER_NAME: ${{ matrix.name || matrix.image }}
         run: |
+          # Write reports to a fixed dir (no timestamp) and publish the
+          # per-container markdown as a scanner-summary-container-* artifact so
+          # the scan-summary job (security-summary) can stitch it. Capture the
+          # scan exit code so the markdown is copied even when findings fail
+          # the severity gate, then re-exit with it.
+          SCAN_EXIT=0
           python -m argus scan container \
             --image "$ARGUS_IMAGE_REF" \
             --scanners "$ARGUS_SCANNERS" \
             --severity-threshold "$ARGUS_FAIL_ON_SEVERITY" \
-            --format markdown --format sarif
+            --output-dir ./container-reports \
+            --no-timestamp \
+            --format markdown --format sarif || SCAN_EXIT=$?
+
+          SAFE_NAME=$(printf '%s' "$CONTAINER_NAME" | tr '/' '-' | tr -cd '[:alnum:]._-')
+          echo "safe_name=$SAFE_NAME" >> "$GITHUB_OUTPUT"
+
+          mkdir -p scanner-summaries
+          if [ -f container-reports/container-scan.md ]; then
+            cp container-reports/container-scan.md "scanner-summaries/container-${SAFE_NAME}.md"
+          fi
+
+          exit $SCAN_EXIT
+
+      - name: Upload container summary section
+        if: always() && steps.scan.outputs.safe_name != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: scanner-summary-container-${{ steps.scan.outputs.safe_name }}
+          path: scanner-summaries/container-${{ steps.scan.outputs.safe_name }}.md
+          if-no-files-found: warn
+          retention-days: 7
+        continue-on-error: true
 
   scan-summary:
     name: Container Scan Summary

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -230,6 +230,7 @@ jobs:
           fi
 
       - name: Run security scanners via argus CLI
+        id: scan
         if: steps.build.outputs.build_success == 'true'
         env:
           ARGUS_IMAGE_REF: ${{ steps.build.outputs.full_image }}
@@ -237,12 +238,41 @@ jobs:
           ARGUS_FAIL_ON_SEVERITY: ${{ inputs.fail_on_severity }}
           ARGUS_ENABLE_CODE_SECURITY: ${{ inputs.enable_code_security }}
           ARGUS_ALLOW_FAILURE: ${{ inputs.allow_failure }}
+          CONTAINER_NAME: ${{ matrix.container.name }}
         run: |
+          # Write reports to a fixed dir (no timestamp) so the per-container
+          # markdown can be published as a scanner-summary-container-* artifact
+          # for the downstream security-summary job to stitch. Capture the scan
+          # exit code so the markdown is still copied when findings fail the
+          # gate, then re-exit with it to preserve the severity-threshold result.
+          SCAN_EXIT=0
           python -m argus scan container \
             --image "$ARGUS_IMAGE_REF" \
             --scanners "$ARGUS_SCANNERS" \
             --severity-threshold "$ARGUS_FAIL_ON_SEVERITY" \
-            --format markdown --format sarif
+            --output-dir ./container-reports \
+            --no-timestamp \
+            --format markdown --format sarif || SCAN_EXIT=$?
+
+          SAFE_NAME=$(printf '%s' "$CONTAINER_NAME" | tr '/' '-' | tr -cd '[:alnum:]._-')
+          echo "safe_name=$SAFE_NAME" >> "$GITHUB_OUTPUT"
+
+          mkdir -p scanner-summaries
+          if [ -f container-reports/container-scan.md ]; then
+            cp container-reports/container-scan.md "scanner-summaries/container-${SAFE_NAME}.md"
+          fi
+
+          exit $SCAN_EXIT
+
+      - name: Upload container summary section
+        if: always() && steps.scan.outputs.safe_name != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: scanner-summary-container-${{ steps.scan.outputs.safe_name }}
+          path: scanner-summaries/container-${{ steps.scan.outputs.safe_name }}.md
+          if-no-files-found: warn
+          retention-days: 7
+        continue-on-error: true
 
   scan-remote-image:
     name: Scan Remote Image
@@ -285,18 +315,45 @@ jobs:
           REGISTRY_USERNAME: ${{ inputs.registry_username }}
 
       - name: Run security scanners via argus CLI
+        id: scan
         env:
           ARGUS_IMAGE_REF: ${{ inputs.image_ref }}
           ARGUS_SCANNERS: ${{ inputs.scanners || 'trivy,grype,syft' }}
           ARGUS_FAIL_ON_SEVERITY: ${{ inputs.fail_on_severity }}
           ARGUS_ENABLE_CODE_SECURITY: ${{ inputs.enable_code_security }}
           ARGUS_ALLOW_FAILURE: ${{ inputs.allow_failure }}
+          CONTAINER_NAME: ${{ inputs.container_name != '' && inputs.container_name || inputs.image_ref }}
         run: |
+          # See build-and-scan: write to a fixed dir, capture exit, publish the
+          # per-container markdown as a scanner-summary-container-* artifact.
+          SCAN_EXIT=0
           python -m argus scan container \
             --image "$ARGUS_IMAGE_REF" \
             --scanners "$ARGUS_SCANNERS" \
             --severity-threshold "$ARGUS_FAIL_ON_SEVERITY" \
-            --format markdown --format sarif
+            --output-dir ./container-reports \
+            --no-timestamp \
+            --format markdown --format sarif || SCAN_EXIT=$?
+
+          SAFE_NAME=$(printf '%s' "$CONTAINER_NAME" | tr '/' '-' | tr -cd '[:alnum:]._-')
+          echo "safe_name=$SAFE_NAME" >> "$GITHUB_OUTPUT"
+
+          mkdir -p scanner-summaries
+          if [ -f container-reports/container-scan.md ]; then
+            cp container-reports/container-scan.md "scanner-summaries/container-${SAFE_NAME}.md"
+          fi
+
+          exit $SCAN_EXIT
+
+      - name: Upload container summary section
+        if: always() && steps.scan.outputs.safe_name != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: scanner-summary-container-${{ steps.scan.outputs.safe_name }}
+          path: scanner-summaries/container-${{ steps.scan.outputs.safe_name }}.md
+          if-no-files-found: warn
+          retention-days: 7
+        continue-on-error: true
 
   container-scan-summary:
     name: Container Scan Summary

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -310,16 +310,14 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Download all scan artifacts
-        if: needs.discover-containers.outputs.has_containers == 'true' || inputs.scan_mode == 'remote'
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        continue-on-error: true
-        with:
-          pattern: ${{ inputs.scan_mode == 'remote' && inputs.container_name != '' && format('container-scan-results-{0}*', inputs.container_name) || 'container-scan-results-*' }}
-
+      # security-summary self-downloads the per-container summary artifacts
+      # (scanner-summary-container-*), so no separate download step is needed.
       - name: Generate container summary
-        uses: huntridge-labs/argus/.github/actions/scanner-container-summary@1.4.1
+        uses: huntridge-labs/argus/.github/actions/security-summary@1.4.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          summary_pattern: 'scanner-summary-container-*'
+          title: '🐳 Container Security Scan Results'
+          comment_marker: 'container-scan-parallel-comment'
           post_pr_comment: ${{ inputs.post_pr_comment }}

--- a/.github/workflows/test-actions.yml
+++ b/.github/workflows/test-actions.yml
@@ -95,7 +95,7 @@ jobs:
           declare -A exceptions=(
             ["comment-pr"]="Utility action - tested indirectly by all scanner and linter actions"
             ["get-job-id"]="Utility action - tested indirectly by other jobs"
-            ["scanner-container-summary"]="Tested as part of scanner-container"
+            ["scanner-container-summary"]="Deprecated shim - forwards to security-summary (tested in test-summary job)"
             ["scanner-zap-summary"]="Tested as part of scanner-zap"
             ["security-summary"]="Tested in test-summary job"
             ["ai-summary"]="Manual-only action - triggered via dedicated ai-summary.yml workflow with user-supplied PR number"

--- a/examples/workflows/actions-container-scan-matrix.yml
+++ b/examples/workflows/actions-container-scan-matrix.yml
@@ -101,8 +101,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate combined summary
-        uses: huntridge-labs/argus/.github/actions/scanner-container-summary@1.4.1
+        uses: huntridge-labs/argus/.github/actions/security-summary@1.4.1
         with:
+          summary_pattern: 'scanner-summary-container-*'
+          title: '🐳 Container Security Scan Results'
+          comment_marker: 'container-scan-parallel-comment'
           post_pr_comment: 'true'
 
 # ============================================


### PR DESCRIPTION
## Description
`scanner-container-summary@1.4.0` (and `@1.4.1`) crash the combined-summary step with `No such file or directory`. The action references three scripts — `parse_trivy_results.py`, `parse_grype_results.py`, `generate_container_summary.py` — that **were intentionally deleted** in `bd3fc12` during the Phase 3 thin-wrapper migration (when `scanner-container` was rewritten to call the Argus SDK directly). The references were left dangling. It also still downloads the obsolete `container-scan-results-*` artifact name.

> **Note on the issue's proposed fix:** #251 suggested the scripts were "only in worktree branches" and proposed re-adding them + cutting 1.4.1. That premise was incorrect — the scripts were deleted on purpose, `1.4.1` is broken identically, and re-adding them would reintroduce raw-JSON parsers that no longer match the SDK's artifact format. `security-summary` already does this job the SDK way.

## Changes Made
- [ ] Added new scanner/workflow
- [x] Modified existing scanner/workflow
- [x] Updated documentation
- [x] Fixed bug
- [ ] Other (please specify)

### Details
`security-summary` is the canonical SDK-era aggregator: it downloads `scanner-summary-*` artifacts (which include the `scanner-summary-container-*` markdown that the SDK-backed `scanner-container` now emits), stitches them, and posts a PR comment. Rather than maintain two aggregators:

- **`scanner-container-summary` → deprecation shim.** Emits a `::warning::` and forwards to `security-summary` scoped to `summary_pattern: scanner-summary-container-*`, preserving the container title and PR-comment marker (`container-scan-parallel-comment`) so existing `@<version>` pins keep working. Removes the dead-script invocation entirely.
- **Consumers migrated to `security-summary`**: `container-scan.yml`, `container-scan-from-config.yml`, and `examples/workflows/actions-container-scan-matrix.yml`. (In `container-scan.yml` the redundant, stale `container-scan-results-*` pre-download step was dropped — `security-summary` self-downloads.)
- **Docs**: deprecation notice in the action README + catalog; decision recorded as **ADR-030**.

Dropped the action's `total_vulnerabilities` / `critical_count` / … outputs — they never functioned (the action crashed) and `security-summary` doesn't expose per-severity counts. Referencing them now yields empty strings, not an error.

**Breaking changes:** none for working setups. The shim keeps external `@scanner-container-summary` pins functional; it's slated for removal in a future major release.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

### Test Results
- `actionlint` clean on all changed workflows.
- `tests/unit/actions/` (action-schema validation) → **267 passed, 5 skipped** (validates the rewritten shim's structure).
- YAML parse OK for all changed action/workflow files; no remaining functional references to the deleted scripts.

## Security Considerations
- [x] No security impact

### Security Details
No security-relevant behavior change. comment-pr obtains its token via `actions/github-script`'s `github.token` default, so the extra composite layer in the shim doesn't affect PR-comment auth.

## AI Context Updates (.ai/)
- [x] `.ai/decisions.yaml` updated (ADR-030)
- [ ] N/A - No .ai/ updates needed

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Closes #251

## Inline-workflow uploads (now handled here — b058f70)
Migrating `container-scan.yml` / `container-scan-from-config.yml` to `security-summary` would have turned their prior loud crash into a **silent empty summary**, because those workflows run `argus scan` inline and never uploaded the per-container markdown `security-summary` stitches. Each inline scan step now mirrors `scanner-container`: writes to a fixed `--output-dir ./container-reports --no-timestamp` and publishes `container-scan.md` as a `scanner-summary-container-<name>` artifact before the summary job (scan exit code captured + re-raised so the severity gate is preserved). Consumers on the `scanner-container` composite path were always fine — it already uploads these (confirmed from golden-path consumer validation in the thread).

## Follow-ups (out of scope)
- `tests/CONTRIBUTING.md` and `docs/developer/portability-research.md` still mention the deleted script/test filenames as historical/migration context — left as-is.

