### PR TITLE
feat(view): live vulnerability intelligence — EPSS + CISA KEV (Phase 6)

### DIFF
--- a/.ai/architecture.yaml
+++ b/.ai/architecture.yaml
@@ -97,6 +97,11 @@ components:
         unified-diff bump of requirements*.txt (pip) or package.json (npm), preserving the version-spec style,
         with an ecosystem-command fallback. Drives the terminal viewer's ``F`` Fix overlay; AI tier (scn/ai.py)
         and action SHA-pinning / opengrep autofix are later phases (docs/developer/CONSOLE-ROADMAP.md).
+      core/enrichment.py: UI-free live vulnerability intelligence (Phase 6). EnrichmentService.enrich(cve_ids)
+        fetches EPSS (FIRST.org, exploit probability) + CISA KEV (actively-exploited) with an on-disk TTL cache
+        and injectable HTTP/clock; risk_score(severity, enrichment) blends severity x EPSS x KEV (KEV floors at
+        0.9) for re-ranking; risk_badge / enrichment_detail_rows render it. Opt-in, offline-degrading, sends only
+        public CVE ids. Drives the terminal viewer's ``i`` Intel action (EPSS/KEV/Risk in the detail pane).
       viewers/: '`argus view` interfaces (optional extras)'
       viewers/__init__.py: ViewerUnavailable shared exception
       viewers/terminal/: '`argus view --interface=terminal` — Textual TUI ([terminal] extra). Includes
@@ -702,6 +707,11 @@ docsite:
         unified-diff bump of requirements*.txt (pip) or package.json (npm), preserving the version-spec style,
         with an ecosystem-command fallback. Drives the terminal viewer's ``F`` Fix overlay; AI tier (scn/ai.py)
         and action SHA-pinning / opengrep autofix are later phases (docs/developer/CONSOLE-ROADMAP.md).
+      core/enrichment.py: UI-free live vulnerability intelligence (Phase 6). EnrichmentService.enrich(cve_ids)
+        fetches EPSS (FIRST.org, exploit probability) + CISA KEV (actively-exploited) with an on-disk TTL cache
+        and injectable HTTP/clock; risk_score(severity, enrichment) blends severity x EPSS x KEV (KEV floors at
+        0.9) for re-ranking; risk_badge / enrichment_detail_rows render it. Opt-in, offline-degrading, sends only
+        public CVE ids. Drives the terminal viewer's ``i`` Intel action (EPSS/KEV/Risk in the detail pane).
       viewers/: '`argus view` interfaces (optional extras)'
       viewers/__init__.py: ViewerUnavailable shared exception
       viewers/terminal/: '`argus view --interface=terminal` — Textual TUI ([terminal] extra). Includes

