### PR TITLE
feat(console): form editor for argus.yml (Configure screen)

### DIFF
--- a/.ai/architecture.yaml
+++ b/.ai/architecture.yaml
@@ -106,7 +106,9 @@ components:
         RunScanPromptScreen + RunScanScreen stream it) and reloads results when it finishes. Right-click context
         menus anchor at the cursor via mouse_actions.clamp_menu_offset. console.py + console_model.py provide the
         Argus Console — the home launcher (scan / findings / configure / init / settings / docs) with a
-        live-themed Settings screen backed by argus.core.console_config; bare ``argus`` opens it in an interactive
+        live-themed Settings screen backed by argus.core.console_config and a Configure form editor (ConfigScreen)
+        for argus.yml backed by config_editor.py (UI-free, comment-preserving targeted line edits + schema validation);
+        bare ``argus`` opens it in an interactive
         TTY (cli._run_bare_argus), falling back to --help when non-interactive, and ``argus view`` deep-links to
         the findings viewer.'
       viewers/browser/: '`argus view --interface=browser` — FastAPI + Jinja2 web UI, 127.0.0.1 only ([browser]
@@ -707,7 +709,9 @@ docsite:
         RunScanPromptScreen + RunScanScreen stream it) and reloads results when it finishes. Right-click context
         menus anchor at the cursor via mouse_actions.clamp_menu_offset. console.py + console_model.py provide the
         Argus Console — the home launcher (scan / findings / configure / init / settings / docs) with a
-        live-themed Settings screen backed by argus.core.console_config; bare ``argus`` opens it in an interactive
+        live-themed Settings screen backed by argus.core.console_config and a Configure form editor (ConfigScreen)
+        for argus.yml backed by config_editor.py (UI-free, comment-preserving targeted line edits + schema validation);
+        bare ``argus`` opens it in an interactive
         TTY (cli._run_bare_argus), falling back to --help when non-interactive, and ``argus view`` deep-links to
         the findings viewer.'
       viewers/browser/: '`argus view --interface=browser` — FastAPI + Jinja2 web UI, 127.0.0.1 only ([browser]

