### PR TITLE
fix(mumps): port parser to the tree-sitter >=0.22 Language() API

### DIFF
--- a/.ai/errors.yaml
+++ b/.ai/errors.yaml
@@ -108,6 +108,31 @@ error_patterns:
 
     reference: "argus/scanners/mumps/taint.py (filter_charset_guarded)"
 
+  - pattern: "TypeError: Language.__init__.*argument|Parser.*set_language|tree-sitter.*bump fails all mumps unit-test legs"
+    category: scanner
+    context: |
+      A tree-sitter / py-tree-sitter upgrade (e.g. Dependabot proposing
+      >=0.22, surfaced by #247) breaks the MUMPS parser and fails every
+      mumps unit-test leg. py-tree-sitter 0.22 removed the two-arg
+      ``Language(path, name)`` constructor and ``Parser.set_language``.
+
+    root_cause: |
+      ``MumpsParser._load`` used the pre-0.22 API
+      (``Language(str(grammar), "mumps")`` + ``Parser()`` +
+      ``parser.set_language(...)``). 0.22+ requires a pre-loaded language
+      pointer wrapped in a PyCapsule and takes the language in the
+      ``Parser(language)`` constructor. The compiled ``mumps.so`` (language
+      ABI 14) itself is compatible with both lines — only the Python loader
+      changed.
+
+    solution:
+      steps:
+        - "MumpsParser now version-gates the loader (_tree_sitter_version): ≤0.21 keeps the two-arg Language + set_language; ≥0.22 loads via ctypes.cdll + PyCapsule_New(... b'tree_sitter.Language') + Parser(language)."
+        - "The [mumps] extra cap is an unpinned floor (tree-sitter>=0.20); no rebuild of the grammar .so is needed."
+        - "No Dependabot ignore is required — the dual path absorbs the API break."
+      verification: "TestTreeSitterVersionGating in test_mumps_scanner.py; full mumps suite passes on both 0.21.3 and 0.25.2"
+    reference: "argus/scanners/mumps/parser.py (_tree_sitter_version / _load_mumps_language / _build_parser) — issue #248"
+
   # ==============================================================================
   # SARIF ERRORS
   # ==============================================================================

--- a/argus/scanners/mumps/parser.py
+++ b/argus/scanners/mumps/parser.py
@@ -92,6 +92,61 @@ class ParsedSource:
         return f"{self.path}:{line}:{col}"
 
 
+def _tree_sitter_version() -> tuple[int, int]:
+    """Return the installed ``tree-sitter`` (major, minor), or ``(0, 22)``.
+
+    Selects the grammar-loading path: py-tree-sitter 0.22 dropped the
+    two-arg ``Language(path, name)`` constructor and ``Parser.set_language``
+    in favor of a pre-loaded language pointer + ``Parser(language)``.
+    Unknown / unparsable versions default to the modern path — the ≥0.22
+    line is the current release and the install floor going forward.
+    See issue #248.
+    """
+    try:
+        import importlib.metadata as _md
+
+        major, minor = _md.version("tree-sitter").split(".")[:2]
+        return (int(major), int(minor))
+    except Exception:
+        return (0, 22)
+
+
+def _load_mumps_language(language_cls, grammar_path: str):
+    """Load the compiled MUMPS grammar into a tree-sitter ``Language``.
+
+    ≤0.21 takes ``Language(path, name)``. ≥0.22 takes a single PyCapsule
+    wrapping the pointer returned by the grammar's ``tree_sitter_mumps``
+    symbol. The compiled ``mumps.so`` (language ABI 14) is compatible with
+    both lines, so the upgrade needs no grammar rebuild.
+    """
+    if _tree_sitter_version() < (0, 22):
+        return language_cls(grammar_path, "mumps")
+
+    import ctypes
+
+    capsule_new = ctypes.pythonapi.PyCapsule_New
+    capsule_new.restype = ctypes.py_object
+    capsule_new.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_void_p]
+
+    lib = ctypes.cdll.LoadLibrary(grammar_path)
+    lib.tree_sitter_mumps.restype = ctypes.c_void_p
+    capsule = capsule_new(lib.tree_sitter_mumps(), b"tree_sitter.Language", None)
+    return language_cls(capsule)
+
+
+def _build_parser(parser_cls, language):
+    """Build a ``Parser`` bound to *language* across tree-sitter versions.
+
+    ≥0.22 takes the language in the constructor (``set_language`` was
+    removed); ≤0.21 uses the no-arg constructor + ``set_language``.
+    """
+    if _tree_sitter_version() < (0, 22):
+        parser = parser_cls()
+        parser.set_language(language)
+        return parser
+    return parser_cls(language)
+
+
 class MumpsParser:
     """Lazy-initialized parser for MUMPS source files.
 
@@ -122,10 +177,8 @@ class MumpsParser:
                 f"MUMPS grammar shared library not found. Searched: {paths}. "
                 "Run scripts/build-mumps-grammar.sh or use the scanner-mumps container image.",
             )
-        cls._language = Language(str(grammar), "mumps")
-        parser = Parser()
-        parser.set_language(cls._language)
-        cls._parser = parser
+        cls._language = _load_mumps_language(Language, str(grammar))
+        cls._parser = _build_parser(Parser, cls._language)
 
     @classmethod
     def parse(cls, path: Path, source_bytes: bytes) -> ParsedSource:

--- a/argus/tests/scanners/test_mumps_scanner.py
+++ b/argus/tests/scanners/test_mumps_scanner.py
@@ -144,6 +144,65 @@ class TestGrammarLoading:
             MumpsParser.parse(Path("x.m"), b" ; empty\n")
 
 
+class TestTreeSitterVersionGating:
+    """Dual-path grammar loading across the py-tree-sitter 0.22 API break (#248).
+
+    py-tree-sitter 0.22 dropped the two-arg ``Language(path, name)``
+    constructor and ``Parser.set_language``. The parser selects the path by
+    version; CI installs only one tree-sitter, so these tests pin the branch
+    *selection* directly. The ≥0.22 grammar loader (ctypes/PyCapsule) is
+    exercised end-to-end by the real-grammar tests in test_mumps_rules.py.
+    """
+
+    def test_version_parses_major_minor(self, monkeypatch):
+        from argus.scanners.mumps import parser as pm
+        monkeypatch.setattr("importlib.metadata.version", lambda _n: "0.25.2")
+        assert pm._tree_sitter_version() == (0, 25)
+
+    def test_version_falls_back_to_modern_when_unknown(self, monkeypatch):
+        from argus.scanners.mumps import parser as pm
+
+        def _boom(_n):
+            raise RuntimeError("tree-sitter not installed")
+
+        monkeypatch.setattr("importlib.metadata.version", _boom)
+        assert pm._tree_sitter_version() == (0, 22)
+
+    def test_legacy_path_uses_two_arg_language_and_set_language(self, monkeypatch):
+        from argus.scanners.mumps import parser as pm
+        monkeypatch.setattr(pm, "_tree_sitter_version", lambda: (0, 21))
+
+        class _Lang:
+            def __init__(self, *args):
+                self.args = args
+
+        class _Parser:
+            def __init__(self, *args):
+                self.ctor_args = args
+                self.language = None
+
+            def set_language(self, lang):
+                self.language = lang
+
+        lang = pm._load_mumps_language(_Lang, "/x/mumps.so")
+        assert lang.args == ("/x/mumps.so", "mumps")
+        parser = pm._build_parser(_Parser, lang)
+        assert parser.ctor_args == ()
+        assert parser.language is lang
+
+    def test_modern_path_passes_language_to_parser_ctor(self, monkeypatch):
+        from argus.scanners.mumps import parser as pm
+        monkeypatch.setattr(pm, "_tree_sitter_version", lambda: (0, 25))
+
+        class _Parser:
+            def __init__(self, language):
+                self.language = language
+
+        sentinel = object()
+        parser = pm._build_parser(_Parser, sentinel)
+        assert parser.language is sentinel
+
+
 class _StubNode:
     """Empty AST node — has no children so walk() yields only itself
     and the call-graph builder finds zero labels / edges."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,9 +98,11 @@ browser = [
 # Apache-2.0, MITRE PR 23-4084) is not on PyPI; installing this extra only
 # brings in py-tree-sitter. Users still need either
 # ``scripts/build-mumps-grammar.sh`` (local) or the scanner-mumps container image
-# (which ships a prebuilt grammar). Pinned below 0.22 because v0.22
-# reworked Language() to require a pre-loaded library pointer.
-mumps = ["tree-sitter>=0.20,<0.22"]
+# (which ships a prebuilt grammar). MumpsParser supports both the legacy
+# two-arg ``Language(path, name)`` API (≤0.21) and the ≥0.22 PyCapsule loader,
+# so the cap is an unpinned floor — Renovate can track the current line. See
+# issue #248.
+mumps = ["tree-sitter>=0.20"]
 # All optional features
 all = ["argus-security[ai,completion,mcp,terminal,browser,mumps]"]
 


### PR DESCRIPTION
## Description
`pyproject.toml` capped the `[mumps]` extra at `tree-sitter>=0.20,<0.22` because `MumpsParser` used the pre-0.22 API (`Language(str(grammar), "mumps")` + `Parser()` + `set_language`). py-tree-sitter 0.22 removed that two-arg constructor and `set_language` in favor of a pre-loaded language pointer + `Parser(language)`, so every Dependabot bump past 0.22 (most recently #247 → 0.25.2) failed all four mumps unit-test legs. This ports the parser so the cap can come off.

## Changes Made
- [ ] Added new scanner/workflow
- [x] Modified existing scanner/workflow
- [ ] Updated documentation
- [x] Fixed bug

### Details
- **Version-gated loader** in `argus/scanners/mumps/parser.py`: `_tree_sitter_version()` selects the path — `<0.22` keeps the legacy `Language(path, "mumps")` + `Parser()` + `set_language`; `>=0.22` loads the compiled grammar via `ctypes.cdll.LoadLibrary` + `PyCapsule_New(ptr, b"tree_sitter.Language", None)` + `Parser(language)`. Unknown/unparsable versions default to the modern path. This keeps existing 0.20/0.21-pinned installs working while unblocking the current line — the dual-path approach confirmed in the issue spike.
- **Cap → unpinned floor** `tree-sitter>=0.20`, so Renovate tracks the current release.
- **No grammar rebuild**: the compiled `mumps.so` (language ABI 14) is compatible with both tree-sitter lines, so `docker/Dockerfile.mumps` and `scripts/build-mumps-grammar.sh` are untouched.
- **No Dependabot ignore to remove**: the issue mentioned one, but none exists on `main` (`dependabot.yml` has no `ignore` block) — likely from an unmerged branch. The cap bump alone re-opens upgrades.
- `.ai/errors.yaml` documents the API-break → dual-path resolution.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed

### Test Results
The full mumps suite — golden + per-rule + scanner (**139 tests**) — passes on **both** tree-sitter versions, exercising both loader paths against the same cached `mumps.so`:

```
tree-sitter 0.21.3 (legacy path): 139 passed
tree-sitter 0.25.2 (new path):    139 passed
```

Added `TestTreeSitterVersionGating` to `test_mumps_scanner.py` to pin the branch *selection* in CI (CI installs only one tree-sitter — now the latest via the unpinned floor, so it exercises the ≥0.22 path; these tests cover the `<0.22` branch regardless). `ruff` clean.

## Security Considerations
- [x] No security impact

### Security Details
No change to detection logic — all 28 M-rules and the taint/golden guards produce identical findings on the new binding (verified by the passing golden suite on both versions). The grammar `.so` is the same vetted artifact.

## AI Context Updates (.ai/)
- [x] `.ai/errors.yaml` updated (tree-sitter API-break pattern + dual-path fix)
- [ ] N/A

## Checklist
- [x] Code follows project style guidelines
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Closes #248. Unblocks the tree-sitter bumps #247 surfaced.