--- a/argus/core/enrichment.py
+++ b/argus/core/enrichment.py
@@ -1,0 +1,328 @@
+"""Live vulnerability intelligence — EPSS + CISA KEV enrichment (Phase 6).
+
+Turns a finding from "a CVE id + severity" into "*should I care, right
+now?*" by layering two free, no-auth signals onto each CVE:
+
+- **EPSS** (FIRST.org) — the exploit-probability score: how likely this CVE
+  is to be exploited in the next 30 days.
+- **CISA KEV** — whether the CVE is in the Known-Exploited-Vulnerabilities
+  catalog, i.e. *actively* exploited in the wild.
+
+These re-rank findings by real-world risk: a CRITICAL with a 0.02 EPSS and
+no KEV entry is less urgent than a HIGH at 0.7 EPSS that's in KEV. No OSS
+scanner surfaces this today.
+
+Design (mirrors the rest of the core):
+- **UI-free** — no Textual / FastAPI; pure data + stdlib HTTP.
+- **Opt-in & offline-degrading** — callers choose when to fetch; with no
+  network (or ``offline``), :meth:`EnrichmentService.enrich` returns ``{}``
+  and findings render exactly as before, just without the badges.
+- **Privacy-safe** — only public CVE ids leave the machine, never source or
+  secrets. Results cache on disk with a TTL so repeat triage is offline.
+- **Testable** — the parse / score functions are pure; the service takes an
+  injectable HTTP getter and clock so the cache + fetch logic is unit-tested
+  with no network.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Iterable
+
+from argus.core.models import Severity
+
+EPSS_API = "https://api.first.org/data/v1/epss"
+KEV_FEED = (
+    "https://www.cisa.gov/sites/default/files/feeds/"
+    "known_exploited_vulnerabilities.json"
+)
+
+_CVE_BATCH = 100          # EPSS API accepts a comma-separated batch
+_DEFAULT_TIMEOUT = 6.0    # seconds — fail fast so triage never hangs
+_TTL_EPSS = 6 * 3600      # EPSS refreshes daily; 6h cache is plenty
+_TTL_KEV = 24 * 3600      # KEV catalog updates ~daily
+
+
+@dataclass(frozen=True)
+class Enrichment:
+    """The intelligence layered onto one CVE. All fields optional/None-safe."""
+
+    cve: str
+    epss: float | None = None          # exploit probability, 0..1
+    percentile: float | None = None    # EPSS percentile, 0..1
+    kev: bool = False                  # in CISA Known-Exploited catalog
+    source: str = ""                   # which signals contributed, e.g. "epss+kev"
+
+
+# Severity → base risk weight in [0, 1]. Severity still dominates; EPSS
+# modulates and KEV floors (see ``risk_score``).
+SEVERITY_WEIGHT: dict[Severity, float] = {
+    Severity.CRITICAL: 1.0,
+    Severity.HIGH: 0.8,
+    Severity.MEDIUM: 0.5,
+    Severity.LOW: 0.2,
+    Severity.INFO: 0.05,
+    Severity.UNKNOWN: 0.1,
+}
+
+
+def risk_score(severity: Severity, enr: Enrichment | None) -> float:
+    """Blend severity + EPSS + KEV into a single 0..1 priority score.
+
+    Severity-weighted and EPSS-modulated; a KEV (actively-exploited) entry
+    floors the score at 0.9 because "exploited in the wild" outranks a
+    nominal severity label. Returns the plain severity weight when no
+    enrichment is available, so unenriched findings still sort sensibly.
+    """
+    base = SEVERITY_WEIGHT.get(severity, 0.1)
+    epss = enr.epss if (enr and enr.epss is not None) else 0.0
+    combined = 0.6 * base + 0.4 * epss
+    if enr and enr.kev:
+        combined = max(combined, 0.9)
+    return round(min(1.0, combined), 4)
+
+
+def risk_badge(enr: Enrichment | None) -> str:
+    """Short display badge, e.g. ``"🔥KEV  EPSS 73%"``. Empty when unenriched."""
+    if enr is None:
+        return ""
+    parts: list[str] = []
+    if enr.kev:
+        parts.append("🔥KEV")
+    if enr.epss is not None:
+        parts.append(f"EPSS {round(enr.epss * 100)}%")
+    return "  ".join(parts)
+
+
+def enrichment_detail_rows(
+    severity: Severity, enr: Enrichment | None,
+) -> list[tuple[str, str]]:
+    """Detail-pane ``(label, value)`` rows for a finding's enrichment.
+
+    Empty when unenriched, so callers can unconditionally append the result
+    to ``finding_detail_rows``. Front-end-agnostic (plain strings), matching
+    the shape ``finding_detail_rows`` returns.
+    """
+    if enr is None:
+        return []
+    rows: list[tuple[str, str]] = []
+    if enr.epss is not None:
+        pct = (
+            f"  (percentile {round((enr.percentile or 0) * 100)})"
+            if enr.percentile is not None else ""
+        )
+        rows.append(("EPSS", f"{round(enr.epss * 100, 1)}% exploit probability{pct}"))
+    rows.append((
+        "KEV",
+        "⚠ actively exploited (CISA KEV)" if enr.kev else "not in CISA KEV",
+    ))
+    rows.append(("Risk", f"{round(risk_score(severity, enr) * 100)}/100"))
+    return rows
+
+
+def is_cve(identifier: str | None) -> bool:
+    """True when ``identifier`` looks like a CVE id (the EPSS/KEV key)."""
+    if not identifier:
+        return False
+    upper = identifier.upper()
+    if not upper.startswith("CVE-"):
+        return False
+    parts = upper.split("-")
+    return len(parts) == 3 and parts[1].isdigit() and parts[2].isdigit()
+
+
+def parse_epss_response(payload: object) -> dict[str, tuple[float | None, float | None]]:
+    """Parse the FIRST.org EPSS response into ``{CVE: (epss, percentile)}``.
+
+    Tolerant of missing/malformed rows — a bad row is skipped, never raised.
+    """
+    out: dict[str, tuple[float | None, float | None]] = {}
+    if not isinstance(payload, dict):
+        return out
+    for row in payload.get("data") or []:
+        if not isinstance(row, dict):
+            continue
+        cve = str(row.get("cve", "")).upper()
+        if not cve:
+            continue
+        out[cve] = (_as_float(row.get("epss")), _as_float(row.get("percentile")))
+    return out
+
+
+def parse_kev_response(payload: object) -> set[str]:
+    """Parse the CISA KEV catalog into a set of uppercase CVE ids."""
+    out: set[str] = set()
+    if not isinstance(payload, dict):
+        return out
+    for vuln in payload.get("vulnerabilities") or []:
+        if not isinstance(vuln, dict):
+            continue
+        cid = str(vuln.get("cveID", "")).upper()
+        if cid:
+            out.add(cid)
+    return out
+
+
+def _as_float(value: object) -> float | None:
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+
+
+def _default_http_get(url: str) -> object | None:
+    """GET ``url`` and parse JSON; return ``None`` on any failure.
+
+    Best-effort by contract: network errors, timeouts, and non-JSON bodies
+    all degrade to ``None`` so enrichment never breaks triage.
+    """
+    try:
+        request = urllib.request.Request(url, headers={"User-Agent": "argus-enrichment"})
+        with urllib.request.urlopen(request, timeout=_DEFAULT_TIMEOUT) as resp:  # noqa: S310
+            return json.loads(resp.read().decode("utf-8"))
+    except Exception:
+        return None
+
+
+HttpGet = Callable[[str], object | None]
+
+
+def _network_disabled() -> bool:
+    """Honour the common offline env vars so enrichment never reaches out."""
+    return any(
+        os.environ.get(var, "").strip().lower() in ("1", "true", "yes")
+        for var in ("ARGUS_NO_NETWORK", "NO_NETWORK", "OFFLINE")
+    )
+
+
+class EnrichmentService:
+    """Fetches + caches EPSS / KEV intelligence for a set of CVEs.
+
+    HTTP and the clock are injectable so the cache + fetch logic is fully
+    unit-testable offline.
+    """
+
+    def __init__(
+        self,
+        *,
+        cache_dir: Path | None = None,
+        http_get: HttpGet | None = None,
+        now: Callable[[], float] = time.time,
+        offline: bool | None = None,
+        ttl_epss: int = _TTL_EPSS,
+        ttl_kev: int = _TTL_KEV,
+    ) -> None:
+        self._cache_dir = cache_dir or _default_cache_dir()
+        self._http_get = http_get or _default_http_get
+        self._now = now
+        self._offline = _network_disabled() if offline is None else offline
+        self._ttl_epss = ttl_epss
+        self._ttl_kev = ttl_kev
+
+    @property
+    def offline(self) -> bool:
+        return self._offline
+
+    def enrich(self, cve_ids: Iterable[str]) -> dict[str, Enrichment]:
+        """Return ``{CVE: Enrichment}`` for the CVE-shaped ids given.
+
+        Non-CVE ids (GHSA-only, scanner-internal) are skipped — EPSS/KEV are
+        CVE-keyed. Returns ``{}`` when offline or given nothing to do.
+        """
+        cves = sorted({c.upper() for c in cve_ids if is_cve(c)})
+        if not cves or self._offline:
+            return {}
+        kev = self._kev_set()
+        epss = self._epss_map(cves)
+        result: dict[str, Enrichment] = {}
+        for cve in cves:
+            score, pct = epss.get(cve, (None, None))
+            in_kev = cve in kev
+            contributed = "+".join(
+                name for name, on in (("epss", score is not None), ("kev", in_kev)) if on
+            )
+            result[cve] = Enrichment(
+                cve=cve, epss=score, percentile=pct, kev=in_kev,
+                source=contributed or "none",
+            )
+        return result
+
+    # -- KEV catalog (one cached file) --------------------------------------
+
+    def _kev_set(self) -> set[str]:
+        cached = self._read_cache("kev.json", self._ttl_kev)
+        if cached is not None:
+            return parse_kev_response(cached)
+        payload = self._http_get(KEV_FEED)
+        if payload is None:
+            return set()
+        self._write_cache("kev.json", payload)
+        return parse_kev_response(payload)
+
+    # -- EPSS scores (per-CVE map cache) ------------------------------------
+
+    def _epss_map(self, cves: list[str]) -> dict[str, tuple[float | None, float | None]]:
+        cache = self._read_epss_cache()
+        fresh: dict[str, tuple[float | None, float | None]] = {}
+        stale: list[str] = []
+        for cve in cves:
+            entry = cache.get(cve)
+            if entry and (self._now() - entry.get("ts", 0)) < self._ttl_epss:
+                fresh[cve] = (entry.get("epss"), entry.get("percentile"))
+            else:
+                stale.append(cve)
+        for batch in _chunked(stale, _CVE_BATCH):
+            fetched = self._fetch_epss(batch)
+            now = self._now()
+            for cve in batch:
+                epss, pct = fetched.get(cve, (None, None))
+                fresh[cve] = (epss, pct)
+                cache[cve] = {"epss": epss, "percentile": pct, "ts": now}
+        if stale:
+            self._write_cache("epss.json", cache)
+        return fresh
+
+    def _fetch_epss(self, cves: list[str]) -> dict[str, tuple[float | None, float | None]]:
+        query = urllib.parse.urlencode({"cve": ",".join(cves)})
+        payload = self._http_get(f"{EPSS_API}?{query}")
+        return parse_epss_response(payload) if payload is not None else {}
+
+    def _read_epss_cache(self) -> dict[str, dict]:
+        raw = self._read_cache("epss.json", ttl=None)  # per-entry TTL, not file TTL
+        return raw if isinstance(raw, dict) else {}
+
+    # -- cache primitives ---------------------------------------------------
+
+    def _read_cache(self, name: str, ttl: int | None) -> object | None:
+        path = self._cache_dir / name
+        try:
+            if ttl is not None and (self._now() - path.stat().st_mtime) >= ttl:
+                return None
+            return json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return None
+
+    def _write_cache(self, name: str, payload: object) -> None:
+        try:
+            self._cache_dir.mkdir(parents=True, exist_ok=True)
+            (self._cache_dir / name).write_text(
+                json.dumps(payload), encoding="utf-8",
+            )
+        except OSError:
+            pass  # cache is best-effort; a read-only FS just means no caching
+
+
+def _default_cache_dir() -> Path:
+    base = os.environ.get("XDG_CACHE_HOME") or str(Path.home() / ".cache")
+    return Path(base) / "argus" / "enrichment"
+
+
+def _chunked(items: list[str], size: int) -> Iterable[list[str]]:
+    for start in range(0, len(items), size):
+        yield items[start:start + size]

--- a/argus/tests/core/test_enrichment.py
+++ b/argus/tests/core/test_enrichment.py
@@ -1,0 +1,208 @@
+"""Unit tests for argus.core.enrichment (Phase 6 — live vuln intelligence).
+
+UI-free + network-free: the parse/score functions are pure, and the
+service is driven with an injected HTTP getter + fake clock so caching,
+TTL expiry, batching, and offline behaviour are all exercised without a
+single real request.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from argus.core.enrichment import (
+    EPSS_API,
+    KEV_FEED,
+    Enrichment,
+    EnrichmentService,
+    enrichment_detail_rows,
+    is_cve,
+    parse_epss_response,
+    parse_kev_response,
+    risk_badge,
+    risk_score,
+)
+from argus.core.models import Severity
+
+
+class TestIsCve:
+    @pytest.mark.parametrize("ident", ["CVE-2021-44228", "cve-2021-44228", "CVE-2023-1234567"])
+    def test_accepts_cve_shapes(self, ident):
+        assert is_cve(ident) is True
+
+    @pytest.mark.parametrize("ident", ["", None, "GHSA-xxxx-yyyy-zzzz", "CVE-2021", "B001", "CVE-abc-123"])
+    def test_rejects_non_cve(self, ident):
+        assert is_cve(ident) is False
+
+
+class TestParseEpss:
+    def test_parses_rows(self):
+        payload = {"data": [
+            {"cve": "CVE-2021-44228", "epss": "0.97565", "percentile": "0.99977"},
+            {"cve": "cve-2020-0001", "epss": "0.001", "percentile": "0.1"},
+        ]}
+        out = parse_epss_response(payload)
+        assert out["CVE-2021-44228"] == (0.97565, 0.99977)
+        assert out["CVE-2020-0001"] == (0.001, 0.1)
+
+    def test_malformed_rows_skipped(self):
+        payload = {"data": [{"cve": "CVE-1-1", "epss": "nope"}, "junk", {"no_cve": 1}]}
+        out = parse_epss_response(payload)
+        assert out["CVE-1-1"] == (None, None)
+        assert len(out) == 1
+
+    def test_non_dict_is_empty(self):
+        assert parse_epss_response(None) == {}
+        assert parse_epss_response([1, 2]) == {}
+
+
+class TestParseKev:
+    def test_extracts_cve_ids(self):
+        payload = {"vulnerabilities": [
+            {"cveID": "CVE-2021-44228", "vendorProject": "Apache"},
+            {"cveID": "cve-2017-0144"},
+        ]}
+        assert parse_kev_response(payload) == {"CVE-2021-44228", "CVE-2017-0144"}
+
+    def test_tolerates_bad_entries(self):
+        assert parse_kev_response({"vulnerabilities": ["x", {"no_id": 1}]}) == set()
+
+    def test_non_dict_is_empty(self):
+        assert parse_kev_response(None) == set()
+
+
+class TestRiskScore:
+    def test_severity_only_uses_weight(self):
+        assert risk_score(Severity.CRITICAL, None) == round(0.6 * 1.0, 4)
+        assert risk_score(Severity.LOW, None) == round(0.6 * 0.2, 4)
+
+    def test_epss_modulates_upward(self):
+        low = risk_score(Severity.MEDIUM, Enrichment("CVE-1-1", epss=0.0))
+        high = risk_score(Severity.MEDIUM, Enrichment("CVE-1-1", epss=0.9))
+        assert high > low
+
+    def test_kev_floors_at_0_9(self):
+        # A LOW severity in KEV must outrank a plain CRITICAL.
+        kev_low = risk_score(Severity.LOW, Enrichment("CVE-1-1", kev=True))
+        assert kev_low >= 0.9
+        assert kev_low > risk_score(Severity.CRITICAL, None)
+
+    def test_clamped_to_one(self):
+        assert risk_score(Severity.CRITICAL, Enrichment("CVE-1-1", epss=1.0, kev=True)) == 1.0
+
+    def test_unknown_severity_low_floor(self):
+        assert risk_score(Severity.UNKNOWN, None) == round(0.6 * 0.1, 4)
+
+
+class TestRiskBadge:
+    def test_kev_and_epss(self):
+        badge = risk_badge(Enrichment("CVE-1-1", epss=0.73, kev=True))
+        assert "🔥KEV" in badge and "EPSS 73%" in badge
+
+    def test_epss_only(self):
+        assert risk_badge(Enrichment("CVE-1-1", epss=0.05)) == "EPSS 5%"
+
+    def test_empty_when_none(self):
+        assert risk_badge(None) == ""
+        assert risk_badge(Enrichment("CVE-1-1")) == ""
+
+
+class TestEnrichmentDetailRows:
+    def test_empty_when_unenriched(self):
+        assert enrichment_detail_rows(Severity.HIGH, None) == []
+
+    def test_includes_epss_kev_risk(self):
+        rows = dict(enrichment_detail_rows(
+            Severity.HIGH, Enrichment("CVE-1-1", epss=0.73, percentile=0.99, kev=True),
+        ))
+        assert "73.0%" in rows["EPSS"] and "percentile 99" in rows["EPSS"]
+        assert "actively exploited" in rows["KEV"]
+        assert rows["Risk"].endswith("/100")
+
+    def test_not_in_kev_phrasing(self):
+        rows = dict(enrichment_detail_rows(Severity.LOW, Enrichment("CVE-1-1", epss=0.01)))
+        assert rows["KEV"] == "not in CISA KEV"
+
+
+class _FakeHttp:
+    """Records calls and serves canned EPSS / KEV payloads."""
+
+    def __init__(self, epss=None, kev=None):
+        self.calls: list[str] = []
+        self._epss = epss or {}
+        self._kev = kev or set()
+
+    def __call__(self, url: str):
+        self.calls.append(url)
+        if url.startswith(KEV_FEED):
+            return {"vulnerabilities": [{"cveID": c} for c in self._kev]}
+        if url.startswith(EPSS_API):
+            wanted = url.split("cve=", 1)[1].split("&", 1)[0]
+            cves = wanted.replace("%2C", ",").split(",")
+            return {"data": [
+                {"cve": c, "epss": str(self._epss[c][0]), "percentile": str(self._epss[c][1])}
+                for c in cves if c in self._epss
+            ]}
+        return None
+
+
+class TestEnrichmentService:
+    def test_enrich_merges_epss_and_kev(self, tmp_path):
+        http = _FakeHttp(
+            epss={"CVE-2021-44228": (0.97, 0.99)},
+            kev={"CVE-2021-44228"},
+        )
+        svc = EnrichmentService(cache_dir=tmp_path, http_get=http, offline=False)
+        out = svc.enrich(["CVE-2021-44228"])
+        enr = out["CVE-2021-44228"]
+        assert enr.epss == 0.97 and enr.percentile == 0.99 and enr.kev is True
+        assert "epss" in enr.source and "kev" in enr.source
+
+    def test_offline_returns_empty(self, tmp_path):
+        http = _FakeHttp(epss={"CVE-1-1": (0.5, 0.5)})
+        svc = EnrichmentService(cache_dir=tmp_path, http_get=http, offline=True)
+        assert svc.enrich(["CVE-1-1"]) == {}
+        assert http.calls == []  # never reached out
+
+    def test_non_cve_ids_skipped(self, tmp_path):
+        http = _FakeHttp()
+        svc = EnrichmentService(cache_dir=tmp_path, http_get=http, offline=False)
+        assert svc.enrich(["GHSA-aaaa-bbbb-cccc", "B001", ""]) == {}
+
+    def test_caches_across_calls(self, tmp_path):
+        http = _FakeHttp(epss={"CVE-1-1": (0.5, 0.5)}, kev=set())
+        svc = EnrichmentService(cache_dir=tmp_path, http_get=http, offline=False)
+        svc.enrich(["CVE-1-1"])
+        first = len(http.calls)
+        svc.enrich(["CVE-1-1"])  # second time: served from cache
+        assert len(http.calls) == first  # no new requests
+
+    def test_ttl_expiry_refetches(self, tmp_path):
+        clock = {"t": 1000.0}
+        http = _FakeHttp(epss={"CVE-1-1": (0.5, 0.5)})
+        svc = EnrichmentService(
+            cache_dir=tmp_path, http_get=http, offline=False,
+            now=lambda: clock["t"], ttl_epss=100, ttl_kev=100,
+        )
+        svc.enrich(["CVE-1-1"])
+        before = len(http.calls)
+        clock["t"] += 1000  # well past TTL
+        svc.enrich(["CVE-1-1"])
+        assert len(http.calls) > before  # stale → refetched
+
+    def test_http_failure_degrades(self, tmp_path):
+        svc = EnrichmentService(
+            cache_dir=tmp_path, http_get=lambda url: None, offline=False,
+        )
+        out = svc.enrich(["CVE-1-1"])
+        # Still produces an entry (no signal), never raises.
+        assert out["CVE-1-1"].epss is None and out["CVE-1-1"].kev is False
+
+    def test_kev_cache_written_to_disk(self, tmp_path):
+        http = _FakeHttp(kev={"CVE-9-9"})
+        svc = EnrichmentService(cache_dir=tmp_path, http_get=http, offline=False)
+        svc.enrich(["CVE-9-9"])
+        cached = json.loads((tmp_path / "kev.json").read_text())
+        assert any(v["cveID"] == "CVE-9-9" for v in cached["vulnerabilities"])