--- a/argus/tests/viewers/terminal/test_config_editor.py
+++ b/argus/tests/viewers/terminal/test_config_editor.py
@@ -1,0 +1,146 @@
+"""Unit tests for argus.viewers.terminal.config_editor (Phase 2).
+
+UI-free: no Textual. Pins comment-/format-preserving targeted edits,
+the editable-row model, toggle/enum cycling, and validation.
+"""
+
+from __future__ import annotations
+
+from argus.viewers.terminal.config_editor import (
+    EditRow,
+    apply_row,
+    editable_rows,
+    set_value,
+    validate,
+)
+
+
+SAMPLE = """\
+version: "1.0"
+scanners:
+  bandit:
+    enabled: true
+  gitleaks:
+    enabled: false
+reporting:
+  severity_threshold: high  # fail gate
+  output_dir: "./argus-results"
+execution:
+  backend: auto
+  pull_policy: if-not-present
+view:
+  cve_source: nvd
+  open_location: ask
+"""
+
+
+class TestEditableRows:
+    def test_scanner_toggles_and_scalars(self):
+        rows = {r.key: r for r in editable_rows(SAMPLE)}
+        assert rows["scanner:bandit"].value == "on"
+        assert rows["scanner:gitleaks"].value == "off"
+        assert rows["reporting.severity_threshold"].value == "high"
+        assert rows["execution.backend"].value == "auto"
+        assert rows["execution.pull_policy"].value == "if-not-present"
+        assert rows["view.cve_source"].value == "nvd"
+        assert rows["view.open_location"].value == "ask"
+
+    def test_enum_rows_carry_options(self):
+        rows = {r.key: r for r in editable_rows(SAMPLE)}
+        assert rows["view.cve_source"].kind == "enum"
+        assert "github" in rows["view.cve_source"].options
+
+    def test_absent_settings_not_offered(self):
+        rows = {r.key: r for r in editable_rows("scanners:\n  bandit:\n    enabled: true\n")}
+        assert "reporting.severity_threshold" not in rows
+        assert "scanner:bandit" in rows
+
+    def test_scanner_without_enabled_skipped(self):
+        rows = {r.key: r for r in editable_rows("scanners:\n  bandit:\n    path: src\n")}
+        assert "scanner:bandit" not in rows
+
+    def test_malformed_yaml_returns_empty(self):
+        assert editable_rows("{not: valid: yaml:") == []
+
+    def test_non_mapping_returns_empty(self):
+        assert editable_rows("- a\n- b\n") == []
+
+
+class TestSetValue:
+    def test_toggle_nested_scanner_enabled(self):
+        out = set_value(SAMPLE, ["scanners", "bandit", "enabled"], "false")
+        assert "  bandit:\n    enabled: false\n" in out
+        # gitleaks untouched
+        assert "  gitleaks:\n    enabled: false\n" in out
+
+    def test_only_targeted_scanner_changes(self):
+        out = set_value(SAMPLE, ["scanners", "gitleaks", "enabled"], "true")
+        assert "  bandit:\n    enabled: true\n" in out      # bandit unchanged
+        assert "  gitleaks:\n    enabled: true\n" in out
+
+    def test_section_scalar_preserves_inline_comment(self):
+        out = set_value(SAMPLE, ["reporting", "severity_threshold"], "medium")
+        assert "severity_threshold: medium  # fail gate" in out
+
+    def test_enum_scalar_edit(self):
+        out = set_value(SAMPLE, ["execution", "backend"], "docker")
+        assert "  backend: docker\n" in out
+
+    def test_path_not_found_returns_none(self):
+        assert set_value(SAMPLE, ["scanners", "nope", "enabled"], "true") is None
+        assert set_value(SAMPLE, ["reporting", "nope"], "x") is None
+
+    def test_no_op_returns_none(self):
+        assert set_value(SAMPLE, ["execution", "backend"], "auto") is None
+
+    def test_indentation_preserved(self):
+        out = set_value(SAMPLE, ["view", "cve_source"], "github")
+        assert "  cve_source: github\n" in out
+
+    def test_list_items_not_matched(self):
+        text = "formats:\n  - sarif\n  - json\nview:\n  cve_source: nvd\n"
+        # ensure the list under formats doesn't confuse path tracking
+        out = set_value(text, ["view", "cve_source"], "mitre")
+        assert "  cve_source: mitre\n" in out
+
+
+class TestRowCycling:
+    def test_toggle_next_value(self):
+        on = EditRow("scanner:x", "x", "toggle", "on", ["scanners", "x", "enabled"])
+        off = EditRow("scanner:y", "y", "toggle", "off", ["scanners", "y", "enabled"])
+        assert on.next_value() == "false"
+        assert off.next_value() == "true"
+
+    def test_enum_cycles_and_wraps(self):
+        opts = ["nvd", "cve_org", "github", "mitre"]
+        r = EditRow("view.cve_source", "cve", "enum", "mitre", ["view", "cve_source"], opts)
+        assert r.next_value() == "nvd"  # wraps
+        r2 = EditRow("view.cve_source", "cve", "enum", "nvd", ["view", "cve_source"], opts)
+        assert r2.next_value() == "cve_org"
+
+    def test_apply_row_returns_new_text_and_value(self):
+        rows = {r.key: r for r in editable_rows(SAMPLE)}
+        new_text, new_value = apply_row(SAMPLE, rows["scanner:bandit"])
+        assert new_value == "false"
+        assert "    enabled: false\n" in new_text
+
+    def test_apply_row_noop_returns_none(self):
+        # A row whose path vanished → no-op.
+        ghost = EditRow("x", "x", "toggle", "on", ["scanners", "ghost", "enabled"])
+        assert apply_row(SAMPLE, ghost) is None
+
+
+class TestValidate:
+    def test_valid_config_ok(self):
+        assert validate(SAMPLE) is None
+
+    def test_broken_yaml_reports(self):
+        msg = validate("{not: valid: yaml:")
+        assert msg and "Invalid YAML" in msg
+
+    def test_non_mapping_reports(self):
+        assert validate("- a\n- b\n") is not None
+
+    def test_edited_config_still_valid(self):
+        out = set_value(SAMPLE, ["scanners", "bandit", "enabled"], "false")
+        assert validate(out) is None

--- a/argus/tests/viewers/terminal/test_console.py
+++ b/argus/tests/viewers/terminal/test_console.py
@@ -123,10 +123,21 @@ class TestDispatch:
         app.dispatch_menu("init")
         assert calls["exit"] and calls["exit"][0] == "init"
 
