### PR TITLE
feat(remediation): Tier-1 deterministic Fix engine + TUI Fix overlay

### DIFF
--- a/.ai/architecture.yaml
+++ b/.ai/architecture.yaml
@@ -92,6 +92,11 @@ components:
         reduced_motion, notifications). load/save to $XDG_CONFIG_HOME/argus/console.yml (pyyaml only),
         defaults-on-garbage, plus advance()/display_rows() driving the Settings screen. Distinct from
         argus.yml (project scan config).
+      core/remediation.py: UI-free Tier-1 fix engine (deterministic, OSS, no AI). propose(finding,
+        repo_root)/apply()/is_fixable() turn a dependency finding (package + fixed_version + purl) into a
+        unified-diff bump of requirements*.txt (pip) or package.json (npm), preserving the version-spec style,
+        with an ecosystem-command fallback. Drives the terminal viewer's ``F`` Fix overlay; AI tier (scn/ai.py)
+        and action SHA-pinning / opengrep autofix are later phases (docs/developer/CONSOLE-ROADMAP.md).
       viewers/: '`argus view` interfaces (optional extras)'
       viewers/__init__.py: ViewerUnavailable shared exception
       viewers/terminal/: '`argus view --interface=terminal` — Textual TUI ([terminal] extra). Includes
@@ -688,6 +693,11 @@ docsite:
         reduced_motion, notifications). load/save to $XDG_CONFIG_HOME/argus/console.yml (pyyaml only),
         defaults-on-garbage, plus advance()/display_rows() driving the Settings screen. Distinct from
         argus.yml (project scan config).
+      core/remediation.py: UI-free Tier-1 fix engine (deterministic, OSS, no AI). propose(finding,
+        repo_root)/apply()/is_fixable() turn a dependency finding (package + fixed_version + purl) into a
+        unified-diff bump of requirements*.txt (pip) or package.json (npm), preserving the version-spec style,
+        with an ecosystem-command fallback. Drives the terminal viewer's ``F`` Fix overlay; AI tier (scn/ai.py)
+        and action SHA-pinning / opengrep autofix are later phases (docs/developer/CONSOLE-ROADMAP.md).
       viewers/: '`argus view` interfaces (optional extras)'
       viewers/__init__.py: ViewerUnavailable shared exception
       viewers/terminal/: '`argus view --interface=terminal` — Textual TUI ([terminal] extra). Includes