--- a/argus/viewers/terminal/app.py
+++ b/argus/viewers/terminal/app.py
@@ -52,6 +52,13 @@ from argus.core.findings_view import (
     unique_products,
     unique_scanners,
 )
+from argus.core.enrichment import (
+    Enrichment,
+    EnrichmentService,
+    enrichment_detail_rows,
+    is_cve,
+    risk_badge,
+)
 from argus.core.models import Finding, Severity
 
 
@@ -1144,6 +1151,7 @@ class ArgusBrowseCommands(Provider):
             ("Runs: Toggle the runs sidebar", "Show / hide the list of discovered scan runs and switch between them (b)", app.action_toggle_runs),
             ("Scan: Run argus scan", "Launch argus scan from the TUI, stream output, and reload results when done (shift+r)", app.action_run_scan),
             ("Fix: Apply a Tier-1 dependency bump", "Propose + preview + apply a deterministic fix for the focused finding or selection (shift+f)", app.action_fix),
+            ("Intel: Enrich with EPSS + CISA KEV", "Fetch exploit-probability + known-exploited intelligence for the CVEs in view (i)", app.action_enrich),
             ("Search findings",          "Focus the search box", app.action_focus_search),
             ("Filter: Critical only",    "Show only CRITICAL findings", app.action_filter_critical),
             ("Filter: High severity and above", "Show HIGH + CRITICAL findings", app.action_filter_high),