-    def test_configure_edits(self, console):
+    def test_configure_opens_config_screen_when_present(self, console, tmp_path, monkeypatch):
         _module, app, calls = console
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "argus.yml").write_text("scanners:\n  bandit:\n    enabled: true\n")
+        app.dispatch_menu("configure")
+        assert "ConfigScreen" in calls["push"]
+        assert calls["edit"] == 0
+
+    def test_configure_falls_back_to_editor_when_absent(self, console, tmp_path, monkeypatch):
+        _module, app, calls = console
+        monkeypatch.chdir(tmp_path)
+        app.settings = ConsoleSettings(notifications=False)  # silence the nudge toast
         app.dispatch_menu("configure")
         assert calls["edit"] == 1
+        assert "ConfigScreen" not in calls["push"]
 
 
 class TestNotifyGating:
@@ -135,3 +146,21 @@ class TestNotifyGating:
         app.settings = ConsoleSettings(notifications=False)
         # Should return without calling super().notify (which the stub lacks).
         assert app.notify("hello") is None
+
+
+class TestConfigScreen:
+    def test_reads_file_into_working_copy(self, console, tmp_path):
+        module, _app, _calls = console
+        cfg = tmp_path / "argus.yml"
+        body = "scanners:\n  bandit:\n    enabled: true\n"
+        cfg.write_text(body)
+        screen = module.ConfigScreen(cfg)
+        assert screen._text == body
+        assert screen._original == body
+        assert screen._path == cfg
+
+    def test_missing_file_is_empty_working_copy(self, console, tmp_path):
+        module, _app, _calls = console
+        screen = module.ConfigScreen(tmp_path / "absent.yml")
+        assert screen._text == ""
+        assert screen._original == ""

