### PR TITLE
feat(console): in-app init wizard (Initialize screen)

### DIFF
--- a/.ai/architecture.yaml
+++ b/.ai/architecture.yaml
@@ -106,8 +106,10 @@ components:
         RunScanPromptScreen + RunScanScreen stream it) and reloads results when it finishes. Right-click context
         menus anchor at the cursor via mouse_actions.clamp_menu_offset. console.py + console_model.py provide the
         Argus Console — the home launcher (scan / findings / configure / init / settings / docs) with a
-        live-themed Settings screen backed by argus.core.console_config and a Configure form editor (ConfigScreen)
-        for argus.yml backed by config_editor.py (UI-free, comment-preserving targeted line edits + schema validation);
+        live-themed Settings screen backed by argus.core.console_config, a Configure form editor (ConfigScreen)
+        for argus.yml backed by config_editor.py (UI-free, comment-preserving targeted line edits + schema validation),
+        and an Init wizard (InitScreen) backed by init_wizard.py (UI-free frontend over argus.init detect_project +
+        generate_config — detect, toggle proposed scanners, write argus.yml, optionally hand off to the scan runner);
         bare ``argus`` opens it in an interactive
         TTY (cli._run_bare_argus), falling back to --help when non-interactive, and ``argus view`` deep-links to
         the findings viewer.'
@@ -709,8 +711,10 @@ docsite:
         RunScanPromptScreen + RunScanScreen stream it) and reloads results when it finishes. Right-click context
         menus anchor at the cursor via mouse_actions.clamp_menu_offset. console.py + console_model.py provide the
         Argus Console — the home launcher (scan / findings / configure / init / settings / docs) with a
-        live-themed Settings screen backed by argus.core.console_config and a Configure form editor (ConfigScreen)
-        for argus.yml backed by config_editor.py (UI-free, comment-preserving targeted line edits + schema validation);
+        live-themed Settings screen backed by argus.core.console_config, a Configure form editor (ConfigScreen)
+        for argus.yml backed by config_editor.py (UI-free, comment-preserving targeted line edits + schema validation),
+        and an Init wizard (InitScreen) backed by init_wizard.py (UI-free frontend over argus.init detect_project +
+        generate_config — detect, toggle proposed scanners, write argus.yml, optionally hand off to the scan runner);
         bare ``argus`` opens it in an interactive
         TTY (cli._run_bare_argus), falling back to --help when non-interactive, and ``argus view`` deep-links to
         the findings viewer.'

--- a/argus/init.py
+++ b/argus/init.py
@@ -43,6 +43,24 @@ _DOCS_URL = "https://huntridge-labs.github.io/argus/"
 EXIT_SUCCESS = 0
 EXIT_ERROR = 2
 