@@ -1233,6 +1241,7 @@ class FindingDetail(Static):
         self,
         f: Finding | None,
         source_block: str | None = None,
+        enrichment: "Enrichment | None" = None,
     ) -> None:
         if f is None:
             self.update("[dim]Select a finding to see details.[/dim]")
@@ -1245,9 +1254,13 @@ class FindingDetail(Static):
         # refactoring the pane into per-cell widgets.
         header_id = self._linkify_id(f)
         glyph = _SEVERITY_GLYPH.get(f.severity, "?")
-        lines = [f"[bold]{header_id}[/bold]   {glyph}", ""]
+        badge = risk_badge(enrichment)
+        badge_md = f"   [b]{badge}[/b]" if badge else ""
+        lines = [f"[bold]{header_id}[/bold]   {glyph}{badge_md}", ""]
 
-        rows = finding_detail_rows(f)
+        # Enrichment rows (EPSS / KEV / Risk) append after the core rows when
+        # the finding's CVE has been enriched; empty otherwise.
+        rows = finding_detail_rows(f) + enrichment_detail_rows(f.severity, enrichment)
         for label, value in rows:
             rendered = self._linkify_value(label, value)
             lines.append(f"[b]{label}:[/b]".ljust(13) + f" {rendered}")
@@ -1377,6 +1390,11 @@ class BrowseApp(App):
         # — or every fixable row in the multi-select set. Diff-first: shows
         # the proposed change before touching anything.
         Binding("F", "fix", "Fix", show=True),