--- a/argus/viewers/terminal/config_editor.py
+++ b/argus/viewers/terminal/config_editor.py
@@ -1,0 +1,190 @@
+"""UI-free config editing for the Argus Console's Config screen (Phase 2).
+
+Textual-free (imports only yaml + the config/schema layer) so it's
+unit-testable in CI without the ``[terminal]`` extra. The Console's
+``ConfigScreen`` renders the rows this module produces and previews the
+diff before writing.
+
+Editing is **comment-preserving**: rather than re-serialising the whole
+file (which would clobber the user's comments and ordering — the open
+decision in the roadmap), we make targeted in-place edits to the matched
+``key: value`` line via indentation-aware path matching. The editable set
+is bounded to toggle/enum settings (scanner enable + a handful of
+section scalars) so every edit is a single, unambiguous line rewrite. The
+result is validated by re-parsing + the existing schema checker before it
+can be saved.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+import yaml
+
+
+# Bounded enum settings (section, key) → allowed values, in cycle order.
+# Mirrors the values ``argus/core/schema.py`` accepts.
+_ENUMS: dict[tuple[str, str], list[str]] = {
+    ("reporting", "severity_threshold"): ["none", "low", "medium", "high", "critical"],
+    ("execution", "backend"): ["auto", "local", "docker"],
+    ("execution", "pull_policy"): ["always", "if-not-present", "never"],
+    ("view", "cve_source"): ["nvd", "cve_org", "github", "mitre"],
+    ("view", "open_location"): ["ask", "local", "remote"],
+}
+
+# One-line help surfaced beside each setting (the "focused docs").
+_DOCS: dict[str, str] = {
+    "scanner": "Run this scanner on each scan.",
+    "reporting.severity_threshold": "Fail the scan at or above this severity.",
+    "execution.backend": "Run tools locally, in Docker, or auto-detect.",
+    "execution.pull_policy": "When to pull scanner container images.",
+    "view.cve_source": "Advisory site opened for CVE/GHSA links in the viewer.",
+    "view.open_location": "Where file:line links open: ask, local editor, or git remote.",
+}
+
+
+@dataclass
+class EditRow:
+    """One editable setting in the Config screen."""
+
+    key: str                       # stable id, e.g. "scanner:bandit" or "view.cve_source"
+    label: str
+    kind: str                      # "toggle" | "enum"
+    value: str                     # current value, as text ("on"/"off" or the enum value)
+    path: list[str] = field(default_factory=list)   # YAML key path to the value
+    options: list[str] = field(default_factory=list)  # enum options (cycle order)
+    doc: str = ""
+
+    def next_value(self) -> str:
+        """Return the value after this row's current one (toggle / cycle)."""
+        if self.kind == "toggle":
+            return "false" if self.value in ("on", "true", "True") else "true"
+        opts = self.options or [self.value]
+        try:
+            idx = opts.index(self.value)
+        except ValueError:
+            return opts[0]
+        return opts[(idx + 1) % len(opts)]
+
+
+def editable_rows(text: str) -> list[EditRow]:
+    """Parse ``text`` (an argus.yml) into the editable rows.
+
+    Only settings actually present in the file are offered, so every row
+    maps to a real line we can rewrite. Returns ``[]`` for unparsable
+    input.
+    """
+    try:
+        data = yaml.safe_load(text) or {}
+    except yaml.YAMLError:
+        return []
+    if not isinstance(data, dict):
+        return []
+
+    rows: list[EditRow] = []
+    scanners = data.get("scanners")
+    if isinstance(scanners, dict):
+        for name in scanners:
+            block = scanners[name]
+            if not isinstance(block, dict) or "enabled" not in block:
+                continue
+            on = bool(block.get("enabled"))
+            rows.append(EditRow(
+                key=f"scanner:{name}", label=f"scanner · {name}", kind="toggle",
+                value="on" if on else "off", path=["scanners", name, "enabled"],
+                doc=_DOCS["scanner"],
+            ))
+
+    for (section, key), options in _ENUMS.items():
+        block = data.get(section)
+        if isinstance(block, dict) and key in block and block[key] is not None:
+            rows.append(EditRow(
+                key=f"{section}.{key}", label=f"{section} · {key}", kind="enum",
+                value=str(block[key]), path=[section, key], options=options,
+                doc=_DOCS.get(f"{section}.{key}", ""),
+            ))
+    return rows
+
+
+def set_value(text: str, path: list[str], value: str) -> str | None:
+    """Set the YAML scalar at ``path`` to ``value``, preserving formatting.
+
+    Walks the file indentation-aware to find the exact ``key: value`` line
+    at ``path`` and rewrites only its value, keeping the key, indentation,
+    and any trailing inline comment. Returns ``None`` when the path isn't
+    found as a simple scalar line (so callers don't write a no-op).
+
+    Assumes the conventional 2-space indentation argus.yml uses; bounded to
+    the editable settings, which are always plain scalars.
+    """
+    lines = text.splitlines(keepends=True)
+    # Track, per line, the key path implied by indentation.
+    stack: list[tuple[int, str]] = []  # (indent, key)
+    for i, raw in enumerate(lines):
+        stripped = raw.lstrip(" ")
+        if not stripped.strip() or stripped.lstrip().startswith("#"):
+            continue
+        indent = len(raw) - len(stripped)
+        m = re.match(r"([A-Za-z0-9_.\-]+)\s*:(.*)$", stripped)
+        if not m:
+            continue
+        key = m.group(1)
+        # Pop deeper/sibling entries off the stack.
+        while stack and stack[-1][0] >= indent:
+            stack.pop()
+        stack.append((indent, key))
+        current_path = [k for _ind, k in stack]
+        if current_path == path:
+            after = m.group(2)
+            comment = ""
+            cm = re.search(r"(\s+#.*)$", after)
+            if cm:
+                comment = cm.group(1)
+            newline = f"{' ' * indent}{key}: {value}{comment}"
+            newline += "\n" if raw.endswith("\n") else ""
+            if newline == raw:
+                return None
+            lines[i] = newline
+            return "".join(lines)
+    return None
+
+
+def apply_row(text: str, row: EditRow) -> tuple[str, str] | None:
+    """Apply ``row``'s next value to ``text``.
+
+    Returns ``(new_text, new_value)`` or ``None`` if the edit was a no-op /
+    the path vanished. The YAML scalar written is the literal next value
+    (``true``/``false`` for toggles, the enum string otherwise).
+    """
+    new_value = row.next_value()
+    new_text = set_value(text, row.path, new_value)
+    if new_text is None:
+        return None
+    return new_text, new_value
+
+
+def validate(text: str) -> str | None:
+    """Return an error message if ``text`` isn't a valid argus.yml, else None.
+
+    Parses the YAML and runs the existing schema checker so the Config
+    screen can refuse to save a broken edit. Best-effort: if the schema
+    module isn't importable for some reason, YAML-parse validity is the
+    floor.
+    """
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        return f"Invalid YAML: {exc}"
+    if not isinstance(data, dict):
+        return "argus.yml must be a mapping at the top level."
+    try:
+        from argus.core.schema import validate_config
+    except Exception:
+        return None
+    try:
+        issues = validate_config(data)
+    except Exception:
+        return None
+    errors = [str(i) for i in issues if getattr(i, "level", "") == "error"]
+    return "; ".join(errors[:3]) if errors else None

--- a/argus/viewers/terminal/console.py
+++ b/argus/viewers/terminal/console.py
@@ -32,7 +32,7 @@ from textual.widgets.option_list import Option
 
 from argus.core import console_config
 from argus.core.console_config import ConsoleSettings