+# Human labels for the signal keys ``detect_project`` emits. Module-level so
+# both the CLI summary (``_print_summary``) and the Console init wizard
+# (``viewers/terminal/init_wizard``) render the same names.
+SIGNAL_LABELS: dict[str, str] = {
+    "python": "Python source files",
+    "javascript": "JavaScript/TypeScript files",
+    "go": "Go source files",
+    "java": "Java source files",
+    "node": "Node.js project",
+    "dependencies": "Dependency manifests",
+    "container": "Container/Docker files",
+    "iac": "Infrastructure as code",
+    "github-actions": "GitHub Actions workflows",
+    "gitlab-ci": "GitLab CI configuration",
+    "jenkins": "Jenkinsfile",
+    "tool-configs": "Existing tool configurations",
+}
+
 
 def run_init(
     force: bool = False,
@@ -489,22 +507,8 @@ def _print_summary(
 
     if signals:
         print(f"\n{G}  Detected:{R}")
-        signal_labels = {
-            "python": "Python source files",
-            "javascript": "JavaScript/TypeScript files",
-            "go": "Go source files",
-            "java": "Java source files",
-            "node": "Node.js project",
-            "dependencies": "Dependency manifests",
-            "container": "Container/Docker files",
-            "iac": "Infrastructure as code",
-            "github-actions": "GitHub Actions workflows",
-            "gitlab-ci": "GitLab CI configuration",
-            "jenkins": "Jenkinsfile",
-            "tool-configs": "Existing tool configurations",
-        }
         for key, evidence in signals.items():
-            label = signal_labels.get(key, key)
+            label = SIGNAL_LABELS.get(key, key)
             print(f"    {D}-{R} {label} {D}({evidence[0]}){R}")
 
     if readiness is not None:

--- a/argus/tests/viewers/terminal/test_console.py
+++ b/argus/tests/viewers/terminal/test_console.py
@@ -118,10 +118,12 @@ class TestDispatch:
         app.dispatch_menu("findings")
         assert calls["exit"] and calls["exit"][0] == "findings"
 
-    def test_init_exits_with_handoff_sentinel(self, console):
+    def test_init_opens_wizard(self, console, tmp_path, monkeypatch):
         _module, app, calls = console
+        monkeypatch.chdir(tmp_path)  # detect against an empty dir, fast + deterministic
         app.dispatch_menu("init")
-        assert calls["exit"] and calls["exit"][0] == "init"
+        assert "InitScreen" in calls["push"]
+        assert calls["exit"] == []  # no hand-off any more
 
     def test_configure_opens_config_screen_when_present(self, console, tmp_path, monkeypatch):
         _module, app, calls = console
@@ -164,3 +166,14 @@ class TestConfigScreen:
         screen = module.ConfigScreen(tmp_path / "absent.yml")
         assert screen._text == ""
         assert screen._original == ""
+
+
+class TestInitScreen:
+    def test_constructs_from_plan(self, console, tmp_path):
+        module, _app, _calls = console
+        from argus.viewers.terminal import init_wizard
+        plan = init_wizard.build_plan(tmp_path)
+        screen = module.InitScreen(plan)
+        assert screen._text == plan.yaml
+        assert screen._plan is plan
+        assert screen._overwrite_armed is False

--- a/argus/tests/viewers/terminal/test_init_wizard.py
+++ b/argus/tests/viewers/terminal/test_init_wizard.py
@@ -1,0 +1,148 @@
+"""Unit tests for argus.viewers.terminal.init_wizard (Phase 3).
+
+UI-free: no Textual. Pins the detect → propose → write model the Console's
+Init wizard wraps around argus.init's pure functions.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from argus.viewers.terminal.init_wizard import (
+    CONFIG_FILENAME,
+    DetectedCategory,
+    InitPlan,
+    build_plan,
+    detected_categories,
+    readiness_line,
+    summary_line,
+    write_config,
+)
+
+
+@pytest.fixture
+def python_project(tmp_path):
+    """A minimal project the detector recognises (Python + deps + CI)."""
+    (tmp_path / "app.py").write_text("print('hi')\n")
+    (tmp_path / "requirements.txt").write_text("requests==2.32.0\n")
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "ci.yml").write_text("on: push\n")
+    return tmp_path
+
+
+class TestDetectedCategories:
+    def test_maps_keys_to_human_labels(self):
+        cats = detected_categories({"python": ["app.py", "x.py"], "iac": ["main.tf"]})
+        by_key = {c.key: c for c in cats}
+        assert by_key["python"].label == "Python source files"
+        assert by_key["python"].example == "app.py"
+        assert by_key["python"].count == 2
+        assert by_key["iac"].label == "Infrastructure as code"
+
+    def test_unknown_key_falls_back_to_key(self):
+        cats = detected_categories({"mystery": ["a"]})
+        assert cats[0].label == "mystery"
+
+    def test_empty_signals_yields_no_categories(self):
+        assert detected_categories({}) == []
+
+
+class TestBuildPlan:
+    def test_detects_python_project(self, python_project):
+        plan = build_plan(python_project)
+        keys = {c.key for c in plan.categories}
+        assert "python" in keys
+        assert "dependencies" in keys
+        assert "github-actions" in keys
+
+    def test_proposes_expected_scanners(self, python_project):
+        plan = build_plan(python_project)
+        # gitleaks + opengrep always; bandit (python), osv (deps),
+        # supply-chain (gh-actions) all proposed for this project.
+        for scanner in ("gitleaks", "bandit", "osv", "opengrep", "supply-chain"):
+            assert scanner in plan.proposed_scanners
+
+    def test_yaml_is_generated_and_parseable(self, python_project):
+        import yaml
+        plan = build_plan(python_project)
+        assert plan.yaml.strip()
+        parsed = yaml.safe_load(plan.yaml)
+        assert "scanners" in parsed
+
+    def test_config_path_and_absence(self, python_project):
+        plan = build_plan(python_project)
+        assert plan.config_path == python_project / CONFIG_FILENAME
+        assert plan.config_exists is False
+
+    def test_config_exists_when_present(self, python_project):
+        (python_project / CONFIG_FILENAME).write_text("version: '1.0'\n")
+        plan = build_plan(python_project)
+        assert plan.config_exists is True
+
+    def test_no_detect_still_proposes_defaults(self, python_project):
+        plan = build_plan(python_project, detect=False)
+        assert plan.categories == []
+        # Always-on scanners still proposed even with detection off.
+        assert "gitleaks" in plan.proposed_scanners
+        assert "opengrep" in plan.proposed_scanners
+
+    def test_empty_dir_proposes_safe_defaults(self, tmp_path):
+        plan = build_plan(tmp_path)
+        assert "gitleaks" in plan.proposed_scanners
+        assert "bandit" not in plan.proposed_scanners  # no python detected
+
+
+class TestReadinessLine:
+    def test_none_is_empty(self):
+        assert readiness_line(None) == ""
+        assert readiness_line({}) == ""
+
+    def test_formats_buckets(self):
+        line = readiness_line({"local": 2, "container": 1, "missing": 0})
+        assert "2 ready locally" in line
+        assert "1 via container" in line
+        assert "0 missing" in line
+
+    def test_missing_count_surfaced(self):
+        assert "3 missing" in readiness_line({"local": 0, "container": 0, "missing": 3})
+
+
+class TestSummaryLine:
+    def test_with_categories(self, python_project):
+        plan = build_plan(python_project)
+        line = summary_line(plan)
+        assert "detected" in line
+        assert "scanners proposed" in line
+
+    def test_no_signals(self):
+        plan = InitPlan(root=None, categories=[], proposed_scanners=["gitleaks"])
+        assert "no project signals detected" in summary_line(plan)
+
+
+class TestWriteConfig:
+    def test_writes_new_file(self, tmp_path):
+        target = tmp_path / CONFIG_FILENAME
+        written = write_config(target, "version: '1.0'\n")
+        assert written == target
+        assert target.read_text() == "version: '1.0'\n"
+
+    def test_refuses_existing_without_force(self, tmp_path):
+        target = tmp_path / CONFIG_FILENAME
+        target.write_text("old\n")
+        with pytest.raises(FileExistsError):
+            write_config(target, "new\n")
+        assert target.read_text() == "old\n"  # untouched
+
+    def test_overwrites_with_force(self, tmp_path):
+        target = tmp_path / CONFIG_FILENAME
+        target.write_text("old\n")
+        write_config(target, "new\n", force=True)
+        assert target.read_text() == "new\n"
+
+
+class TestDataclasses:
+    def test_detected_category_is_frozen(self):
+        cat = DetectedCategory(key="python", label="Python", example="a.py", count=1)
+        with pytest.raises(Exception):
+            cat.key = "go"  # type: ignore[misc]

--- a/argus/viewers/terminal/console.py
+++ b/argus/viewers/terminal/console.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import os
 import subprocess
-import sys
 from pathlib import Path
 
 from textual.app import App, ComposeResult
@@ -32,13 +31,12 @@ from textual.widgets.option_list import Option
 
 from argus.core import console_config
 from argus.core.console_config import ConsoleSettings
-from argus.viewers.terminal import config_editor, console_model
+from argus.viewers.terminal import config_editor, console_model, init_wizard
 
-# Sentinels the app exits with so ``launch`` can hand off to another
-# full-screen surface (the findings viewer / the init CLI) and then return
-# to the console.
+# Sentinel the app exits with so ``launch`` can hand off to the findings
+# viewer (its own full-screen surface) and then return to the console.
+# Init and Configure are now in-app screens (no hand-off needed).
 _HANDOFF_FINDINGS = "findings"
-_HANDOFF_INIT = "init"
 
 
 def _argus_theme(accent: str) -> Theme:
@@ -304,6 +302,130 @@ class ConfigScreen(Screen):
         self.dismiss()
 
 
+class InitScreen(Screen):
+    """Guided first-run wizard — a frontend over ``argus init``.
+
+    Shows what detection found (``init_wizard.build_plan``), lists the
+    proposed scanners as toggles (reusing ``config_editor`` over the
+    generated argus.yml held in a working copy), and writes the file. No
+    detection logic lives here — it's all in ``argus.init`` / ``init_wizard``.
+
+    ``w`` writes argus.yml, ``r`` writes then offers to run the first scan.
+    Dismisses with ``"scan"`` / ``"written"`` / ``None`` so the app can
+    refresh the home status and optionally launch the scan runner.
+    """
+
+    CSS = """
+    InitScreen { align: center middle; }
+    #init-body {
+        background: $surface; border: thick $accent;
+        width: 84%; max-width: 96; height: auto; max-height: 92%; padding: 1 2;
+    }
+    #init-title { text-style: bold; padding: 0 0 1 0; }
+    #init-summary { color: $text-muted; padding: 0 0 1 0; }
+    #init-detected { height: auto; padding: 0 0 1 0;
+                     border-bottom: dashed $panel; }
+    #init-list { height: auto; max-height: 16; border: none; background: transparent; }
+    #init-hint { color: $text-muted; padding: 1 0 0 0; }
+    """
+    BINDINGS = [
+        Binding("w", "write", "Write", show=True),
+        Binding("r", "write_scan", "Write & scan", show=True),
+        Binding("escape", "cancel", "Cancel", show=True),
+        Binding("q", "cancel", show=False),
+    ]
+
+    def __init__(self, plan: "init_wizard.InitPlan"):
+        super().__init__()
+        self._plan = plan
+        self._text = plan.yaml
+        self._highlight = 0
+        self._overwrite_armed = False
+
+    def compose(self) -> ComposeResult:  # pragma: no cover — UI
+        with Vertical(id="init-body"):
+            yield Static("✨  Initialize · argus.yml", id="init-title")
+            yield Static(init_wizard.summary_line(self._plan), id="init-summary")
+            if self._plan.categories:
+                detected = "\n".join(
+                    f"  ✓ {c.label}  [dim]{c.example}[/dim]"
+                    for c in self._plan.categories
+                )
+            else:
+                detected = "  [dim]no project signals detected — safe defaults proposed[/dim]"
+            readiness = init_wizard.readiness_line(self._plan.readiness)
+            if readiness:
+                detected += f"\n  [dim]tools: {readiness}[/dim]"
+            yield Static(detected, id="init-detected")
+            opts = [
+                Option(f"{r.label:<26}{r.value}", id=r.key)
+                for r in config_editor.editable_rows(self._text)
+            ]
+            yield OptionList(*opts, id="init-list")
+            exists = (
+                "   [yellow]argus.yml exists — write overwrites[/yellow]"
+                if self._plan.config_exists else ""
+            )
+            yield Static(
+                f"enter toggle   ·   w write   ·   r write & scan   ·   esc cancel{exists}",
+                id="init-hint",
+            )
+        yield Footer()
+
+    def on_mount(self) -> None:  # pragma: no cover — UI
+        self._restore_cursor()
+        self.query_one("#init-list", OptionList).focus()
+
+    def _restore_cursor(self) -> None:  # pragma: no cover — UI
+        option_list = self.query_one("#init-list", OptionList)
+        if option_list.option_count:
+            option_list.highlighted = min(self._highlight, option_list.option_count - 1)
+
+    def on_option_list_option_selected(  # pragma: no cover — UI
+        self, event: OptionList.OptionSelected,
+    ) -> None:
+        rows = {r.key: r for r in config_editor.editable_rows(self._text)}
+        row = rows.get(event.option.id)
+        if row is None:
+            return
+        self._highlight = event.option_index
+        result = config_editor.apply_row(self._text, row)
+        if result is not None:
+            self._text, _ = result
+        self.refresh(recompose=True)
+        self.call_after_refresh(self._restore_cursor)
+
+    def _write(self, *, then_scan: bool) -> None:  # pragma: no cover — UI
+        target = self._plan.config_path
+        if target.exists() and not self._overwrite_armed:
+            self._overwrite_armed = True
+            self.app.notify(
+                f"{target.name} already exists — press the same key again to overwrite.",
+                severity="warning", timeout=6,
+            )
+            return
+        error = config_editor.validate(self._text)
+        if error:
+            self.app.notify(f"Not written — {error}", severity="error", timeout=8)
+            return
+        try:
+            init_wizard.write_config(target, self._text, force=True)
+        except OSError as exc:
+            self.app.notify(f"Couldn't write {target.name}: {exc}", severity="error", timeout=6)
+            return
+        self.app.notify(f"Created {target.name}.", severity="information", timeout=3)
+        self.dismiss("scan" if then_scan else "written")
+
+    def action_write(self) -> None:  # pragma: no cover — UI
+        self._write(then_scan=False)
+
+    def action_write_scan(self) -> None:  # pragma: no cover — UI
+        self._write(then_scan=True)
+
+    def action_cancel(self) -> None:  # pragma: no cover — UI
+        self.dismiss()
+
+
 class HomeScreen(Screen):
     """The launcher: wordmark banner, project status, and the menu."""
 
@@ -436,7 +558,7 @@ class ConsoleApp(App):
         elif key == "findings":
             self.exit(_HANDOFF_FINDINGS)
         elif key == "init":
-            self.exit(_HANDOFF_INIT)
+            self._open_init()
         elif key == "configure":
             self._open_config()
 
@@ -473,6 +595,25 @@ class ConsoleApp(App):
         )
         self._edit_config()
 
+    def _open_init(self) -> None:  # pragma: no cover — UI
+        """Open the init wizard over the project at the current directory.
+
+        Detects the project, lets the user review/toggle the proposed
+        scanners, and writes argus.yml in-app. On "write & scan" it hands
+        straight to the scan runner; either way it refreshes home status.
+        """
+        plan = init_wizard.build_plan(Path("."))
+
+        def _after(result: object) -> None:
+            self.config_path = self._detect_config_path()
+            screen = self.screen
+            if isinstance(screen, HomeScreen):
+                screen.refresh_status()
+            if result == "scan":
+                self._open_scan()
+
+        self.push_screen(InitScreen(plan), _after)
+
     def _edit_config(self) -> None:  # pragma: no cover — UI
         editor = os.environ.get("VISUAL") or os.environ.get("EDITOR")
         if not editor:
@@ -486,12 +627,12 @@ class ConsoleApp(App):
 
 
 def launch(results_dir: str | None = None) -> int:
-    """Run the Console, handling findings / init hand-offs in a loop.
+    """Run the Console, handling the findings hand-off in a loop.
 
-    The console exits with a sentinel for the two surfaces that need their
-    own full screen (the findings viewer and ``argus init``); we run that
-    surface, then re-open the console. Quitting the console returns its
-    exit code.
+    The console exits with a sentinel for the findings viewer (the one
+    surface that needs its own full screen); we run it, then re-open the
+    console. Configure and Init are handled in-app. Quitting the console
+    returns its exit code.
     """
     while True:
         app = ConsoleApp(results_dir=results_dir)