+        # Live vulnerability intelligence: fetch EPSS (exploit probability) +
+        # CISA KEV (actively-exploited) for the CVEs in view and re-prioritise
+        # by real-world risk. Opt-in / offline-degrading — only reaches out
+        # when pressed.
+        Binding("i", "enrich", "Intel", show=True),
         # Multi-select — drives the bulk-action workflows (export N rows,
         # paste a CVE list into a bug tracker). ``space``/``a``/``A``
         # manage the selection set; ``c`` copies CVEs from it. ``e``
@@ -1413,6 +1431,13 @@ class BrowseApp(App):
         # Storing the live object reference is the cheapest stable key
         # for an in-memory session.
         self._selected: set[int] = set()
+        # Live vulnerability intelligence (Phase 6): CVE → Enrichment, filled
+        # on demand by ``action_enrich`` (``i``). Empty until the user asks,
+        # so the viewer never reaches the network unprompted.
+        self._enrichment: dict[str, Enrichment] = {}
+        # Injectable for tests; None ⇒ a default service (env-driven offline
+        # detection, on-disk cache) is built on first ``action_enrich``.
+        self._enrichment_service: EnrichmentService | None = None
         # Load ``view:`` config (cve_source / open_location / editor)
         # from any argus.yml the user has in cwd or beside results_dir.
         # ArgusConfig.load() auto-detects and falls back to defaults if