-from argus.viewers.terminal import console_model
+from argus.viewers.terminal import config_editor, console_model
 
 # Sentinels the app exits with so ``launch`` can hand off to another
 # full-screen surface (the findings viewer / the init CLI) and then return
@@ -200,11 +200,107 @@ class SettingsScreen(Screen):
         self.app.settings = self.app.settings.advance(key)
         self.app.apply_theme()       # live preview for theme / accent
         # Rebuild the list cleanly with the new values, then restore cursor.
-        self.recompose()
+        self.refresh(recompose=True)
         self.call_after_refresh(self._restore_cursor)
 
     def action_close(self) -> None:  # pragma: no cover — UI
         self.app.persist_settings()
+        self.dismiss()
+
+
+class ConfigScreen(Screen):
+    """Form editor for argus.yml — scanner toggles + key settings.
+
+    Comment-preserving: edits go through ``config_editor`` which rewrites
+    only the matched line. Changes accumulate in a working copy; ``s``
+    validates and writes, ``esc`` discards. The richer free-text fields
+    (output_dir, etc.) stay editable via ``$EDITOR`` for now — this v1
+    covers the toggle/enum settings that are the common edits.
+    """
+
+    CSS = """
+    ConfigScreen { align: center middle; }
+    #config-body {
+        background: $surface; border: thick $accent;
+        width: 80%; max-width: 92; height: auto; max-height: 90%; padding: 1 2;
+    }
+    #config-title { text-style: bold; padding: 0 0 1 0; }
+    #config-list { height: auto; max-height: 22; border: none; background: transparent; }
+    #config-hint { color: $text-muted; padding: 1 0 0 0; }
+    """
+    BINDINGS = [
+        Binding("s", "save", "Save", show=True),
+        Binding("escape", "cancel", "Cancel", show=True),
+        Binding("q", "cancel", show=False),
+    ]
+
+    def __init__(self, config_path: Path):
+        super().__init__()
+        self._path = config_path
+        try:
+            self._text = config_path.read_text(encoding="utf-8")
+        except OSError:
+            self._text = ""
+        self._original = self._text
+        self._highlight = 0
+
+    def compose(self) -> ComposeResult:  # pragma: no cover — UI
+        rows = config_editor.editable_rows(self._text)
+        dirty = "  [yellow](unsaved)[/yellow]" if self._text != self._original else ""
+        with Vertical(id="config-body"):
+            yield Static(f"⚙  Configure · {self._path.name}{dirty}", id="config-title")
+            opts = [
+                Option(f"{r.label:<26}{r.value:<14}[dim]{r.doc}[/dim]", id=r.key)
+                for r in rows
+            ]
+            yield OptionList(*opts, id="config-list")
+            yield Static(
+                "↑↓ move   ·   enter change   ·   s save   ·   esc cancel",
+                id="config-hint",
+            )
+
+    def on_mount(self) -> None:  # pragma: no cover — UI
+        self._restore_cursor()
+        self.query_one("#config-list", OptionList).focus()
+
+    def _restore_cursor(self) -> None:  # pragma: no cover — UI
+        option_list = self.query_one("#config-list", OptionList)
+        if option_list.option_count:
+            option_list.highlighted = min(self._highlight, option_list.option_count - 1)
+
+    def on_option_list_option_selected(  # pragma: no cover — UI
+        self, event: OptionList.OptionSelected,
+    ) -> None:
+        key = event.option.id
+        rows = {r.key: r for r in config_editor.editable_rows(self._text)}
+        row = rows.get(key)
+        if row is None:
+            return
+        self._highlight = event.option_index
+        result = config_editor.apply_row(self._text, row)
+        if result is not None:
+            self._text, _ = result
+        self.refresh(recompose=True)
+        self.call_after_refresh(self._restore_cursor)
+
+    def action_save(self) -> None:  # pragma: no cover — UI
+        if self._text == self._original:
+            self.app.notify("No changes to save.", severity="information", timeout=3)
+            self.dismiss()
+            return
+        error = config_editor.validate(self._text)
+        if error:
+            self.app.notify(f"Not saved — {error}", severity="error", timeout=8)
+            return
+        try:
+            self._path.write_text(self._text, encoding="utf-8")
+        except OSError as exc:
+            self.app.notify(f"Couldn't write {self._path.name}: {exc}", severity="error", timeout=6)
+            return
+        self.app.notify(f"Saved {self._path.name}.", severity="information", timeout=3)
+        self.dismiss()
+
+    def action_cancel(self) -> None:  # pragma: no cover — UI
         self.dismiss()
 
 