@@ -500,8 +641,5 @@ def launch(results_dir: str | None = None) -> int:
         if result == _HANDOFF_FINDINGS:
             from argus.viewers.terminal.app import run_app
             run_app(results_dir)
-            continue
-        if result == _HANDOFF_INIT:
-            subprocess.run([sys.executable, "-m", "argus", "init"])
             continue
         return app.return_code or 0

--- a/argus/viewers/terminal/init_wizard.py
+++ b/argus/viewers/terminal/init_wizard.py
@@ -1,0 +1,125 @@
+"""UI-free model for the Console's Init wizard (Phase 3).
+
+Textual-free (imports only ``argus.init`` + stdlib) so the wizard's logic is
+unit-testable in CI without the ``[terminal]`` extra. It's a thin wrapper
+over the *pure* detection + config-generation functions in ``argus.init`` —
+no detection logic is reimplemented here:
+
+    detect_project        → what languages / manifests / CI the repo has
+    generate_config       → the proposed argus.yml for those signals
+    _extract_enabled_scanners / _check_local_readiness → review metadata
+
+``InitScreen`` (in ``console.py``) renders the :class:`InitPlan` this module
+builds, lets the user toggle the proposed scanners (reusing
+``config_editor``), then writes ``argus.yml`` via :func:`write_config`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from argus.init import (
+    SIGNAL_LABELS,
+    _check_local_readiness,
+    _extract_enabled_scanners,
+    detect_project,
+    generate_config,
+)
+
+# Canonical config filename the wizard writes.
+CONFIG_FILENAME = "argus.yml"
+
+
+@dataclass(frozen=True)
+class DetectedCategory:
+    """One detected project signal, ready for display."""
+
+    key: str          # detect_project key, e.g. "python"
+    label: str        # human label from SIGNAL_LABELS
+    example: str      # first evidence path, e.g. "src/app.py"
+    count: int        # number of evidence paths
+
+
+@dataclass(frozen=True)
+class InitPlan:
+    """What the wizard detected plus the argus.yml it proposes to write."""
+
+    root: Path
+    categories: list[DetectedCategory] = field(default_factory=list)
+    proposed_scanners: list[str] = field(default_factory=list)
+    yaml: str = ""
+    readiness: dict[str, int] | None = None
+    config_path: Path = field(default_factory=lambda: Path(CONFIG_FILENAME))
+    config_exists: bool = False
+
+
+def detected_categories(signals: dict[str, list[str]]) -> list[DetectedCategory]:
+    """Turn ``detect_project`` output into ordered, display-ready categories."""
+    categories: list[DetectedCategory] = []
+    for key, evidence in signals.items():
+        categories.append(DetectedCategory(
+            key=key,
+            label=SIGNAL_LABELS.get(key, key),
+            example=evidence[0] if evidence else "",
+            count=len(evidence),
+        ))
+    return categories
+
+
+def build_plan(root: Path, *, detect: bool = True) -> InitPlan:
+    """Detect ``root`` and assemble the proposal — pure, no writes.
+
+    Mirrors the first half of ``argus.init.run_init`` (detect → generate →
+    summarise) but stops short of writing, so the wizard can show the plan
+    and let the user adjust it first.
+    """
+    signals = detect_project(root) if detect else {}
+    yaml_text = generate_config(signals)
+    scanners = _extract_enabled_scanners(yaml_text)
+    config_path = root / CONFIG_FILENAME
+    return InitPlan(
+        root=root,
+        categories=detected_categories(signals),
+        proposed_scanners=scanners,
+        yaml=yaml_text,
+        readiness=_check_local_readiness(scanners),
+        config_path=config_path,
+        config_exists=config_path.is_file(),
+    )
+
+
+def readiness_line(readiness: dict[str, int] | None) -> str:
+    """One-line readiness summary, or ``""`` when unavailable."""
+    if not readiness:
+        return ""
+    local = readiness.get("local", 0)
+    container = readiness.get("container", 0)
+    missing = readiness.get("missing", 0)
+    parts = [f"{local} ready locally", f"{container} via container"]
+    parts.append(f"{missing} missing" if missing else "0 missing")
+    return " · ".join(parts)
+
+
+def summary_line(plan: InitPlan) -> str:
+    """A single human line describing the plan for the wizard header."""
+    if plan.categories:
+        labels = ", ".join(c.label for c in plan.categories)
+        detected = f"detected {labels}"
+    else:
+        detected = "no project signals detected — proposing safe defaults"
+    scanners = f"{len(plan.proposed_scanners)} scanners proposed"
+    return f"{detected}   ·   {scanners}"
+
+
+def write_config(config_path: Path, content: str, *, force: bool = False) -> Path:
+    """Write ``content`` to ``config_path``.
+
+    Raises :class:`FileExistsError` when the file already exists and
+    ``force`` is False — mirroring ``argus init``'s overwrite guard so the
+    wizard never silently clobbers a user's config.
+    """
+    if config_path.exists() and not force:
+        raise FileExistsError(config_path)
+    config_path.write_text(content, encoding="utf-8")
+    return config_path

--- a/docs/console.md
+++ b/docs/console.md
@@ -33,7 +33,7 @@ argus scan ...   # every subcommand is unchanged
   | Run a scan | Runs `argus scan` and streams it live, then reloads. |
   | View findings | Opens the full triage viewer (same as `argus view`). |
   | Configure | Opens the form editor for `argus.yml` (see below). |
-  | Initialize | Runs `argus init` to detect the project + write config. |
+  | Initialize | Guided first-run wizard — detect the project, review, write `argus.yml` (see below). |
   | Settings | Theme, accent colour, animations, notifications. |
   | Help & docs | Keybindings and where to learn more. |
   | Quit | Leave the console. |
@@ -56,6 +56,20 @@ Settings that aren't toggle/choice fields (paths, URLs, custom args) and
 adding a brand-new scanner block still go through Initialize or your
 `$EDITOR`. If no `argus.yml` exists yet, Configure points you to Initialize
 and falls back to `$EDITOR` / `$VISUAL` so you can create one by hand.
+
+## Initialize
+
+A guided first-run wizard, all in-app — no shelling out to the CLI. It runs
+the same detection as `argus init`, shows what it found (languages,
+dependency manifests, CI, infrastructure) and a one-line tool-readiness
+summary, then lists the **proposed scanners** as toggles so you can turn any
+off before writing. Press `w` to write `argus.yml`, or `r` to write **and**
+jump straight into your first scan; `esc` cancels.
+
+If an `argus.yml` already exists, the wizard says so and asks you to press
+the write key a second time to confirm the overwrite — it never clobbers a
+config silently. The detection and config generation are the exact pure
+functions behind `argus init`; the wizard is just a frontend over them.
 
 ## Settings
 
@@ -82,6 +96,6 @@ Settings are user preferences, kept separate from your project's
 The Console and `argus view terminal` share the same findings viewer —
 "View findings" opens it, and `argus view` is the direct deep-link. See
 [`view-terminal.md`](view-terminal.md) for the full triage reference. The
-broader plan for the Console (the init wizard and deeper vulnerability
-mitigation are next) lives in
+broader plan for the Console (deeper vulnerability mitigation and folding
+the findings viewer in as a true in-app screen are next) lives in
 [`developer/CONSOLE-ROADMAP.md`](developer/CONSOLE-ROADMAP.md).

--- a/docs/developer/CONSOLE-ROADMAP.md
+++ b/docs/developer/CONSOLE-ROADMAP.md
@@ -168,13 +168,29 @@ Edit `argus.yml` by form, not by hand.
   logic (`scripts/docsite/architecture.py`) is the source of truth to reuse
   when that lands.
 
-## Phase 3 — Init wizard screen (planned)
+## Phase 3 — Init wizard screen (shipped, into PR #261)
 
-Guided first-run. Wraps the existing detection (`argus init` —
-language / framework / linter detection) in an interactive screen: detect →
-review the proposed scanner set → tweak → write `argus.yml` → offer to run
-the first scan (hand off to the Phase-0 runner). No new detection logic;
-it's a frontend over `argus init`.
+Guided first-run, all in-app — the `argus init` subprocess hand-off is gone.
+
+**Shipped**
+- **`InitScreen`** (`argus/viewers/terminal/console.py`), reached from the
+  home menu's *Initialize* entry: detect → show what was found + a
+  tool-readiness line → list the proposed scanners as toggles → write
+  `argus.yml`. `w` writes; `r` writes **and** hands off to the Phase-0 scan
+  runner for the first scan; `esc` cancels. An existing `argus.yml` requires
+  a confirming second keypress before it's overwritten (mirrors
+  `argus init`'s `--force` guard) — never a silent clobber.
+- **UI-free core** (`argus/viewers/terminal/init_wizard.py`, textual-free →
+  CI-covered): `build_plan(root)` calls the *pure* `argus.init` functions
+  (`detect_project`, `generate_config`, `_extract_enabled_scanners`,
+  `_check_local_readiness`) and returns an `InitPlan` (detected categories,
+  proposed scanners, the generated YAML, readiness). `write_config` enforces
+  the overwrite guard. **No detection logic is reimplemented** — the wizard
+  is strictly a frontend over `argus init`. The signal→label map was
+  promoted to `argus.init.SIGNAL_LABELS` so the CLI summary and the wizard
+  render identical names.
+- Scanner toggles reuse the Phase-2 `config_editor` over the generated YAML,
+  so toggling and the comment-preserving write share one implementation.
 
 ## Phase 4 — Console home, settings, and bare-`argus` entry (shipped: shell)
 
@@ -199,17 +215,17 @@ findings viewer in as a true in-app screen (it's a hand-off today).
   when stdout *and* stdin are a TTY; piped / CI / no-`[terminal]` falls
   back to `--help` (the backward-compat contract). `argus view` still
   deep-links to findings.
-- **Configure / Init** reach the real CLI capabilities now: Configure opens
-  the Phase-2 form editor (falling back to `$EDITOR`/`$VISUAL` via
-  `App.suspend` when no `argus.yml` exists yet), Init streams `argus init`.
-  The init wizard (Phase 3) replaces the streaming hand-off.
+- **Configure / Init** are both in-app screens now: Configure opens the
+  Phase-2 form editor (falling back to `$EDITOR`/`$VISUAL` via `App.suspend`
+  when no `argus.yml` exists yet), Init opens the Phase-3 wizard. The
+  `argus init` subprocess hand-off has been removed.
 
 **Remaining**
-- Findings + Init are hand-offs (the console exits with a sentinel; the
-  viewer / `argus init` run, then the console reopens). The seamless
-  single-app version folds the findings viewer in as a `FindingsScreen`
-  mounted by both the Console and `argus view` — the "Console module
-  layout" decision below.
+- Findings is still a hand-off (the console exits with a sentinel; the
+  viewer runs, then the console reopens). The seamless single-app version
+  folds the findings viewer in as a `FindingsScreen` mounted by both the
+  Console and `argus view` — the "Console module layout" decision below.
+  (Configure and Init are now in-app screens; only findings remains.)
 - Deeper terminal-compat / accessibility (`NO_COLOR`, low-color, SSH/tmux
   fallbacks, screen-reader plain mode) beyond reduced-motion + the
   animation kill-switch.


### PR DESCRIPTION
## Description
Phase 3 of the Console roadmap: an **in-app Initialize wizard**. The home menu's **Initialize** entry now opens an `InitScreen` instead of shelling out to `argus init`. This PR targets the Console integration branch (`feat/tui-explorer-and-scan-runner`, PR #261), not `main` — it merges in once green so the full Console can be reviewed as one solution.

## Changes Made
- [x] Modified existing scanner/workflow
- [x] Updated documentation
- [ ] Added new scanner/workflow
- [ ] Fixed bug
- [x] Other (please specify): new Console wizard screen + UI-free wizard core

### Details
- **`InitScreen`** (`argus/viewers/terminal/console.py`): detect → show what was found + a one-line tool-readiness summary → list proposed scanners as toggles → write `argus.yml`. `w` writes; `r` writes **and** hands off to the Phase-0 scan runner for the first scan; `esc` cancels. An existing `argus.yml` requires a confirming second keypress before overwrite (mirrors `argus init --force`) — never a silent clobber.
- **`init_wizard.py`** (new, `argus/viewers/terminal/`): UI-free, textual-free **frontend over the pure `argus.init` functions** — no detection logic is reimplemented.
  - `build_plan(root)` calls `detect_project` / `generate_config` / `_extract_enabled_scanners` / `_check_local_readiness` and returns an `InitPlan` (detected categories, proposed scanners, generated YAML, readiness).
  - `write_config` enforces the overwrite guard (`FileExistsError` unless `force`).
- **Reuse, not duplication**: scanner toggles reuse the Phase-2 `config_editor` over the generated YAML, so toggling and the comment-preserving write share one implementation.
- **`argus.init.SIGNAL_LABELS`**: the signal→label map was promoted to a module-level constant so the CLI summary and the wizard render identical names.
- **Dead code removed**: with Init in-app, the `_HANDOFF_INIT` sentinel and its `subprocess` hand-off in `launch()` are gone (the unused `sys` import too).

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

### Test Results
- `test_init_wizard.py` (new): 24 tests covering detected-category mapping, plan building (python project / empty dir / `detect=False`), readiness formatting, summary line, and the `write_config` overwrite guard.
- `test_console.py` (updated): `init` now routes through `_open_init` (pushes `InitScreen`, no hand-off); added `InitScreen` construction coverage.
- Manual: real-Textual `Pilot` smoke tests confirmed detect → toggle (recompose) → write end-to-end, and the existing-config two-keypress overwrite arm.
- Full suite: **4051 passed, 21 skipped**, coverage gate met (≥80%). The 3 local-only `viewers/browser` failures are the known pre-existing fastapi-0.136.1 template diffs (green in CI), unrelated to this change.

## Security Considerations
- [x] No security impact

### Security Details
The wizard writes a generated/validated `argus.yml` and never overwrites an existing file without an explicit second confirmation. No code execution; detection is the same read-only logic `argus init` already runs.

## AI Context Updates (.ai/)
- [x] `.ai/architecture.yaml` updated (Init wizard + `init_wizard.py` noted under `viewers/terminal/`)
- [ ] `.ai/workflows.yaml` updated
- [ ] `.ai/decisions.yaml` updated
- [ ] `.ai/errors.yaml` updated

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (`docs/console.md` Initialize section, `docs/developer/CONSOLE-ROADMAP.md` Phase 3 → shipped)
- [ ] Changelog updated (handled at release)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Part of the Console epic (`docs/developer/CONSOLE-ROADMAP.md`, Phase 3).

## Screenshots/Logs (if applicable)
Wizard is keyboard-driven (enter toggle · w write · r write & scan · esc cancel). It shows the detected project signals, a readiness line, and the proposed scanner toggles.