@@ -1837,9 +1862,54 @@ class BrowseApp(App):
             return
         finding = self._visible[row]
         block = self._source_context_block(finding)
+        enrichment = self._enrichment.get(finding.cve.upper()) if finding.cve else None
         self.query_one("#detail", FindingDetail).update_finding(
-            finding, source_block=block,
+            finding, source_block=block, enrichment=enrichment,
         )
+
+    def action_enrich(self) -> None:  # pragma: no cover — UI/worker
+        """Fetch EPSS + CISA KEV intelligence for the CVEs in view (``i``).
+
+        Opt-in and offline-degrading: only reaches the network when pressed,
+        runs in a thread so the UI never blocks, and no-ops cleanly when
+        offline or when no CVE-identified findings are present.
+        """
+        cves = sorted({f.cve for f in self.all_findings if is_cve(f.cve)})
+        if not cves:
+            self.notify("No CVE-identified findings to enrich.", severity="information")
+            return
+        service = self._enrichment_service or EnrichmentService()
+        if service.offline:
+            self.notify(
+                "Offline — enrichment needs network access (EPSS + CISA KEV).",
+                severity="warning",
+            )
+            return
+        self.notify(
+            f"Fetching EPSS + CISA KEV for {len(cves)} CVEs…", severity="information",
+        )
+        self.run_worker(
+            lambda: self._enrich_work(service, cves), thread=True, exclusive=True,
+        )
+
+    def _enrich_work(  # pragma: no cover — worker thread
+        self, service: EnrichmentService, cves: list[str],
+    ) -> None:
+        result = service.enrich(cves)
+        self.call_from_thread(self._apply_enrichment, result)
+
+    def _apply_enrichment(  # pragma: no cover — UI
+        self, result: dict[str, Enrichment],
+    ) -> None:
+        self._enrichment.update(result)
+        kev = sum(1 for e in result.values() if e.kev)
+        epss = [e.epss for e in result.values() if e.epss is not None]
+        top = round(max(epss) * 100) if epss else 0
+        self.notify(
+            f"Enriched {len(result)} CVEs · {kev} in CISA KEV · top EPSS {top}%",
+            severity="information",
+        )
+        self._update_detail(self.query_one(DataTable).cursor_row)
 
     def _source_context_block(self, finding: Finding) -> str | None:
         """Render the ``[bold]Source[/bold]`` block for the detail pane.

--- a/docs/view-terminal.md
+++ b/docs/view-terminal.md
@@ -72,6 +72,7 @@ Press `?` inside the TUI for the same reference, grouped by purpose.
 | `b` | toggle the runs sidebar — switch between scan runs without relaunching |
 | `R` (shift+r) | run `argus scan` in-app, stream output, and reload results when done |
 | `F` (shift+f) | fix — propose a dependency bump for the finding (or selection), preview the diff, apply |
+| `i` | enrich — fetch EPSS + CISA KEV intelligence for the CVEs in view (see below) |
 | **Other** | |
 | `d` | executive dashboard overlay |
 | `D` (shift+d) | scan-over-scan diff — pick another `argus-results.json` and bucket changes |
@@ -132,6 +133,30 @@ re-run the scan (`R`) to confirm the finding is resolved. Findings that
 can be fixed also get an `⚒ Apply fix` entry in the right-click context
 menu. Findings with no known fixed version (or in an ecosystem Tier 1
 doesn't cover yet) report that no automatic fix is available.
+
+## Live vulnerability intelligence (`i`)
+
+A CVE id and a severity label don't answer the question that actually
+matters: *should I care about this one, right now?* Press `i` to enrich the
+CVEs in view with two free, no-auth signals that do:
+
+- **EPSS** (FIRST.org) — the **exploit-probability** score: how likely the
+  CVE is to be exploited in the next 30 days.
+- **CISA KEV** — whether the CVE is in the **Known-Exploited-Vulnerabilities**
+  catalog, i.e. *actively* exploited in the wild.
+
+The selected finding's detail pane then shows an **EPSS** percentage, a
+**KEV** flag, and a blended **Risk** score (severity-weighted, EPSS-modulated,
+floored high for KEV entries) — so a HIGH that's actively exploited rises
+above a CRITICAL that isn't. A toast summarises the batch (how many CVEs, how
+many in KEV, the top EPSS), and the header gains a `🔥KEV` / `EPSS n%` badge.
+
+Enrichment is **opt-in and offline-degrading**: it only reaches the network
+when you press `i`, runs off the UI thread so nothing blocks, caches results
+on disk (`$XDG_CACHE_HOME/argus/`) so repeat triage is offline, and sends
+only public CVE ids — never your source or secrets. With no network (or
+`ARGUS_NO_NETWORK=1`) the viewer behaves exactly as before, just without the
+badges.
 
 ## Mouse interactions
 


### PR DESCRIPTION
## Description
Phase 6 — the **headline** of the modernization program: **live vulnerability intelligence**. Press `i` in the terminal viewer to enrich the CVEs in view with EPSS + CISA KEV, so a finding answers *"should I care, right now?"* instead of just showing a CVE id + severity. Targets the integration branch (`feat/tui-explorer-and-scan-runner`, PR #261).

No OSS scanner surfaces this today — it's the differentiator.

## Changes Made
- [x] Added new core module (`argus/core/enrichment.py`)
- [x] Modified existing scanner/workflow (terminal viewer)
- [x] Updated documentation
- [ ] Fixed bug

### Details
- **`argus/core/enrichment.py`** (UI-free):
  - **EPSS** (FIRST.org, exploit probability over 30 days) + **CISA KEV** (actively-exploited catalog), both free / no-auth.
  - `EnrichmentService.enrich(cve_ids)` fetches + caches (on-disk TTL under `$XDG_CACHE_HOME/argus/`) with an **injectable HTTP getter + clock**, so all cache/fetch/TTL/offline paths are unit-tested with a fake transport — zero real requests in CI.
  - `risk_score(severity, enrichment)` blends `severity × EPSS × KEV` — KEV floors the score at 0.9, so a HIGH that's actively exploited outranks a CRITICAL that isn't. `risk_badge` / `enrichment_detail_rows` render it.
- **Viewer integration** (`app.py`): `i` runs a **thread worker** (UI never blocks); the selected finding's detail pane gains **EPSS / KEV / Risk** rows and a `🔥KEV` header badge; a toast summarises the batch (count · in-KEV · top EPSS). Command-palette entry mirrors it.
- **Opt-in & offline-degrading by construction:** only reaches the network when pressed, honours `ARGUS_NO_NETWORK` / `NO_NETWORK` / `OFFLINE`, sends **only public CVE ids** (never source or secrets), caches so repeat triage is offline, and degrades to today's behaviour with no network.
- **Follow-ons (noted):** risk-based list *sorting* (needs threading enrichment into the pure sort core) and GHSA/OSV advisory text.

## Testing
- [x] Unit tests added/updated — `test_enrichment.py`: 33 tests covering `is_cve`, EPSS/KEV parsing (incl. malformed), `risk_score` (severity weights, EPSS modulation, KEV floor, clamp), `risk_badge`, `enrichment_detail_rows`, and the service (merge, offline, non-CVE skip, **caching across calls**, **TTL expiry refetch**, HTTP-failure degrade, disk cache).
- [x] Manual testing — real-Textual `Pilot` smoke: `i` → fake service → `_enrichment` populated, detail pane renders EPSS 97% / "actively exploited" / Risk + `🔥KEV` badge.
- Full suite: **4084 passed, 21 skipped**, coverage gate met. (3 local-only `viewers/browser` fastapi-0.136.1 failures are pre-existing + green in CI.)

## Security Considerations
- [x] Potential security implications (explain below)

### Security Details
Adds **opt-in outbound network** to the terminal viewer (FIRST.org EPSS API + the CISA KEV feed). Mitigations: never fires unprompted (only on `i`); only public CVE identifiers leave the machine — no source, paths, or secrets; honours offline env vars; fail-closed (any network/JSON error degrades to no-enrichment, never raises); results cached locally. The browser viewer is untouched (still read-only / no egress). Worth an ADR for the egress posture.

## AI Context Updates (.ai/)
- [x] `.ai/architecture.yaml` updated (`core/enrichment.py` entry + viewer `i` action, both mirror blocks)

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (`docs/view-terminal.md` — keybind + "Live vulnerability intelligence" section)
- [ ] Changelog updated (handled by release-it)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Console epic — `docs/developer/CONSOLE-ROADMAP.md`, Phase 6.