@@ -342,7 +438,7 @@ class ConsoleApp(App):
         elif key == "init":
             self.exit(_HANDOFF_INIT)
         elif key == "configure":
-            self._edit_config()
+            self._open_config()
 
     def _open_scan(self) -> None:  # pragma: no cover — UI
         from argus.viewers.terminal import scan_runner
@@ -359,14 +455,27 @@ class ConsoleApp(App):
 
         self.push_screen(RunScanScreen(argv, launch_root=self.launch_root), _after)
 
+    def _open_config(self) -> None:  # pragma: no cover — UI
+        """Open the form editor when an argus.yml exists, else fall back to
+        $EDITOR (to create one) or nudge toward Initialize."""
+        self.config_path = self._detect_config_path()
+        if self.config_path.is_file():
+            def _after(_result: object) -> None:
+                screen = self.screen
+                if isinstance(screen, HomeScreen):
+                    screen.refresh_status()
+            self.push_screen(ConfigScreen(self.config_path), _after)
+            return
+        self.notify(
+            "No argus.yml yet — pick Initialize to generate one, "
+            "or set $EDITOR to create it by hand.",
+            severity="warning", timeout=6,
+        )
+        self._edit_config()
+
     def _edit_config(self) -> None:  # pragma: no cover — UI
         editor = os.environ.get("VISUAL") or os.environ.get("EDITOR")
         if not editor:
-            self.notify(
-                "Set $EDITOR or $VISUAL to edit argus.yml here "
-                "(the form-based editor lands in a later release).",
-                severity="warning", timeout=6,
-            )
             return
         with self.suspend():
             subprocess.run([editor, str(self.config_path)])