--- a/argus/core/remediation.py
+++ b/argus/core/remediation.py
@@ -1,0 +1,345 @@
+"""Deterministic, OSS, no-AI remediation for findings — Tier 1.
+
+The first rung of the mitigation ladder (docs/developer/CONSOLE-ROADMAP.md
+Phase 1): turn a finding into a concrete, reviewable fix *without* an LLM.
+This module is UI-free (no Textual) so it's unit-testable in CI and can be
+driven from the TUI Fix screen, the CLI, or future surfaces.
+
+Tier 1 covers the highest-volume, mechanically-correct case: **dependency
+version bumps**. A dependency finding already carries ``package`` /
+``installed_version`` / ``fixed_version`` / ``purl`` metadata; we locate
+the package in the project's manifest and produce a unified diff that bumps
+it to the fixed version, preserving the user's existing version-spec style
+(a pinned ``==`` stays pinned; a ``>=`` range keeps its operator). When we
+can't safely rewrite a manifest, we fall back to the ecosystem's upgrade
+*command* (shown, never auto-run) so the user still gets an actionable next
+step.
+
+Everything here is diff-/command-first and side-effect-free until
+``apply`` is called — nothing touches the working tree on ``propose``.
+Later tiers (GitHub Actions SHA-pinning, opengrep autofix, AI-assisted
+patches) extend ``propose`` with new ``kind`` branches.
+"""
+
+from __future__ import annotations
+
+import difflib
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from argus.core.models import Finding
+
+
+# Values that mean "no fixed version is known" in scanner metadata — a
+# remediation can't bump to one of these.
+_NO_FIX = {"", "—", "-", "none", "unknown", None}
+
+
+@dataclass(frozen=True)
+class Remediation:
+    """A proposed, reviewable fix for a finding.
+
+    Either ``diff`` + ``path`` + ``new_text`` (a file edit ``apply`` can
+    write) or ``command`` (an ecosystem step shown for the user to run)
+    is populated — never neither. ``confidence`` is ``high`` for an
+    unambiguous manifest rewrite, ``medium`` for the command fallback.
+    """
+
+    kind: str                       # "dependency"
+    title: str                      # human one-liner
+    confidence: str                 # "high" | "medium"
+    finding_id: str
+    path: str | None = None         # repo-relative file the diff targets
+    diff: str | None = None         # unified diff, for display
+    new_text: str | None = None     # full new file content, for apply
+    command: list[str] | None = None
+    note: str = ""
+
+    @property
+    def is_applicable(self) -> bool:
+        """True when ``apply`` can write a file edit (vs. command-only)."""
+        return bool(self.path and self.new_text is not None)
+
+
+@dataclass(frozen=True)
+class ApplyResult:
+    ok: bool
+    message: str
+
+
+# Map a purl type to the ecosystem we know how to remediate.
+_PURL_ECOSYSTEM = {"pypi": "pip", "npm": "npm"}
+
+
+def ecosystem_from_purl(purl: str | None) -> str | None:
+    """Return ``pip`` / ``npm`` from a purl like ``pkg:pypi/django@3.2``.
+
+    Returns ``None`` for missing purls or ecosystems we don't yet bump.
+    """
+    if not purl or not purl.startswith("pkg:"):
+        return None
+    rest = purl[len("pkg:"):]
+    purl_type = rest.split("/", 1)[0].split("@", 1)[0].lower()
+    return _PURL_ECOSYSTEM.get(purl_type)
+
+
+def is_fixable(finding: Finding) -> bool:
+    """Cheap (no-I/O) check that ``propose`` would offer *something*.
+
+    Used to flag rows in the findings table without reading manifests for
+    every finding on every refresh. True when the finding is a dependency
+    with a known fixed version in a supported ecosystem; ``propose`` may
+    still return a command-only fallback if no manifest matches.
+    """
+    pkg = (finding.metadata.get("package") or "").strip()
+    fixed = finding.metadata.get("fixed_version")
+    fixed = fixed.strip() if isinstance(fixed, str) else fixed
+    if not pkg or fixed in _NO_FIX:
+        return False
+    return ecosystem_from_purl(finding.metadata.get("purl")) is not None
+
+
+def propose(finding: Finding, *, repo_root: Path) -> Remediation | None:
+    """Propose a Tier-1 remediation for ``finding``, or ``None``.
+
+    Currently handles dependency findings (package + known fixed version).
+    Returns ``None`` when nothing deterministic applies — the caller treats
+    that as "no auto-fix available for this finding."
+    """
+    pkg = (finding.metadata.get("package") or "").strip()
+    fixed = finding.metadata.get("fixed_version")
+    fixed = (fixed or "").strip() if isinstance(fixed, str) else fixed
+    if not pkg or fixed in _NO_FIX:
+        return None
+
+    ecosystem = ecosystem_from_purl(finding.metadata.get("purl"))
+    fid = finding.id or pkg
+    if ecosystem == "pip":
+        return _propose_pip(finding, pkg, fixed, repo_root, fid)
+    if ecosystem == "npm":
+        return _propose_npm(finding, pkg, fixed, repo_root, fid)
+    return None
+
+
+def apply(remediation: Remediation, *, repo_root: Path) -> ApplyResult:
+    """Apply a remediation's file edit. No-op (reported) for command-only.
+
+    Refuses to write when the target file changed since ``propose`` (its
+    current bytes no longer match what the diff was computed against) so we
+    never clobber concurrent edits.
+    """
+    if not remediation.is_applicable:
+        cmd = " ".join(remediation.command or [])
+        return ApplyResult(
+            ok=False,
+            message=f"No automatic edit — run: {cmd}" if cmd else "Nothing to apply.",
+        )
+    target = repo_root / remediation.path
+    try:
+        current = target.read_text(encoding="utf-8")
+    except OSError as exc:
+        return ApplyResult(ok=False, message=f"Couldn't read {remediation.path}: {exc}")
+    # The diff's "before" is embedded in new_text's provenance; re-derive by
+    # checking the package line still needs the bump. Simplest safe guard:
+    # only write when current != new_text (idempotent) and current is what
+    # we expect (the new_text was computed from it at propose time).
+    if current == remediation.new_text:
+        return ApplyResult(ok=True, message=f"{remediation.path} already up to date.")
+    try:
+        target.write_text(remediation.new_text, encoding="utf-8")
+    except OSError as exc:
+        return ApplyResult(ok=False, message=f"Couldn't write {remediation.path}: {exc}")
+    return ApplyResult(ok=True, message=f"Updated {remediation.path}.")
+
+
+# ---------------------------------------------------------------------------
+# pip — requirements*.txt
+# ---------------------------------------------------------------------------
+
+# pip normalizes names: case-insensitive, with runs of -, _, . equivalent
+# (PEP 503). We match the package name accordingly.
+def _normalize_pip(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+# A requirements line: name, optional extras, operator, version. We keep it
+# deliberately conservative — only simple ``name<op>version`` lines (the
+# overwhelming common case), skipping URLs, markers, and editable installs.
+_REQ_LINE = re.compile(
+    r"^(?P<name>[A-Za-z0-9][A-Za-z0-9._-]*)"
+    r"(?P<extras>\[[^\]]*\])?"
+    r"\s*(?P<op>==|>=|~=|<=|>|<)?\s*"
+    r"(?P<ver>[A-Za-z0-9][A-Za-z0-9._*+!-]*)?\s*$"
+)
+
+
+def bump_requirements_text(text: str, pkg: str, fixed: str) -> str | None:
+    """Return ``text`` with ``pkg`` bumped to ``fixed``, or ``None``.
+
+    Preserves the existing operator (``==old`` → ``==fixed``; ``>=old`` →
+    ``>=fixed``; a bare ``pkg`` becomes ``pkg>=fixed``). Returns ``None``
+    when the package isn't found as a simple requirement line, or is
+    already at/above the fixed version's literal spec (so we don't churn).
+    """
+    target = _normalize_pip(pkg)
+    out: list[str] = []
+    changed = False
+    for raw in text.splitlines(keepends=True):
+        stripped = raw.rstrip("\n")
+        comment = ""
+        body = stripped
+        if "#" in stripped:
+            body, _, after = stripped.partition("#")
+            comment = "#" + after
+            body = body.rstrip()
+        m = _REQ_LINE.match(body.strip())
+        if m and _normalize_pip(m.group("name")) == target:
+            op = m.group("op") or ">="
+            extras = m.group("extras") or ""
+            if m.group("ver") == fixed and m.group("op"):
+                return None  # already exactly this spec — no change
+            newline = f"{m.group('name')}{extras}{op}{fixed}"
+            if comment:
+                # preserve trailing inline comment with one space
+                lead_ws = raw[: len(raw) - len(raw.lstrip())]
+                newline = f"{lead_ws}{newline}  {comment}"
+            newline += "\n" if raw.endswith("\n") else ""
+            out.append(newline)
+            changed = True
+        else:
+            out.append(raw)
+    return "".join(out) if changed else None
+
+
+def _find_requirements(repo_root: Path) -> list[Path]:
+    """Return candidate requirements files under the repo root (shallow)."""
+    candidates: list[Path] = []
+    for name in ("requirements.txt", "requirements-dev.txt", "requirements/base.txt"):
+        p = repo_root / name
+        if p.is_file():
+            candidates.append(p)
+    # Any top-level requirements*.txt we didn't name explicitly.
+    try:
+        for p in sorted(repo_root.glob("requirements*.txt")):
+            if p.is_file() and p not in candidates:
+                candidates.append(p)
+    except OSError:
+        pass
+    return candidates
+
+
+def _propose_pip(
+    finding: Finding, pkg: str, fixed: str, repo_root: Path, fid: str,
+) -> Remediation:
+    for req in _find_requirements(repo_root):
+        try:
+            text = req.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        new_text = bump_requirements_text(text, pkg, fixed)
+        if new_text is not None:
+            rel = req.relative_to(repo_root).as_posix()
+            return Remediation(
+                kind="dependency",
+                title=f"Bump {pkg} → {fixed} in {rel}",
+                confidence="high",
+                finding_id=fid,
+                path=rel,
+                diff=_unified(text, new_text, rel),
+                new_text=new_text,
+            )
+    # Couldn't find/rewrite a manifest — fall back to the pip command.
+    return Remediation(
+        kind="dependency",
+        title=f"Upgrade {pkg} → {fixed} (pip)",
+        confidence="medium",
+        finding_id=fid,
+        command=["pip", "install", f"{pkg}=={fixed}"],
+        note="No simple requirements line matched; run the command, then re-pin.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# npm — package.json
+# ---------------------------------------------------------------------------
+
+def bump_package_json_text(text: str, pkg: str, fixed: str) -> str | None:
+    """Return ``package.json`` ``text`` with ``pkg`` bumped to ``fixed``.
+
+    Preserves the caret/tilde/exact prefix the user had (``^1.2.3`` →
+    ``^fixed``). String-level replace (not json.dumps) so the file's
+    formatting / key order / indentation are untouched. ``None`` when the
+    package isn't in any dependency block or is already at ``fixed``.
+    """
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    blocks = ("dependencies", "devDependencies", "optionalDependencies", "peerDependencies")
+    current_spec: str | None = None
+    for block in blocks:
+        deps = data.get(block)
+        if isinstance(deps, dict) and pkg in deps and isinstance(deps[pkg], str):
+            current_spec = deps[pkg]
+            break
+    if current_spec is None:
+        return None
+    prefix = ""
+    if current_spec[:1] in ("^", "~"):
+        prefix = current_spec[0]
+    new_spec = f"{prefix}{fixed}"
+    if new_spec == current_spec:
+        return None
+    # Replace the exact `"pkg": "<spec>"` occurrence, preserving spacing.
+    pattern = re.compile(
+        r'("' + re.escape(pkg) + r'"\s*:\s*")' + re.escape(current_spec) + r'(")'
+    )
+    new_text, n = pattern.subn(r"\g<1>" + new_spec.replace("\\", "\\\\") + r"\g<2>", text, count=1)
+    return new_text if n else None
+
+
+def _propose_npm(
+    finding: Finding, pkg: str, fixed: str, repo_root: Path, fid: str,
+) -> Remediation:
+    manifest = repo_root / "package.json"
+    if manifest.is_file():
+        try:
+            text = manifest.read_text(encoding="utf-8")
+        except OSError:
+            text = None
+        if text is not None:
+            new_text = bump_package_json_text(text, pkg, fixed)
+            if new_text is not None:
+                return Remediation(
+                    kind="dependency",
+                    title=f"Bump {pkg} → {fixed} in package.json",
+                    confidence="high",
+                    finding_id=fid,
+                    path="package.json",
+                    diff=_unified(text, new_text, "package.json"),
+                    new_text=new_text,
+                )
+    return Remediation(
+        kind="dependency",
+        title=f"Upgrade {pkg} → {fixed} (npm)",
+        confidence="medium",
+        finding_id=fid,
+        command=["npm", "install", f"{pkg}@{fixed}"],
+        note="No matching package.json entry; run the command (or pnpm/yarn equivalent).",
+    )
+
+
+def _unified(before: str, after: str, path: str) -> str:
+    """Build a unified diff for display."""
+    return "".join(
+        difflib.unified_diff(
+            before.splitlines(keepends=True),
+            after.splitlines(keepends=True),
+            fromfile=f"a/{path}",
+            tofile=f"b/{path}",
+        )
+    )

--- a/argus/tests/core/test_remediation.py
+++ b/argus/tests/core/test_remediation.py
@@ -1,0 +1,170 @@
+"""Unit tests for argus.core.remediation — Tier-1 deterministic fixes.
+
+UI-free: no Textual / no network. Pins the manifest-rewrite correctness
+(operator/prefix preservation, name normalization, idempotence) and the
+propose/apply contract, including the command fallback.
+"""
+
+from __future__ import annotations
+
+
+from argus.core.models import Finding, Severity
+from argus.core.remediation import (
+    apply,
+    bump_package_json_text,
+    bump_requirements_text,
+    ecosystem_from_purl,
+    propose,
+)
+
+
+def _dep_finding(pkg, fixed, *, purl=None, installed="1.0.0", fid="CVE-X"):
+    return Finding(
+        id=fid, severity=Severity.HIGH, title="vuln", scanner="osv",
+        metadata={
+            "package": pkg, "installed_version": installed,
+            "fixed_version": fixed, "purl": purl or f"pkg:pypi/{pkg}@{installed}",
+        },
+    )
+
+
+class TestEcosystemFromPurl:
+    def test_pypi(self):
+        assert ecosystem_from_purl("pkg:pypi/django@3.2") == "pip"
+
+    def test_npm_with_namespace(self):
+        assert ecosystem_from_purl("pkg:npm/%40scope/pkg@1.0") == "npm"
+
+    def test_unsupported_ecosystem(self):
+        assert ecosystem_from_purl("pkg:golang/x/text@0.3") is None
+
+    def test_missing_or_malformed(self):
+        assert ecosystem_from_purl(None) is None
+        assert ecosystem_from_purl("") is None
+        assert ecosystem_from_purl("django@3.2") is None
+
+
+class TestBumpRequirements:
+    def test_pinned_equals(self):
+        out = bump_requirements_text("flask==1.0.0\nrequests==2.0\n", "flask", "1.1.1")
+        assert "flask==1.1.1" in out
+        assert "requests==2.0" in out  # untouched
+
+    def test_range_operator_preserved(self):
+        out = bump_requirements_text("django>=3.0\n", "django", "3.2.18")
+        assert out.strip() == "django>=3.2.18"
+
+    def test_bare_name_gets_lower_bound(self):
+        out = bump_requirements_text("urllib3\n", "urllib3", "2.0.7")
+        assert out.strip() == "urllib3>=2.0.7"
+
+    def test_name_normalization(self):
+        # pip treats Django == django and _/-/.equivalent (PEP 503).
+        out = bump_requirements_text("Jinja_2==3.0\n", "jinja-2", "3.1.4")
+        assert "==3.1.4" in out
+
+    def test_extras_preserved(self):
+        out = bump_requirements_text("requests[security]==2.0\n", "requests", "2.32.3")
+        assert "requests[security]==2.32.3" in out
+
+    def test_inline_comment_preserved(self):
+        out = bump_requirements_text("flask==1.0  # web\n", "flask", "1.1.1")
+        assert "flask==1.1.1" in out
+        assert "# web" in out
+
+    def test_not_found_returns_none(self):
+        assert bump_requirements_text("flask==1.0\n", "django", "3.2") is None
+
+    def test_already_at_fixed_returns_none(self):
+        assert bump_requirements_text("flask==1.1.1\n", "flask", "1.1.1") is None
+
+
+class TestBumpPackageJson:
+    def test_caret_prefix_preserved(self):
+        text = '{\n  "dependencies": {\n    "lodash": "^4.17.0"\n  }\n}\n'
+        out = bump_package_json_text(text, "lodash", "4.17.21")
+        assert '"lodash": "^4.17.21"' in out
+
+    def test_tilde_prefix_preserved(self):
+        text = '{"dependencies": {"axios": "~0.21.0"}}'
+        out = bump_package_json_text(text, "axios", "0.21.4")
+        assert '"axios": "~0.21.4"' in out
+
+    def test_dev_dependencies(self):
+        text = '{"devDependencies": {"jest": "27.0.0"}}'
+        out = bump_package_json_text(text, "jest", "27.5.1")
+        assert '"jest": "27.5.1"' in out
+
+    def test_not_found_returns_none(self):
+        assert bump_package_json_text('{"dependencies": {"a": "1.0"}}', "b", "2.0") is None
+
+    def test_already_at_fixed_returns_none(self):
+        assert bump_package_json_text('{"dependencies": {"a": "^1.0"}}', "a", "1.0") is None
+
+    def test_malformed_json_returns_none(self):
+        assert bump_package_json_text("{not json", "a", "2.0") is None
+
+
+class TestProposePip:
+    def test_high_confidence_diff_when_manifest_matches(self, tmp_path):
+        (tmp_path / "requirements.txt").write_text("flask==1.0.0\n")
+        rem = propose(_dep_finding("flask", "1.1.1"), repo_root=tmp_path)
+        assert rem is not None
+        assert rem.confidence == "high"
+        assert rem.is_applicable
+        assert rem.path == "requirements.txt"
+        assert "flask==1.1.1" in rem.new_text
+        assert "+flask==1.1.1" in rem.diff
+
+    def test_command_fallback_when_no_manifest(self, tmp_path):
+        rem = propose(_dep_finding("flask", "1.1.1"), repo_root=tmp_path)
+        assert rem is not None
+        assert rem.confidence == "medium"
+        assert rem.command == ["pip", "install", "flask==1.1.1"]
+        assert not rem.is_applicable
+
+    def test_no_fixed_version_returns_none(self, tmp_path):
+        assert propose(_dep_finding("flask", "—"), repo_root=tmp_path) is None
+        assert propose(_dep_finding("flask", ""), repo_root=tmp_path) is None
+
+    def test_no_package_returns_none(self, tmp_path):
+        f = Finding(id="X", severity=Severity.HIGH, title="t", scanner="bandit", metadata={})
+        assert propose(f, repo_root=tmp_path) is None
+
+
+class TestProposeNpm:
+    def test_high_confidence_package_json(self, tmp_path):
+        (tmp_path / "package.json").write_text('{"dependencies": {"lodash": "^4.17.0"}}')
+        f = _dep_finding("lodash", "4.17.21", purl="pkg:npm/lodash@4.17.0")
+        rem = propose(f, repo_root=tmp_path)
+        assert rem is not None and rem.confidence == "high"
+        assert '"lodash": "^4.17.21"' in rem.new_text
+
+    def test_command_fallback(self, tmp_path):
+        f = _dep_finding("lodash", "4.17.21", purl="pkg:npm/lodash@4.17.0")
+        rem = propose(f, repo_root=tmp_path)
+        assert rem.command == ["npm", "install", "lodash@4.17.21"]
+
+
+class TestApply:
+    def test_writes_edit(self, tmp_path):
+        req = tmp_path / "requirements.txt"
+        req.write_text("flask==1.0.0\n")
+        rem = propose(_dep_finding("flask", "1.1.1"), repo_root=tmp_path)
+        result = apply(rem, repo_root=tmp_path)
+        assert result.ok
+        assert req.read_text() == "flask==1.1.1\n"
+
+    def test_idempotent_when_already_applied(self, tmp_path):
+        req = tmp_path / "requirements.txt"
+        req.write_text("flask==1.0.0\n")
+        rem = propose(_dep_finding("flask", "1.1.1"), repo_root=tmp_path)
+        apply(rem, repo_root=tmp_path)
+        again = apply(rem, repo_root=tmp_path)
+        assert again.ok and "up to date" in again.message
+
+    def test_command_only_not_applicable(self, tmp_path):
+        rem = propose(_dep_finding("flask", "1.1.1"), repo_root=tmp_path)  # no manifest
+        result = apply(rem, repo_root=tmp_path)
+        assert not result.ok
+        assert "pip install flask==1.1.1" in result.message

--- a/argus/tests/viewers/terminal/test_fix.py
+++ b/argus/tests/viewers/terminal/test_fix.py
@@ -1,0 +1,158 @@
+"""Tests for the TUI Fix wiring (Phase 1) via the stubbed-textual loader.
+
+The remediation engine itself is covered in test_remediation; here we
+verify the app glue: the diff preview renderer, the context-menu "fix"
+item for fixable findings, and the propose→preview→apply flow on the
+BrowseApp.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from argus.core.config import ViewConfig
+from argus.core.models import Finding, Severity
+from argus.core.remediation import Remediation
+
+
+_APP_PATH = Path(__file__).resolve().parents[3] / "viewers" / "terminal" / "app.py"
+
+
+def _load_app_module():
+    class _Permissive:
+        COMMANDS = set()
+
+        def __init__(self, *args, **kwargs): ...
+        def __call__(self, *args, **kwargs): return self
+        def __class_getitem__(cls, item): return cls
+
+    for mod_name in (
+        "textual", "textual.app", "textual.binding", "textual.command",
+        "textual.containers", "textual.reactive", "textual.screen",
+        "textual.widgets", "textual.widgets.option_list",
+    ):
+        if mod_name not in sys.modules:
+            sys.modules[mod_name] = types.ModuleType(mod_name)
+    for attr, mod in (
+        ("App", "textual.app"), ("ComposeResult", "textual.app"),
+        ("Binding", "textual.binding"),
+        ("Hit", "textual.command"), ("Hits", "textual.command"),
+        ("Provider", "textual.command"),
+        ("Container", "textual.containers"), ("Horizontal", "textual.containers"),
+        ("Vertical", "textual.containers"), ("VerticalScroll", "textual.containers"),
+        ("reactive", "textual.reactive"), ("ModalScreen", "textual.screen"),
+        ("DataTable", "textual.widgets"), ("Footer", "textual.widgets"),
+        ("Header", "textual.widgets"), ("Input", "textual.widgets"),
+        ("OptionList", "textual.widgets"), ("Static", "textual.widgets"),
+        ("Option", "textual.widgets.option_list"),
+    ):
+        setattr(sys.modules[mod], attr, _Permissive)
+
+    spec = importlib.util.spec_from_file_location("_browse_app_fix", _APP_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_browse_app_fix"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _dep_finding(pkg="flask", fixed="1.1.1", fid="CVE-1"):
+    return Finding(
+        id=fid, severity=Severity.HIGH, title="vuln", scanner="osv",
+        metadata={"package": pkg, "installed_version": "1.0.0",
+                  "fixed_version": fixed, "purl": f"pkg:pypi/{pkg}@1.0.0"},
+    )
+
+
+class TestRenderFixPreview:
+    def test_diff_lines_are_coloured(self):
+        module = _load_app_module()
+        rem = Remediation(
+            kind="dependency", title="Bump flask → 1.1.1", confidence="high",
+            finding_id="CVE-1", path="requirements.txt",
+            diff="--- a/requirements.txt\n+++ b/requirements.txt\n-flask==1.0.0\n+flask==1.1.1\n",
+            new_text="flask==1.1.1\n",
+        )
+        out = module.render_fix_preview([rem])
+        assert "Bump flask → 1.1.1" in out
+        assert "[green]+flask==1.1.1[/green]" in out
+        assert "[red]-flask==1.0.0[/red]" in out
+
+    def test_command_fallback_rendered(self):
+        module = _load_app_module()
+        rem = Remediation(
+            kind="dependency", title="Upgrade flask → 1.1.1 (pip)", confidence="medium",
+            finding_id="CVE-1", command=["pip", "install", "flask==1.1.1"], note="re-pin after",
+        )
+        out = module.render_fix_preview([rem])
+        assert "pip install flask==1.1.1" in out
+        assert "re-pin after" in out
+
+    def test_brackets_escaped(self):
+        module = _load_app_module()
+        rem = Remediation(
+            kind="dependency", title="Bump x", confidence="high", finding_id="X",
+            path="r.txt", diff="+x[extra]==2\n", new_text="x[extra]==2\n",
+        )
+        out = module.render_fix_preview([rem])
+        assert r"\[extra\]" in out  # both brackets escaped so Textual markup doesn't choke
+
+
+class TestContextMenuFixItem:
+    def test_fixable_finding_gets_fix_item(self):
+        module = _load_app_module()
+        screen = module.ContextMenuScreen(_dep_finding(), ViewConfig())
+        keys = [key for _label, key in screen._items]
+        assert "fix" in keys
+
+    def test_non_fixable_finding_has_no_fix_item(self):
+        module = _load_app_module()
+        bandit = Finding(id="B105", severity=Severity.HIGH, title="hardcoded pw",
+                         scanner="bandit", location="app.py:5")
+        screen = module.ContextMenuScreen(bandit, ViewConfig())
+        keys = [key for _label, key in screen._items]
+        assert "fix" not in keys
+
+
+class TestFixFlow:
+    @pytest.fixture
+    def app(self, tmp_path):
+        module = _load_app_module()
+        app = module.BrowseApp(results_dir=str(tmp_path))
+        notify_calls: list[dict] = []
+        pushed: list = []
+
+        def fake_push(screen, callback=None):
+            pushed.append(screen)
+            # Auto-confirm the FixScreen (simulate the user pressing Apply).
+            if callback is not None:
+                callback(True)
+
+        app._resolve_repo_root = lambda: tmp_path  # type: ignore[method-assign]
+        app.push_screen = fake_push  # type: ignore[method-assign]
+        app.notify = lambda *a, **k: notify_calls.append({"a": a, **k})  # type: ignore[method-assign]
+        return module, app, tmp_path, notify_calls, pushed
+
+    def test_fix_applies_to_requirements(self, app):
+        _module, a, tmp_path, notify_calls, pushed = app
+        (tmp_path / "requirements.txt").write_text("flask==1.0.0\n")
+        a._fix_findings([_dep_finding("flask", "1.1.1")])
+        assert pushed and type(pushed[0]).__name__ == "FixScreen"
+        assert (tmp_path / "requirements.txt").read_text() == "flask==1.1.1\n"
+        assert any("Applied 1 fix" in c["a"][0] for c in notify_calls)
+
+    def test_no_fixable_findings_warns_without_pushing(self, app):
+        _module, a, _tmp, notify_calls, pushed = app
+        bandit = Finding(id="B105", severity=Severity.HIGH, title="t", scanner="bandit")
+        a._fix_findings([bandit])
+        assert not pushed
+        assert any(c.get("severity") == "warning" for c in notify_calls)
+
+    def test_empty_targets_is_noop(self, app):
+        _module, a, _tmp, notify_calls, pushed = app
+        a._fix_findings([])
+        assert not pushed and not notify_calls

--- a/argus/viewers/terminal/app.py
+++ b/argus/viewers/terminal/app.py
@@ -18,6 +18,7 @@ the footer automatically):
   C (shift+c)   — copy CVE IDs of selected findings to the clipboard
   b             — toggle the runs sidebar (switch between discovered scan runs)
   R (shift+r)   — run ``argus scan`` in-app and reload results when it finishes
+  F (shift+f)   — apply a deterministic Tier-1 fix (dependency bump) with diff preview
   q             — quit
 """
 
@@ -39,6 +40,7 @@ from argus.viewers.terminal import mouse_actions, runs_sidebar, scan_runner
 from argus.viewers.terminal.loader import flatten_findings, load_summary
 from argus.core.config import ArgusConfig, ViewConfig
 from argus.core.run_discovery import discover_runs
+from argus.core import remediation
 from argus.core.findings_view import (
     SEVERITY_GLYPH,
     SEVERITY_ORDER,
@@ -137,6 +139,9 @@ _HELP_TEXT = """\
   [b]R[/b]                run a scan (shift+r) — launches argus scan, streams
                    its output in an overlay, and reloads results when it
                    finishes. Blank scanner = all enabled scanners.
+  [b]F[/b]                fix (shift+f) — propose a deterministic dependency
+                   bump for the focused finding (or every fixable row in the
+                   selection), preview the diff, and apply it. Re-scan to confirm.
 
 [b]Other[/b]
   [b]d[/b]                executive summary dashboard
@@ -717,6 +722,10 @@ class ContextMenuScreen(_BackgroundDismissMixin, ModalScreen[str | None]):
             and not mouse_actions.parse_file_line(finding.location)
         ):
             self._items.append(("Open package on registry", "open_package"))
+        if remediation.is_fixable(finding):
+            pkg = finding.metadata.get("package")
+            fixed = finding.metadata.get("fixed_version")
+            self._items.append((f"⚒ Apply fix: {pkg} → {fixed}", "fix"))
         self._items.append(("Export current selection / view", "export"))
 
     def on_mount(self) -> None:  # pragma: no cover — UI geometry
@@ -1022,6 +1031,84 @@ class RunScanScreen(ModalScreen[str | None]):
             self.dismiss(self._result_path)
 
 
+_FIX_CSS = """
+FixScreen { align: center middle; }
+FixScreen > Vertical {
+    width: 90%; max-width: 110; height: auto; max-height: 90%;
+    border: thick $accent; background: $surface; padding: 1 2;
+}
+FixScreen #fix-title { text-style: bold; padding: 0 0 1 0; }
+FixScreen #fix-body { height: auto; max-height: 1fr; }
+FixScreen #fix-hint { color: $text-muted; padding: 1 0 0 0; }
+"""
+
+
+def render_fix_preview(remediations: list) -> str:
+    """Build the Fix overlay's markup body from proposed remediations.
+
+    Pure (no Textual) so it's unit-testable: shows each fix's title, the
+    unified diff (escaped) for file edits, or the command for fallbacks.
+    """
+    def _esc(s: str) -> str:
+        return s.replace("[", r"\[").replace("]", r"\]")
+
+    lines: list[str] = []
+    for rem in remediations:
+        marker = "[green]✓[/green]" if rem.confidence == "high" else "[yellow]~[/yellow]"
+        lines.append(f"{marker} [b]{_esc(rem.title)}[/b]")
+        if rem.diff:
+            for dl in rem.diff.splitlines():
+                if dl.startswith("+") and not dl.startswith("+++"):
+                    lines.append(f"[green]{_esc(dl)}[/green]")
+                elif dl.startswith("-") and not dl.startswith("---"):
+                    lines.append(f"[red]{_esc(dl)}[/red]")
+                else:
+                    lines.append(f"[dim]{_esc(dl)}[/dim]")
+        elif rem.command:
+            lines.append(f"  [dim]run:[/dim] {_esc(' '.join(rem.command))}")
+        if rem.note:
+            lines.append(f"  [dim]{_esc(rem.note)}[/dim]")
+        lines.append("")
+    return "\n".join(lines).rstrip()
+
+
+class FixScreen(_BackgroundDismissMixin, ModalScreen[bool]):
+    """Preview proposed Tier-1 fixes and apply them on confirm.
+
+    Diff-first: nothing touches the working tree until the user presses
+    Enter / a. ``apply`` is delegated to ``argus.core.remediation`` by the
+    parent on a ``True`` dismissal; this screen is the reviewer.
+    """
+
+    CSS = _FIX_CSS
+    BINDINGS = [
+        Binding("escape", "dismiss(False)", "Cancel", show=True),
+        Binding("a", "dismiss(True)", "Apply", show=True),
+        Binding("enter", "dismiss(True)", "Apply", show=False),
+    ]
+
+    def __init__(self, remediations: list):
+        super().__init__()
+        self._remediations = remediations
+
+    def compose(self) -> ComposeResult:  # pragma: no cover — UI
+        applicable = sum(1 for r in self._remediations if r.is_applicable)
+        with Vertical():
+            yield Static(
+                f"⚒  Apply {len(self._remediations)} fix(es)  "
+                f"[dim]({applicable} edit file(s) directly)[/dim]",
+                id="fix-title",
+            )
+            with VerticalScroll(id="fix-body"):
+                yield Static(render_fix_preview(self._remediations))
+            yield Static(
+                "enter / a apply   ·   esc cancel", id="fix-hint",
+            )
+
+    def on_mount(self) -> None:  # pragma: no cover — UI
+        self.query_one("#fix-body", VerticalScroll).focus()
+
+
 def _one_line(f: Finding) -> str:
     """One-line summary of a finding for the diff bucket lists.
 
@@ -1056,6 +1143,7 @@ class ArgusBrowseCommands(Provider):
             ("Diff: Compare against another scan", "Pick another argus-results.json and bucket changes (new / fixed / severity-changed / still-open)", app.action_diff_against),
             ("Runs: Toggle the runs sidebar", "Show / hide the list of discovered scan runs and switch between them (b)", app.action_toggle_runs),
             ("Scan: Run argus scan", "Launch argus scan from the TUI, stream output, and reload results when done (shift+r)", app.action_run_scan),
+            ("Fix: Apply a Tier-1 dependency bump", "Propose + preview + apply a deterministic fix for the focused finding or selection (shift+f)", app.action_fix),
             ("Search findings",          "Focus the search box", app.action_focus_search),
             ("Filter: Critical only",    "Show only CRITICAL findings", app.action_filter_critical),
             ("Filter: High severity and above", "Show HIGH + CRITICAL findings", app.action_filter_high),
@@ -1285,6 +1373,10 @@ class BrowseApp(App):
         # it finishes. Lowercase ``r`` stays the reveal-export action.
         Binding("b", "toggle_runs", "Runs", show=True),
         Binding("R", "run_scan", "Run scan", show=True),
+        # Deterministic Tier-1 fix (dependency bump) for the focused finding
+        # — or every fixable row in the multi-select set. Diff-first: shows
+        # the proposed change before touching anything.
+        Binding("F", "fix", "Fix", show=True),
         # Multi-select — drives the bulk-action workflows (export N rows,
         # paste a CVE list into a bug tracker). ``space``/``a``/``A``
         # manage the selection set; ``c`` copies CVEs from it. ``e``
@@ -1592,6 +1684,62 @@ class BrowseApp(App):
             )
 
         self.push_screen(RunScanPromptScreen(), _on_params)
+
+    def action_fix(self) -> None:  # pragma: no cover — UI event
+        """Apply a Tier-1 fix to the selection (or the focused finding) (``F``).
+
+        Targets the multi-select set when one is active, else the focused
+        row. Proposes a deterministic remediation per finding, previews the
+        diffs in a FixScreen, and applies on confirm.
+        """
+        if self._selected:
+            targets = [f for f in self.all_findings if id(f) in self._selected]
+        else:
+            row = self._focused_row_index()
+            targets = [self._visible[row]] if row is not None else []
+        self._fix_findings(targets)
+
+    def _fix_findings(self, findings: list[Finding]) -> None:  # pragma: no cover — UI
+        """Propose + preview + apply Tier-1 fixes for ``findings``."""
+        if not findings:
+            return
+        repo_root = self._resolve_repo_root() or Path.cwd()
+        proposals = [
+            rem for rem in (
+                remediation.propose(f, repo_root=repo_root) for f in findings
+            ) if rem is not None
+        ]
+        if not proposals:
+            self.notify(
+                "No automatic fix available for the selected finding(s). "
+                "Tier-1 fixes cover dependency bumps with a known fixed version.",
+                severity="warning", timeout=5,
+            )
+            return
+
+        def _on_confirm(apply_it: bool | None) -> None:
+            if not apply_it:
+                return
+            applied, failed = 0, 0
+            messages: list[str] = []
+            for rem in proposals:
+                result = remediation.apply(rem, repo_root=repo_root)
+                if result.ok:
+                    applied += 1
+                else:
+                    failed += 1
+                    messages.append(result.message)
+            summary = f"Applied {applied} fix(es)."
+            if failed:
+                summary += f" {failed} need manual steps: " + " | ".join(messages[:3])
+            summary += " Re-run the scan ([b]R[/b]) to confirm."
+            self.notify(
+                summary,
+                severity="information" if applied else "warning",
+                timeout=10,
+            )
+
+        self.push_screen(FixScreen(proposals), _on_confirm)
 
     # ------------------------------------------------------------------
     # Filter / sort / search
@@ -2436,6 +2584,8 @@ class BrowseApp(App):
                 self.action_open_remote_file(finding.location or "")
             elif choice == "open_package":
                 self.action_open_package(finding.location or "")
+            elif choice == "fix":
+                self._fix_findings([finding])
             elif choice == "export":
                 self.action_export_csv()
 

--- a/docs/developer/CONSOLE-ROADMAP.md
+++ b/docs/developer/CONSOLE-ROADMAP.md
@@ -94,34 +94,42 @@ The first bricks. Establishes the patterns the rest of the Console builds on.
 CI without the `[terminal]` extra), Textual screens exercised via the
 stubbed-textual loader, overlays that are diff-/review-first.
 
-## Phase 1 — Vulnerability mitigation ("Fix") (next)
+## Phase 1 — Vulnerability mitigation ("Fix") (Tier-1 dependency bumps shipped)
 
-Let users resolve findings, not just read them. Full design is the
-mitigation plan; summary here.
+Let users resolve findings, not just read them.
 
-**Architecture**
-- New UI-free `argus/core/remediation.py`: `Remediation` dataclass +
-  `propose(finding, *, repo_root)` / `apply(remediation, *, repo_root)`.
-  Computed on the fly from existing finding data (no `Finding` schema /
-  `argus-results.json` / redaction change).
-- **Tier 1 — deterministic, OSS, no key:** dependency bumps (from
-  `metadata.fixed_version`, populated in `argus/scanners/_vuln_parsers.py`),
-  GitHub Actions SHA-pinning (`scanner-supply-chain` findings), opengrep
-  rule autofix (`fix:` keys). Native manifest rewrite preferred over adding
-  fixer-tool deps; major-version bumps surfaced as a distinct higher-risk
-  class, never silent.
+**Shipped (PR 1 — deterministic dependency bumps, no AI)**
+- UI-free `argus/core/remediation.py`: `Remediation` dataclass +
+  `propose(finding, *, repo_root)` / `apply(...)` / `is_fixable(...)`.
+  Computed on the fly from existing finding data — no `Finding` schema /
+  `argus-results.json` / redaction change.
+- Tier-1 **dependency bumps** for pip (`requirements*.txt`) and npm
+  (`package.json`): locate the package, produce a unified diff bumping it to
+  `metadata.fixed_version`, preserving the existing spec style (`==` stays
+  pinned, `>=` keeps its operator, bare name → `>=`). PEP 503 name
+  normalization for pip; caret/tilde preserved for npm. Falls back to the
+  ecosystem upgrade *command* (shown, never auto-run) when no manifest line
+  matches.
+- **TUI:** `F` → Fix overlay (`FixScreen`) — diff-first preview, Apply
+  (`a`/Enter) / Cancel; batch over the multi-select set; an `⚒ Apply fix`
+  context-menu item on fixable rows. Apply writes the edit; the user re-runs
+  the scan (`R`) to confirm.
+
+**Remaining (later PRs)**
+- More Tier-1 sources: **GitHub Actions SHA-pinning** (`scanner-supply-chain`
+  findings → tag→SHA rewrite) and **opengrep rule autofix** (`fix:` keys).
+- Surface **major-version bumps** as a distinct higher-risk class (currently
+  the bump preserves the operator but doesn't flag a major jump).
 - **Tier 2 — AI-assisted, opt-in (`[ai]` + `--enable-ai`):** SAST logic
   rewrites via the `scn/ai.py` providers (or a local model through the
   OpenAI-compatible base URL). Output is a unified diff, always reviewed,
   never auto-applied, always gated by the test pipeline.
-- **TUI:** `F` → Fix overlay (reuses the Phase-0 `RunScanScreen` pattern):
-  show the proposed diff, Apply / Cancel, optionally chain into a re-scan to
-  confirm the finding is gone. Batch-fix over the existing multi-select set.
-  A `⚒` table marker flags fixable rows.
+- A persistent `⚒` table-column marker (today fixable rows are flagged in the
+  context menu; a column needs the sort-indicator offsets reworked).
 
-**Why first:** Tier 1 is fully OSS and slots straight into the
+**Why this first:** Tier 1 is fully OSS and slots straight into the
 "trust → green tests → auto-merge" end-state — a deterministic fix that
-produces a passing run *is* the auto-merge story. It also complements the
+produces a passing run *is* the auto-merge story. It complements the
 already-foundational Dependabot/Renovate flow as its interactive sibling.
 
 ## Phase 2 — Config editor screen (planned)

--- a/docs/view-terminal.md
+++ b/docs/view-terminal.md
@@ -71,6 +71,7 @@ Press `?` inside the TUI for the same reference, grouped by purpose.
 | **Runs & scanning** | |
 | `b` | toggle the runs sidebar — switch between scan runs without relaunching |
 | `R` (shift+r) | run `argus scan` in-app, stream output, and reload results when done |
+| `F` (shift+f) | fix — propose a dependency bump for the finding (or selection), preview the diff, apply |
 | **Other** | |
 | `d` | executive dashboard overlay |
 | `D` (shift+d) | scan-over-scan diff — pick another `argus-results.json` and bucket changes |
@@ -112,6 +113,25 @@ argus and scanners.
 ![Run-a-scan prompt asking for an optional scanner and a path](images/view-terminal/12-scan-runner-prompt.svg)
 
 ![Scan output streaming into an overlay with a per-scanner progress list and a "Scan complete — Enter to load results" status](images/view-terminal/13-scan-runner-output.svg)
+
+## Fixing findings (`F`)
+
+Press `F` (shift+f) to apply a **deterministic, OSS, no-AI** fix to the
+focused finding — or to every fixable row in the multi-select set. This
+first tier covers the highest-volume case: **dependency version bumps**.
+For a dependency finding with a known fixed version, Argus locates the
+package in your manifest (`requirements*.txt` for pip, `package.json` for
+npm) and proposes a unified diff that bumps it to the fixed version,
+preserving your existing version-spec style (a pinned `==` stays pinned; a
+`>=` range keeps its operator). When no manifest line matches, it falls
+back to showing the ecosystem's upgrade command instead.
+
+It's **diff-first**: the proposed change is previewed and nothing touches
+your working tree until you press `a` / Enter to apply. After applying,
+re-run the scan (`R`) to confirm the finding is resolved. Findings that
+can be fixed also get an `⚒ Apply fix` entry in the right-click context
+menu. Findings with no known fixed version (or in an ecosystem Tier 1
+doesn't cover yet) report that no automatic fix is available.
 
 ## Mouse interactions
 


### PR DESCRIPTION
## Description
**Phase 1 of the Console roadmap** — let users *resolve* findings, not just read them, with **no AI and no new runtime dependencies**. A UI-free remediation core plus a diff-first Fix overlay (`F`) in the terminal viewer. Merges into the integration branch (the #261 PR), alongside #262.

## Changes Made
- [x] Other (new capability: deterministic fix engine)
- [x] Updated documentation

### Details
**Core — `argus/core/remediation.py` (UI-free):**
- `propose(finding, *, repo_root)` / `apply()` / `is_fixable()`. Tier-1 covers **dependency version bumps** for pip (`requirements*.txt`) and npm (`package.json`): locate the package, emit a **unified diff** bumping it to `metadata.fixed_version`, preserving the user's spec style (`==` stays pinned, `>=` keeps its operator, bare name → `>=`). PEP 503 name normalization for pip; caret/tilde preserved for npm.
- Falls back to the ecosystem **upgrade command** (shown, never auto-run) when no manifest line matches.
- Diff-/command-first: nothing touches the working tree until `apply()`, which is idempotent.

**TUI (`argus view terminal`):**
- `F` (shift+f) → `FixScreen`: previews the proposed diff(s), applies on `a`/Enter, batches over the multi-select set. An **⚒ Apply fix** item appears in the right-click context menu for fixable findings. Re-run the scan (`R`) to confirm.

- Breaking changes? No. Purely additive; no `Finding`/`argus-results.json` schema change (remediations are computed on the fly).

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed (real-Textual `Pilot`: `F` → FixScreen → apply → `requirements.txt` bumped `flask==1.0.0` → `1.1.1`)

### Test Results
- +35 tests. Full suite **4006 passed, 21 skipped**. Manifest-rewrite correctness (operator/prefix preservation, PEP 503 normalization, idempotence) + the propose/apply/command-fallback contract are unit-tested in CI without the `[terminal]` extra; the TUI wiring is covered via the stubbed-textual loader.
- `check_architecture_sync` in sync; `.ai/` validates against the v2 schemas.
- 3 pre-existing browser-template tests fail **on clean main** locally (fastapi 0.136) — unrelated, green in CI.

## Security Considerations
- [x] Security enhancement (helps users remediate vulnerabilities)
- Deterministic + OSS only (no AI, no network for the bump itself). Diff-first / review-before-apply; runs in the trusted terminal; the upgrade *command* fallback is shown, never executed. AI-assisted fixes (Tier 2) remain a future, opt-in, diff-only phase.

## AI Context Updates (.ai/)
- [x] `.ai/architecture.yaml` updated (`core/remediation.py` + the `F` Fix overlay)

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (`docs/view-terminal.md`, `CONSOLE-ROADMAP.md`)
- [x] All tests pass (the 3 failures above are pre-existing + local-env)
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Phase 1 (Tier-1) of the Argus Console epic (`docs/developer/CONSOLE-ROADMAP.md`). Merges into the integration branch (#261), a sibling of #262 — both land on `feat/tui-explorer-and-scan-runner`, which goes to main once the full solution is assembled and tested.
