### PR TITLE
docs(ai): carry forward scopes.py + #237 digest-binding prose to architecture.yaml

### DIFF
--- a/.ai/architecture.yaml
+++ b/.ai/architecture.yaml
@@ -84,6 +84,7 @@ components:
         compute_summary, diff_scans (scan-over-scan bucketing keyed off (scanner, id, location)). Consumed
         by argus view terminal (TUI ``D`` keybind, DiffScreen) and argus view browser (web UI ``/diff``
         route).
+      core/scopes.py: 'Finding scope taxonomy. scope_for_finding maps a finding to security / lint / supply-chain from each scanner''s category (linter->lint; sca/container/supply-chain->supply-chain; else security) via the live registry with a name-prefix fallback. Drives the scope-organized report output (reporters/scope_views.py).'
       viewers/: '`argus view` interfaces (optional extras)'
       viewers/__init__.py: ViewerUnavailable shared exception
       viewers/terminal/: '`argus view --interface=terminal` — Textual TUI ([terminal] extra). Includes
@@ -506,7 +507,7 @@ data_flow:
       \ each target: scan_image(trivy + grype + syft + exposure + services)\n      → If reporting.keep_raw:\
       \ copy trivy/grype/syft raw outputs and write\n        exposure-findings.json / services-findings.json\
       \ to <output_dir>/raw/<image>/\n        (the exposure / services helpers have no upstream JSON output,\
-      \ so the\n        lifecycle path synthesizes one when they produce findings)\n    → Map ContainerScanResult\
+      \ so the\n        lifecycle path synthesizes one when they produce findings)\n    → Bind to content: scan_image resolves the image's digest (RepoDigest when pulled/pushed, config Id for never-pushed local builds; best-effort, \"\" if unknown) onto ContainerScanResult.digest and each finding's metadata (image_digest + image_ref) — so results attest what was scanned, not just a mutable tag (#237). Surfaced in per-image markdown and argus-results.json/SARIF.\n    → Map ContainerScanResult\
       \ → ScanResult(scanner=\"container/<name>\", findings=combined)\n    → Same JsonReporter / SARIF\
       \ reporter pipeline as source scans —\n      argus view consumes the canonical argus-results.json\
       \ without\n      container-specific code (PR #116, ADR-018).\n\nComposite action pipeline (GitHub\
@@ -664,6 +665,7 @@ docsite:
         compute_summary, diff_scans (scan-over-scan bucketing keyed off (scanner, id, location)). Consumed
         by argus view terminal (TUI ``D`` keybind, DiffScreen) and argus view browser (web UI ``/diff``
         route).
+      core/scopes.py: 'Finding scope taxonomy. scope_for_finding maps a finding to security / lint / supply-chain from each scanner''s category (linter->lint; sca/container/supply-chain->supply-chain; else security) via the live registry with a name-prefix fallback. Drives the scope-organized report output (reporters/scope_views.py).'
       viewers/: '`argus view` interfaces (optional extras)'
       viewers/__init__.py: ViewerUnavailable shared exception
       viewers/terminal/: '`argus view --interface=terminal` — Textual TUI ([terminal] extra). Includes


### PR DESCRIPTION
## Description
Carries forward two non-rendering `.ai/architecture.yaml` prose enrichments that were deferred during the AICaC v1→v2 schema migration (#226). Documentation-only; no code or rendered-docs change.

## Changes Made
- [x] Updated documentation
- [ ] Added new scanner/workflow
- [ ] Modified existing scanner/workflow
- [ ] Fixed bug
- [ ] Other (please specify)

### Details
- Which workflows/scanners are affected? None — `.ai/` source prose only.
- What new features or fixes are included?
  - **`core/scopes.py` component blurb** added to `components.argus-sdk.structure` (and the `docsite:` mirror). Documents `scope_for_finding`: registry-derived `security` / `lint` / `supply-chain` taxonomy (`linter→lint`; `sca`/`container`/`supply-chain`→`supply-chain`; else `security`) with a `lint-*` name-prefix fallback, driving the scope-organized report output (`reporters/scope_views.py`).
  - **"Bind to content" data_flow step** (#237) added to the container-scan pipeline note. `scan_image` resolves the image digest (`RepoDigest` when pulled/pushed, config `Id` for never-pushed local builds; best-effort, `""` if unknown) onto `ContainerScanResult.digest` and each finding's `image_digest` / `image_ref` metadata.
- Any breaking changes? No.

## Testing
- [x] Manual testing performed
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Tested with different scanner combinations

### Test Results
- All six `.ai/` files validate against the AICaC v2 schemas (`TOTAL_ERRORS=0`).
- `scripts/ci/check_architecture_sync.py` — in sync with the SDK.
- Docsite builds clean (76 nodes, 12 flows); **full rendered-site diff against `main` is empty** (same `--ref`) — confirms these are non-rendering source enrichments.
- `generate_index.py --check` — `.ai/index.yaml` is up to date (no regeneration needed).
- Docsite suite: 264 passed. Full pre-push suite: 3869 passed, 21 skipped.
- Both prose claims verified against the live code (`argus/core/scopes.py`, `argus/container/scanner.py` lines 718–727, `argus/container/resources.py` `get_image_digest`).

## Security Considerations
- [x] No security impact

## AI Context Updates (.ai/)
- [x] `.ai/architecture.yaml` updated (component blurb + data_flow note)
- [ ] `.ai/workflows.yaml` updated
- [ ] `.ai/decisions.yaml` updated
- [ ] `.ai/errors.yaml` updated

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Follow-up to #226. Documents the #237 digest-binding behavior in the architecture context.