--- a/argus/viewers/terminal/console_model.py
+++ b/argus/viewers/terminal/console_model.py
@@ -47,7 +47,7 @@ class MenuItem:
 MENU: tuple[MenuItem, ...] = (
     MenuItem("scan", "Run a scan", "Run argus scan and watch it live", "⚡"),
     MenuItem("findings", "View findings", "Browse and triage the latest results", "🔎"),
-    MenuItem("configure", "Configure", "Edit argus.yml in your editor", "⚙"),
+    MenuItem("configure", "Configure", "Toggle scanners + settings in argus.yml", "⚙"),
     MenuItem("init", "Initialize", "Detect the project and generate argus.yml", "✨"),
     MenuItem("settings", "Settings", "Theme, colours, animations, notifications", "🎛"),
     MenuItem("docs", "Help & docs", "Keybindings and where to learn more", "📖"),

--- a/docs/console.md
+++ b/docs/console.md
@@ -32,11 +32,30 @@ argus scan ...   # every subcommand is unchanged
   |---|---|
   | Run a scan | Runs `argus scan` and streams it live, then reloads. |
   | View findings | Opens the full triage viewer (same as `argus view`). |
-  | Configure | Opens `argus.yml` in your `$EDITOR` / `$VISUAL`. |
+  | Configure | Opens the form editor for `argus.yml` (see below). |
   | Initialize | Runs `argus init` to detect the project + write config. |
   | Settings | Theme, accent colour, animations, notifications. |
   | Help & docs | Keybindings and where to learn more. |
   | Quit | Leave the console. |
+
+## Configure
+
+Edit `argus.yml` by form instead of by hand. Move with the arrows, press
+Enter to cycle the focused setting, `s` to save, `esc` to discard. Each row
+shows the current value and a one-line description of what it controls.
+
+The form covers the common edits — scanner on/off toggles and the bounded
+choice settings (`severity_threshold`, execution `backend` / `pull_policy`,
+and the viewer's `cve_source` / `open_location`). Edits are
+**comment-preserving**: only the matched line's value is rewritten, so your
+comments, ordering, and indentation survive. Before saving, the edited file
+is re-validated against the config schema — an invalid edit is refused with
+the reason rather than written.
+
+Settings that aren't toggle/choice fields (paths, URLs, custom args) and
+adding a brand-new scanner block still go through Initialize or your
+`$EDITOR`. If no `argus.yml` exists yet, Configure points you to Initialize
+and falls back to `$EDITOR` / `$VISUAL` so you can create one by hand.
 
 ## Settings
 
@@ -63,6 +82,6 @@ Settings are user preferences, kept separate from your project's
 The Console and `argus view terminal` share the same findings viewer —
 "View findings" opens it, and `argus view` is the direct deep-link. See
 [`view-terminal.md`](view-terminal.md) for the full triage reference. The
-broader plan for the Console (config editor, init wizard, vulnerability
-mitigation) lives in
+broader plan for the Console (the init wizard and deeper vulnerability
+mitigation are next) lives in
 [`developer/CONSOLE-ROADMAP.md`](developer/CONSOLE-ROADMAP.md).

--- a/docs/developer/CONSOLE-ROADMAP.md
+++ b/docs/developer/CONSOLE-ROADMAP.md
@@ -132,24 +132,41 @@ Let users resolve findings, not just read them.
 produces a passing run *is* the auto-merge story. It complements the
 already-foundational Dependabot/Renovate flow as its interactive sibling.
 
-## Phase 2 — Config editor screen (planned)
+## Phase 2 — Config editor screen (shipped, into PR #261)
 
 Edit `argus.yml` by form, not by hand.
 
-**Architecture**
-- A Config screen using Textual `Input` / `Select` / `Switch` / `RadioSet`,
-  populated from and validated against the existing config schema
-  (`argus/core/config.py` + `argus/core/schema.py`). Live validation; invalid
-  states block save.
-- **Surfaced focused docs:** render the relevant slice of
-  [`config-reference.md`](../config-reference.md) per field so the answer to
-  "what does this do?" is on screen.
-- **Safe write-back:** form-generated YAML must not clobber a user's comments
-  / ordering. Decide up front: a round-trip-preserving writer (`ruamel.yaml`)
-  vs. regenerate-from-template. This is a prerequisite, not a detail.
-- Scanner selection reuses the logic already behind the docsite Configure
-  mode (`scripts/docsite/architecture.py`), keeping one source of truth for
-  "which scanners, what config they emit."
+**Shipped**
+- **Config screen** (`ConfigScreen` in `argus/viewers/terminal/console.py`)
+  reachable from the home menu's *Configure* entry. Lists the editable
+  settings as an `OptionList`; `enter` cycles a value, `s` validates + writes,
+  `esc` discards. Opens the form when an `argus.yml` exists; with none, it
+  nudges toward Initialize and falls back to `$EDITOR`/`$VISUAL` so a file can
+  still be created by hand.
+- **UI-free edit core** (`argus/viewers/terminal/config_editor.py`,
+  textual-free → CI-covered): `editable_rows` parses the file into
+  toggle/enum rows (scanner `enabled` flags + bounded section scalars —
+  `severity_threshold`, `backend`, `pull_policy`, `cve_source`,
+  `open_location`); `apply_row` cycles a row's value; `validate` re-parses and
+  runs `argus/core/schema.py::validate_config`, blocking save on any
+  `error`-level issue.
+- **Surfaced focused docs:** each row carries a one-line `doc` string
+  (`_DOCS`) rendered beside it, so "what does this do?" is on screen.
+- **Safe write-back — decision resolved.** Rather than re-serialising the
+  whole file (which clobbers comments/ordering), edits are *comment-preserving
+  targeted line rewrites*: `set_value` walks the file indentation-aware to the
+  exact `key: value` line and rewrites only its value, keeping key,
+  indentation, and any trailing inline comment. The editable set is
+  deliberately bounded to plain scalars so every edit is a single,
+  unambiguous line — sidestepping the `ruamel.yaml` round-trip dependency
+  entirely. Free-text fields (e.g. `output_dir`) stay editable via `$EDITOR`.
+
+**Deferred to a follow-up**
+- Free-text `Input` fields (paths, URLs, custom args) and scanner *addition*
+  (the form edits settings that already exist in the file; adding a brand-new
+  scanner block still goes through Init or `$EDITOR`). The docsite Configure
+  logic (`scripts/docsite/architecture.py`) is the source of truth to reuse
+  when that lands.
 
 ## Phase 3 — Init wizard screen (planned)
 
@@ -183,9 +200,9 @@ findings viewer in as a true in-app screen (it's a hand-off today).
   back to `--help` (the backward-compat contract). `argus view` still
   deep-links to findings.
 - **Configure / Init** reach the real CLI capabilities now: Configure opens
-  `argus.yml` in `$EDITOR`/`$VISUAL` (via `App.suspend`), Init streams
-  `argus init`. The form-based config editor (Phase 2) and init wizard
-  (Phase 3) replace these interim flows.
+  the Phase-2 form editor (falling back to `$EDITOR`/`$VISUAL` via
+  `App.suspend` when no `argus.yml` exists yet), Init streams `argus init`.
+  The init wizard (Phase 3) replaces the streaming hand-off.
 
 **Remaining**
 - Findings + Init are hand-offs (the console exits with a sentinel; the
@@ -220,8 +237,11 @@ findings viewer in as a true in-app screen (it's a hand-off today).
 
 ## Open decisions (product calls before the relevant phase)
 
-- **YAML write-back strategy** (Phase 2): `ruamel.yaml` round-trip vs.
-  template regeneration. Affects whether we can preserve user comments.
+- **YAML write-back strategy** (Phase 2): ✅ decided — comment-preserving
+  *targeted line rewrites* (`config_editor.set_value`) over the bounded set of
+  toggle/enum scalars, not a `ruamel.yaml` round-trip or template
+  regeneration. Preserves comments/ordering with no new dependency; the trade
+  is that only settings already present in the file are form-editable.
 - **Bare-`argus` default change** (Phase 4): ✅ decided — bare `argus`
   opens the Console, gated on stdout+stdin both being a TTY so headless /
   CI / piped use is untouched (no deprecation window needed). Still worth a


### PR DESCRIPTION
## Description
Phase 2 of the Console roadmap: a **form editor for `argus.yml`**. The home menu's **Configure** entry now opens an in-app `ConfigScreen` instead of shelling out to `$EDITOR`. This PR targets the Console integration branch (`feat/tui-explorer-and-scan-runner`, PR #261), not `main` — it merges in once green so the full Console can be reviewed as one solution.

## Changes Made
- [x] Modified existing scanner/workflow
- [x] Updated documentation
- [ ] Added new scanner/workflow
- [ ] Fixed bug
- [x] Other (please specify): new Console screen + UI-free edit core

### Details
- **`ConfigScreen`** (`argus/viewers/terminal/console.py`): lists editable settings as an `OptionList` with current value + a one-line description. `enter` cycles a value, `s` validates + writes, `esc` discards. When no `argus.yml` exists it nudges toward Initialize and falls back to `$EDITOR`/`$VISUAL`.
- **`config_editor.py`** (new, `argus/viewers/terminal/`): UI-free, textual-free edit core so it's covered in CI without the `[terminal]` extra.
  - `editable_rows` → scanner `enabled` toggles + bounded choice settings (`severity_threshold`, execution `backend`/`pull_policy`, view `cve_source`/`open_location`).
  - `set_value` → **comment-preserving** targeted line rewrite: walks the file indentation-aware to the matched `key: value` line and rewrites only its value, keeping key, indentation, and any trailing inline comment.
  - `validate` → re-parses and runs `argus.core.schema.validate_config`, refusing save on any `error`-level issue.
- **Roadmap decision resolved**: the open "YAML write-back" question is answered in favour of targeted line edits over a `ruamel.yaml` round-trip — no new dependency, at the cost of only editing settings already present in the file.
- **No breaking changes.** The `$EDITOR` path is preserved as the fallback for the no-config and free-text cases.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

### Test Results
- `test_config_editor.py` (new): 22 tests covering editable-row parsing, comment-/indentation-preserving edits, toggle/enum cycling, and validation.
- `test_console.py` (updated): Configure now routes through `_open_config` — covers both the "opens ConfigScreen when `argus.yml` present" and "falls back to `$EDITOR` when absent" paths, plus `ConfigScreen` construction.
- Full suite: **4031 passed, 21 skipped**, coverage **92.58%** (≥80% gate met). The 3 local-only `viewers/browser` failures are the known pre-existing fastapi-0.136.1 template diffs (green in CI), unrelated to this change.

## Security Considerations
- [x] No security impact

### Security Details
Edits are bounded to a fixed set of toggle/enum scalars and validated against the config schema before write. No code execution; the `$EDITOR` fallback is unchanged from prior behaviour.

## AI Context Updates (.ai/)
- [x] `.ai/architecture.yaml` updated (Configure form editor + `config_editor.py` noted under `viewers/terminal/`)
- [ ] `.ai/workflows.yaml` updated
- [ ] `.ai/decisions.yaml` updated
- [ ] `.ai/errors.yaml` updated

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (`docs/console.md` Configure section, `docs/developer/CONSOLE-ROADMAP.md` Phase 2 → shipped)
- [ ] Changelog updated (handled at release)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Part of the Console epic (`docs/developer/CONSOLE-ROADMAP.md`, Phase 2).

## Screenshots/Logs (if applicable)
Console form editor is keyboard-driven (↑↓ move · enter change · s save · esc cancel). Home-screen + settings screenshots are in PR #261 / #262.
