### PR TITLE
feat(view): bulk triage → OpenVEX + ignore files (Phase 7)

### DIFF
--- a/.ai/architecture.yaml
+++ b/.ai/architecture.yaml
@@ -102,6 +102,12 @@ components:
         and injectable HTTP/clock; risk_score(severity, enrichment) blends severity x EPSS x KEV (KEV floors at
         0.9) for re-ranking; risk_badge / enrichment_detail_rows render it. Opt-in, offline-degrading, sends only
         public CVE ids. Drives the terminal viewer's ``i`` Intel action (EPSS/KEV/Risk in the detail pane).
+      core/suppressions.py: UI-free bulk-triage → OpenVEX + scanner ignore files (Phase 7). decision_for(action,
+        ...) maps a triage action (false_positive/not_exploitable/accept_risk/investigating) to a TriageDecision;
+        build_vex_document / merge_vex_documents emit + merge an OpenVEX v0.2.0 doc (audit trail = status,
+        justification, reason, author, timestamp; keyed by CVE+product, idempotent @id); trivyignore_entries /
+        gitleaksignore_entries + write_suppressions append to .trivyignore/.gitleaksignore (never clobber). Reuses
+        the OpenVEX vocabulary of the reporters/attest layer; drives the terminal viewer's ``S`` Suppress action.
       viewers/: '`argus view` interfaces (optional extras)'
       viewers/__init__.py: ViewerUnavailable shared exception
       viewers/terminal/: '`argus view --interface=terminal` — Textual TUI ([terminal] extra). Includes
@@ -713,6 +719,12 @@ docsite:
         and injectable HTTP/clock; risk_score(severity, enrichment) blends severity x EPSS x KEV (KEV floors at
         0.9) for re-ranking; risk_badge / enrichment_detail_rows render it. Opt-in, offline-degrading, sends only
         public CVE ids. Drives the terminal viewer's ``i`` Intel action (EPSS/KEV/Risk in the detail pane).
+      core/suppressions.py: UI-free bulk-triage → OpenVEX + scanner ignore files (Phase 7). decision_for(action,
+        ...) maps a triage action (false_positive/not_exploitable/accept_risk/investigating) to a TriageDecision;
+        build_vex_document / merge_vex_documents emit + merge an OpenVEX v0.2.0 doc (audit trail = status,
+        justification, reason, author, timestamp; keyed by CVE+product, idempotent @id); trivyignore_entries /
+        gitleaksignore_entries + write_suppressions append to .trivyignore/.gitleaksignore (never clobber). Reuses
+        the OpenVEX vocabulary of the reporters/attest layer; drives the terminal viewer's ``S`` Suppress action.
       viewers/: '`argus view` interfaces (optional extras)'
       viewers/__init__.py: ViewerUnavailable shared exception
       viewers/terminal/: '`argus view --interface=terminal` — Textual TUI ([terminal] extra). Includes

--- a/argus/core/suppressions.py
+++ b/argus/core/suppressions.py
@@ -1,0 +1,298 @@
+"""Triage decisions → OpenVEX + scanner ignore files (Phase 7).
+
+The terminal viewer lets a user bulk-triage findings — mark them false
+positive, not-exploitable, risk-accepted, or under-investigation, with a
+reason. This module turns those decisions into durable, auditable artifacts:
+
+- an **OpenVEX** document (the audit trail: per-CVE status + justification +
+  reason + author + timestamp), the answer to the "where do triage decisions
+  come from?" question the OpenVEX *reporter* (``argus/reporters/openvex.py``)
+  deliberately left open, and
+- **scanner ignore-file entries** (``.trivyignore`` / ``.gitleaksignore``) so
+  the next scan respects the decision.
+
+UI-free on purpose (same rule as the rest of the core): the VEX builders,
+the merge, and the ignore-entry formatters are pure and unit-tested; only
+the file writes touch disk (tested with ``tmp_path``). The Textual screen is
+a thin caller.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+# Mirrors argus/reporters/openvex.py; defined here so core doesn't depend on
+# the reporters layer. Keep in sync if the OpenVEX version bumps.
+OPENVEX_CONTEXT = "https://openvex.dev/ns/v0.2.0"
+
+# OpenVEX statuses (the four the spec defines).
+STATUS_NOT_AFFECTED = "not_affected"
+STATUS_AFFECTED = "affected"
+STATUS_FIXED = "fixed"
+STATUS_UNDER_INVESTIGATION = "under_investigation"
+
+# OpenVEX justification vocabulary — required for a ``not_affected`` statement
+# that has no free-text impact_statement.
+JUSTIFICATIONS = (
+    "component_not_present",
+    "vulnerable_code_not_present",
+    "vulnerable_code_not_in_execute_path",
+    "vulnerable_code_cannot_be_controlled_by_adversary",
+    "inline_mitigations_already_exist",
+)
+
+# Triage action → (VEX status, default justification). The actions the
+# viewer offers; the user supplies the free-text reason.
+ACTIONS: dict[str, tuple[str, str]] = {
+    "false_positive": (STATUS_NOT_AFFECTED, "vulnerable_code_not_present"),
+    "not_exploitable": (STATUS_NOT_AFFECTED, "vulnerable_code_not_in_execute_path"),
+    "accept_risk": (STATUS_AFFECTED, ""),
+    "investigating": (STATUS_UNDER_INVESTIGATION, ""),
+}
+
+# Human labels for the action picker.
+ACTION_LABELS: dict[str, str] = {
+    "false_positive": "False positive",
+    "not_exploitable": "Not exploitable",
+    "accept_risk": "Accept risk",
+    "investigating": "Under investigation",
+}
+
+
+@dataclass(frozen=True)
+class TriageDecision:
+    """One triage decision, ready to serialize to VEX / ignore files."""
+
+    cve: str
+    product: str = ""        # PURL or product id (may be empty for non-SCA)
+    status: str = STATUS_NOT_AFFECTED
+    justification: str = ""  # VEX justification (for not_affected)
+    reason: str = ""         # free-text audit note
+    scanner: str = ""
+    author: str = "argus-console"
+    timestamp: str = ""      # ISO 8601; filled by the builder when empty
+
+
+def decision_for(
+    action: str,
+    *,
+    cve: str,
+    product: str = "",
+    reason: str = "",
+    scanner: str = "",
+    author: str = "argus-console",
+    timestamp: str = "",
+) -> TriageDecision:
+    """Build a :class:`TriageDecision` from a triage *action* keyword.
+
+    ``action`` is a key of :data:`ACTIONS`; unknown actions fall back to
+    ``under_investigation`` (the safe "no decision yet" status).
+    """
+    status, justification = ACTIONS.get(action, (STATUS_UNDER_INVESTIGATION, ""))
+    return TriageDecision(
+        cve=cve, product=product, status=status, justification=justification,
+        reason=reason, scanner=scanner, author=author, timestamp=timestamp,
+    )
+
+
+def to_vex_statement(decision: TriageDecision) -> dict:
+    """Render one decision as an OpenVEX statement dict."""
+    statement: dict = {
+        "vulnerability": {"name": decision.cve},
+        "status": decision.status,
+    }
+    if decision.product:
+        statement["products"] = [{"@id": decision.product}]
+    if decision.status == STATUS_NOT_AFFECTED:
+        # not_affected needs a justification OR an impact_statement.
+        if decision.justification:
+            statement["justification"] = decision.justification
+        if decision.reason:
+            statement["impact_statement"] = decision.reason
+    elif decision.status == STATUS_AFFECTED and decision.reason:
+        # "risk accepted" — record the action taken / rationale.
+        statement["action_statement"] = decision.reason
+    elif decision.reason:
+        statement["impact_statement"] = decision.reason
+    if decision.timestamp:
+        statement["timestamp"] = decision.timestamp
+    return statement
+
+
+def build_vex_document(
+    decisions: Iterable[TriageDecision],
+    *,
+    author: str = "argus-console",
+    timestamp: str | None = None,
+) -> dict:
+    """Build a complete OpenVEX v0.2.0 document from triage decisions.
+
+    The ``@id`` is a content digest so re-emitting the same decisions yields
+    the same id (idempotent, diffable); the document timestamp is the only
+    non-deterministic field and can be pinned via ``timestamp``.
+    """
+    stamp = timestamp or datetime.now(timezone.utc).isoformat()
+    # VEX is keyed by vulnerability name — only CVE-bearing decisions belong
+    # here. Secret/CVE-less findings are recorded via the ignore files instead.
+    statements = [
+        to_vex_statement(_with_timestamp(d, stamp)) for d in decisions if d.cve
+    ]
+    digest = hashlib.sha256(
+        json.dumps(statements, sort_keys=True).encode("utf-8"),
+    ).hexdigest()[:16]
+    return {
+        "@context": OPENVEX_CONTEXT,
+        "@id": f"https://huntridge-labs.github.io/argus/vex/{digest}",
+        "author": author,
+        "role": "Document Creator",
+        "timestamp": stamp,
+        "version": 1,
+        "statements": statements,
+    }
+
+
+def merge_vex_documents(existing: dict, new: dict) -> dict:
+    """Merge ``new`` statements into ``existing``, newest decision winning.
+
+    Statements are keyed by (vulnerability name, product id). A re-triage of
+    the same finding replaces the prior statement rather than duplicating it.
+    Bumps the document ``version`` and refreshes metadata from ``new``.
+    """
+    merged: dict[tuple[str, str], dict] = {}
+    for statement in _statements(existing) + _statements(new):
+        merged[_statement_key(statement)] = statement
+    ordered = [merged[k] for k in sorted(merged)]
+    prior_version = existing.get("version", 1) if isinstance(existing, dict) else 1
+    return {
+        "@context": new.get("@context", OPENVEX_CONTEXT),
+        "@id": new.get("@id", existing.get("@id", "")),
+        "author": new.get("author", "argus-console"),
+        "role": "Document Creator",
+        "timestamp": new.get("timestamp", ""),
+        "version": (prior_version if isinstance(prior_version, int) else 1) + 1,
+        "statements": ordered,
+    }
+
+
+def trivyignore_entries(decisions: Iterable[TriageDecision]) -> list[str]:
+    """``.trivyignore`` lines for the suppressing decisions.
+
+    Trivy ignores a vuln by its id; we precede each with a ``# reason``
+    comment so the file stays an audit trail too. Only decisions that
+    actually suppress (not ``under_investigation``) and carry a CVE qualify.
+    """
+    lines: list[str] = []
+    for d in decisions:
+        if d.status == STATUS_UNDER_INVESTIGATION or not d.cve:
+            continue
+        note = d.reason or ACTION_LABELS.get(d.status, d.status)
+        lines.append(f"# {note}")
+        lines.append(d.cve)
+    return lines
+
+
+def gitleaksignore_entries(decisions: Iterable[TriageDecision]) -> list[str]:
+    """``.gitleaksignore`` fingerprints for secret-finding decisions.
+
+    Gitleaks keys ignores by a per-finding fingerprint; we emit one when the
+    decision carries it (in ``product``, where the caller stashes the
+    fingerprint for secret scanners). Skips decisions without one.
+    """
+    lines: list[str] = []
+    for d in decisions:
+        if d.status == STATUS_UNDER_INVESTIGATION or not d.product:
+            continue
+        if d.scanner and "gitleaks" not in d.scanner.lower():
+            continue
+        if d.reason:
+            lines.append(f"# {d.reason}")
+        lines.append(d.product)
+    return lines
+
+
+def write_suppressions(
+    repo_root: Path,
+    decisions: list[TriageDecision],
+    *,
+    timestamp: str | None = None,
+    author: str = "argus-console",
+) -> dict[str, Path]:
+    """Write the VEX doc + ignore-file entries; return ``{artifact: path}``.
+
+    Appends to existing ignore files (never clobbers) and merges into an
+    existing ``argus-results.openvex.json`` if present. Best-effort per
+    artifact: a write that fails is omitted from the returned map rather than
+    aborting the others.
+    """
+    written: dict[str, Path] = {}
+    written.update(_write_vex(repo_root, decisions, timestamp=timestamp, author=author))
+    written.update(_append_ignore(
+        repo_root / ".trivyignore", trivyignore_entries(decisions), key="trivyignore",
+    ))
+    written.update(_append_ignore(
+        repo_root / ".gitleaksignore", gitleaksignore_entries(decisions),
+        key="gitleaksignore",
+    ))
+    return written
+
+
+# -- internals --------------------------------------------------------------
+
+def _with_timestamp(decision: TriageDecision, stamp: str) -> TriageDecision:
+    if decision.timestamp:
+        return decision
+    return TriageDecision(
+        cve=decision.cve, product=decision.product, status=decision.status,
+        justification=decision.justification, reason=decision.reason,
+        scanner=decision.scanner, author=decision.author, timestamp=stamp,
+    )
+
+
+def _statements(doc: object) -> list[dict]:
+    if isinstance(doc, dict):
+        return [s for s in doc.get("statements", []) if isinstance(s, dict)]
+    return []
+
+
+def _statement_key(statement: dict) -> tuple[str, str]:
+    name = str((statement.get("vulnerability") or {}).get("name", ""))
+    products = statement.get("products") or [{}]
+    product = str(products[0].get("@id", "")) if products else ""
+    return (name, product)
+
+
+def _write_vex(
+    repo_root: Path,
+    decisions: list[TriageDecision],
+    *,
+    timestamp: str | None,
+    author: str,
+) -> dict[str, Path]:
+    path = repo_root / "argus-results.openvex.json"
+    new_doc = build_vex_document(decisions, author=author, timestamp=timestamp)
+    try:
+        if path.is_file():
+            existing = json.loads(path.read_text(encoding="utf-8"))
+            new_doc = merge_vex_documents(existing, new_doc)
+        path.write_text(json.dumps(new_doc, indent=2) + "\n", encoding="utf-8")
+    except (OSError, ValueError):
+        return {}
+    return {"openvex": path}
+
+
+def _append_ignore(path: Path, entries: list[str], *, key: str) -> dict[str, Path]:
+    if not entries:
+        return {}
+    try:
+        existing = path.read_text(encoding="utf-8") if path.is_file() else ""
+        block = "\n".join(entries)
+        prefix = "" if (not existing or existing.endswith("\n")) else "\n"
+        path.write_text(f"{existing}{prefix}{block}\n", encoding="utf-8")
+    except OSError:
+        return {}
+    return {key: path}

--- a/argus/tests/core/test_suppressions.py
+++ b/argus/tests/core/test_suppressions.py
@@ -1,0 +1,160 @@
+"""Unit tests for argus.core.suppressions (Phase 7 — bulk triage + VEX).
+
+UI-free: the VEX builders / merge / ignore-entry formatters are pure; the
+writeback is exercised with tmp_path. No Textual, no network.
+"""
+
+from __future__ import annotations
+
+import json
+
+from argus.core.suppressions import (
+    OPENVEX_CONTEXT,
+    STATUS_AFFECTED,
+    STATUS_NOT_AFFECTED,
+    STATUS_UNDER_INVESTIGATION,
+    TriageDecision,
+    build_vex_document,
+    decision_for,
+    gitleaksignore_entries,
+    merge_vex_documents,
+    to_vex_statement,
+    trivyignore_entries,
+    write_suppressions,
+)
+
+
+class TestDecisionFor:
+    def test_false_positive_maps_to_not_affected(self):
+        d = decision_for("false_positive", cve="CVE-1-1", reason="test code")
+        assert d.status == STATUS_NOT_AFFECTED
+        assert d.justification == "vulnerable_code_not_present"
+
+    def test_accept_risk_is_affected(self):
+        d = decision_for("accept_risk", cve="CVE-1-1", reason="mitigated at WAF")
+        assert d.status == STATUS_AFFECTED and d.justification == ""
+
+    def test_unknown_action_is_under_investigation(self):
+        assert decision_for("???", cve="CVE-1-1").status == STATUS_UNDER_INVESTIGATION
+
+
+class TestToVexStatement:
+    def test_not_affected_carries_justification_and_impact(self):
+        d = TriageDecision("CVE-1-1", product="pkg:pypi/x@1", status=STATUS_NOT_AFFECTED,
+                           justification="vulnerable_code_not_present", reason="dead path")
+        stmt = to_vex_statement(d)
+        assert stmt["status"] == STATUS_NOT_AFFECTED
+        assert stmt["justification"] == "vulnerable_code_not_present"
+        assert stmt["impact_statement"] == "dead path"
+        assert stmt["products"] == [{"@id": "pkg:pypi/x@1"}]
+
+    def test_affected_carries_action_statement(self):
+        d = TriageDecision("CVE-1-1", status=STATUS_AFFECTED, reason="risk accepted Q3")
+        stmt = to_vex_statement(d)
+        assert stmt["action_statement"] == "risk accepted Q3"
+        assert "products" not in stmt  # no product → omit
+
+    def test_timestamp_passthrough(self):
+        d = TriageDecision("CVE-1-1", timestamp="2026-06-13T00:00:00+00:00")
+        assert to_vex_statement(d)["timestamp"] == "2026-06-13T00:00:00+00:00"
+
+
+class TestBuildVexDocument:
+    def test_document_shape(self):
+        doc = build_vex_document(
+            [decision_for("false_positive", cve="CVE-1-1", reason="x")],
+            timestamp="2026-06-13T00:00:00+00:00",
+        )
+        assert doc["@context"] == OPENVEX_CONTEXT
+        assert doc["version"] == 1
+        assert doc["timestamp"] == "2026-06-13T00:00:00+00:00"
+        assert doc["statements"][0]["vulnerability"]["name"] == "CVE-1-1"
+
+    def test_deterministic_id_for_same_decisions(self):
+        decisions = [decision_for("false_positive", cve="CVE-1-1", reason="x")]
+        a = build_vex_document(decisions, timestamp="T")
+        b = build_vex_document(decisions, timestamp="T")
+        assert a["@id"] == b["@id"]
+
+    def test_id_changes_with_content(self):
+        a = build_vex_document([decision_for("false_positive", cve="CVE-1-1")], timestamp="T")
+        b = build_vex_document([decision_for("false_positive", cve="CVE-2-2")], timestamp="T")
+        assert a["@id"] != b["@id"]
+
+    def test_skips_decisions_without_cve(self):
+        doc = build_vex_document([
+            TriageDecision("", product="fp:1", status=STATUS_NOT_AFFECTED),  # secret finding
+            decision_for("false_positive", cve="CVE-1-1"),
+        ], timestamp="T")
+        assert len(doc["statements"]) == 1
+        assert doc["statements"][0]["vulnerability"]["name"] == "CVE-1-1"
+
+
+class TestMergeVexDocuments:
+    def test_new_decision_replaces_same_key(self):
+        old = build_vex_document(
+            [TriageDecision("CVE-1-1", product="pkg:pypi/x@1", status=STATUS_AFFECTED)],
+            timestamp="T1",
+        )
+        new = build_vex_document(
+            [TriageDecision("CVE-1-1", product="pkg:pypi/x@1", status=STATUS_NOT_AFFECTED,
+                            justification="vulnerable_code_not_present")],
+            timestamp="T2",
+        )
+        merged = merge_vex_documents(old, new)
+        assert len(merged["statements"]) == 1
+        assert merged["statements"][0]["status"] == STATUS_NOT_AFFECTED
+        assert merged["version"] == 2
+
+    def test_distinct_keys_accumulate(self):
+        old = build_vex_document([TriageDecision("CVE-1-1", product="a")], timestamp="T")
+        new = build_vex_document([TriageDecision("CVE-2-2", product="b")], timestamp="T")
+        merged = merge_vex_documents(old, new)
+        assert len(merged["statements"]) == 2
+
+
+class TestIgnoreEntries:
+    def test_trivyignore_includes_reason_and_cve(self):
+        lines = trivyignore_entries([decision_for("false_positive", cve="CVE-1-1", reason="vendored")])
+        assert "# vendored" in lines and "CVE-1-1" in lines
+
+    def test_trivyignore_skips_under_investigation(self):
+        assert trivyignore_entries([decision_for("investigating", cve="CVE-1-1")]) == []
+
+    def test_gitleaksignore_uses_fingerprint(self):
+        d = TriageDecision("", product="abc123:rule:1", status=STATUS_NOT_AFFECTED, scanner="gitleaks")
+        assert "abc123:rule:1" in gitleaksignore_entries([d])
+
+    def test_gitleaksignore_skips_non_gitleaks(self):
+        d = TriageDecision("CVE-1-1", product="pkg:pypi/x@1", status=STATUS_NOT_AFFECTED, scanner="trivy")
+        assert gitleaksignore_entries([d]) == []
+
+
+class TestWriteSuppressions:
+    def test_writes_vex_and_trivyignore(self, tmp_path):
+        decisions = [decision_for("false_positive", cve="CVE-1-1", reason="vendored", scanner="trivy")]
+        written = write_suppressions(tmp_path, decisions, timestamp="T")
+        assert (tmp_path / "argus-results.openvex.json").is_file()
+        assert written["openvex"] == tmp_path / "argus-results.openvex.json"
+        assert written["trivyignore"] == tmp_path / ".trivyignore"
+        assert "CVE-1-1" in (tmp_path / ".trivyignore").read_text()
+
+    def test_merges_into_existing_vex(self, tmp_path):
+        write_suppressions(tmp_path, [decision_for("false_positive", cve="CVE-1-1")], timestamp="T1")
+        write_suppressions(tmp_path, [decision_for("false_positive", cve="CVE-2-2")], timestamp="T2")
+        doc = json.loads((tmp_path / "argus-results.openvex.json").read_text())
+        names = {s["vulnerability"]["name"] for s in doc["statements"]}
+        assert names == {"CVE-1-1", "CVE-2-2"}
+        assert doc["version"] == 2
+
+    def test_appends_without_clobbering_trivyignore(self, tmp_path):
+        (tmp_path / ".trivyignore").write_text("# pre-existing\nCVE-0-0\n")
+        write_suppressions(tmp_path, [decision_for("false_positive", cve="CVE-1-1")], timestamp="T")
+        text = (tmp_path / ".trivyignore").read_text()
+        assert "CVE-0-0" in text and "CVE-1-1" in text
+
+    def test_under_investigation_writes_no_ignore(self, tmp_path):
+        written = write_suppressions(tmp_path, [decision_for("investigating", cve="CVE-1-1")], timestamp="T")
+        # VEX still records it; no ignore entry though.
+        assert "openvex" in written
+        assert not (tmp_path / ".trivyignore").exists()

--- a/argus/viewers/terminal/app.py
+++ b/argus/viewers/terminal/app.py
@@ -59,6 +59,7 @@ from argus.core.enrichment import (
     is_cve,
     risk_badge,
 )
+from argus.core import suppressions
 from argus.core.models import Finding, Severity
 
 
@@ -878,6 +879,70 @@ class SpanContextMenuScreen(_BackgroundDismissMixin, ModalScreen[str | None]):
         self.dismiss(event.option.id or None)
 
 
+_SUPPRESS_CSS = """
+SuppressScreen { align: center middle; }
+SuppressScreen > Vertical {
+    width: 78; height: auto; padding: 1 2;
+    border: thick $accent; background: $surface; overflow: hidden;
+}
+SuppressScreen #suppress-title { text-style: bold; padding: 0 0 1 0; }
+SuppressScreen .label { color: $text-muted; }
+SuppressScreen Input { margin: 0 0 1 0; }
+SuppressScreen #suppress-actions { height: auto; border: none; background: transparent; }
+SuppressScreen #suppress-hint { color: $text-muted; padding: 1 0 0 0; }
+"""
+
+
+class SuppressScreen(_BackgroundDismissMixin, ModalScreen[dict | None]):
+    """Capture a triage decision for the focused finding / selection.
+
+    Dismisses with ``{"action": <key>, "reason": <text>}`` when a status is
+    picked, or ``None`` on cancel. ``action`` is a key of
+    ``suppressions.ACTIONS``; the caller turns it into an OpenVEX statement +
+    ignore-file entries via ``argus.core.suppressions``.
+    """
+
+    CSS = _SUPPRESS_CSS
+    BINDINGS = [Binding("escape", "dismiss(None)", "Cancel", show=True)]
+
+    def __init__(self, count: int):
+        super().__init__()
+        self._count = count
+
+    def compose(self) -> ComposeResult:  # pragma: no cover — UI
+        with Vertical():
+            yield Static(f"⊘ Triage {self._count} finding(s)", id="suppress-title")
+            yield Static("Reason (recorded in the VEX audit trail):", classes="label")
+            yield Input(
+                placeholder="e.g. vendored dep · not reachable · mitigated at WAF",
+                id="suppress-reason",
+            )
+            yield Static("Status:", classes="label")
+            yield OptionList(
+                *(
+                    Option(suppressions.ACTION_LABELS[key], id=key)
+                    for key in suppressions.ACTIONS
+                ),
+                id="suppress-actions",
+            )
+            yield Static(
+                "type a reason  ·  enter → status list  ·  ↑↓ + enter pick  ·  esc cancel",
+                id="suppress-hint",
+            )
+
+    def on_mount(self) -> None:  # pragma: no cover — UI
+        self.query_one("#suppress-reason", Input).focus()
+
+    def on_input_submitted(self, event: "Input.Submitted") -> None:  # pragma: no cover — UI
+        self.query_one("#suppress-actions", OptionList).focus()
+
+    def on_option_list_option_selected(  # pragma: no cover — UI
+        self, event: OptionList.OptionSelected,
+    ) -> None:
+        reason = self.query_one("#suppress-reason", Input).value.strip()
+        self.dismiss({"action": event.option.id, "reason": reason})
+
+
 _RUN_PROMPT_CSS = """
 RunScanPromptScreen { align: center middle; }
 RunScanPromptScreen > Vertical {
@@ -1152,6 +1217,7 @@ class ArgusBrowseCommands(Provider):
             ("Scan: Run argus scan", "Launch argus scan from the TUI, stream output, and reload results when done (shift+r)", app.action_run_scan),
             ("Fix: Apply a Tier-1 dependency bump", "Propose + preview + apply a deterministic fix for the focused finding or selection (shift+f)", app.action_fix),
             ("Intel: Enrich with EPSS + CISA KEV", "Fetch exploit-probability + known-exploited intelligence for the CVEs in view (i)", app.action_enrich),
+            ("Triage: Suppress / accept-risk (VEX)", "Record a triage decision to OpenVEX + .trivyignore/.gitleaksignore for the focused finding or selection (shift+s)", app.action_suppress),
             ("Search findings",          "Focus the search box", app.action_focus_search),
             ("Filter: Critical only",    "Show only CRITICAL findings", app.action_filter_critical),
             ("Filter: High severity and above", "Show HIGH + CRITICAL findings", app.action_filter_high),
@@ -1395,6 +1461,11 @@ class BrowseApp(App):
         # by real-world risk. Opt-in / offline-degrading — only reaches out
         # when pressed.
         Binding("i", "enrich", "Intel", show=True),
+        # Bulk triage: record a decision (false-positive / not-exploitable /
+        # accept-risk / under-investigation) for the focused finding or the
+        # whole selection, writing an OpenVEX audit trail + scanner ignore
+        # entries so the next scan honours it.
+        Binding("S", "suppress", "Suppress", show=True),
         # Multi-select — drives the bulk-action workflows (export N rows,
         # paste a CVE list into a bug tracker). ``space``/``a``/``A``
         # manage the selection set; ``c`` copies CVEs from it. ``e``
@@ -1910,6 +1981,62 @@ class BrowseApp(App):
             severity="information",
         )
         self._update_detail(self.query_one(DataTable).cursor_row)
+
+    def action_suppress(self) -> None:  # pragma: no cover — UI
+        """Triage the focused finding / selection → OpenVEX + ignore files (``S``).
+
+        Prompts for a status + reason, then writes an OpenVEX statement (the
+        audit trail) and the matching ``.trivyignore`` / ``.gitleaksignore``
+        entries so the next scan honours the decision.
+        """
+        targets = self._suppress_targets()
+        if not targets:
+            self.notify("No findings to triage.", severity="information")
+            return
+
+        def _after(result: dict | None) -> None:
+            if result:
+                self._apply_suppression(targets, result["action"], result["reason"])
+
+        self.push_screen(SuppressScreen(len(targets)), _after)
+
+    def _suppress_targets(self) -> list[Finding]:  # pragma: no cover — UI
+        if self._selected:
+            return [f for f in self.all_findings if id(f) in self._selected]
+        row = self.query_one(DataTable).cursor_row
+        return [self._visible[row]] if 0 <= row < len(self._visible) else []
+
+    def _apply_suppression(  # pragma: no cover — UI
+        self, targets: list[Finding], action: str, reason: str,
+    ) -> None:
+        decisions = [
+            suppressions.decision_for(
+                action,
+                cve=f.cve or "",
+                product=self._suppress_product(f),
+                reason=reason,
+                scanner=f.scanner,
+            )
+            for f in targets
+        ]
+        repo_root = self._resolve_repo_root() or Path.cwd()
+        written = suppressions.write_suppressions(repo_root, decisions)
+        if written:
+            artifacts = ", ".join(sorted(written))
+            self.notify(
+                f"Triaged {len(targets)} finding(s) → {artifacts}",
+                severity="information",
+            )
+        else:
+            self.notify(
+                "Nothing written — findings need a CVE or fingerprint to record.",
+                severity="warning",
+            )
+
+    @staticmethod
+    def _suppress_product(finding: Finding) -> str:  # pragma: no cover — UI
+        meta = finding.metadata or {}
+        return (meta.get("purl") or meta.get("fingerprint") or "").strip()
 
     def _source_context_block(self, finding: Finding) -> str | None:
         """Render the ``[bold]Source[/bold]`` block for the detail pane.

--- a/docs/view-terminal.md
+++ b/docs/view-terminal.md
@@ -73,6 +73,7 @@ Press `?` inside the TUI for the same reference, grouped by purpose.
 | `R` (shift+r) | run `argus scan` in-app, stream output, and reload results when done |
 | `F` (shift+f) | fix — propose a dependency bump for the finding (or selection), preview the diff, apply |
 | `i` | enrich — fetch EPSS + CISA KEV intelligence for the CVEs in view (see below) |
+| `S` (shift+s) | triage — suppress / accept-risk the finding (or selection), writing OpenVEX + ignore files (see below) |
 | **Other** | |
 | `d` | executive dashboard overlay |
 | `D` (shift+d) | scan-over-scan diff — pick another `argus-results.json` and bucket changes |
@@ -157,6 +158,34 @@ on disk (`$XDG_CACHE_HOME/argus/`) so repeat triage is offline, and sends
 only public CVE ids — never your source or secrets. With no network (or
 `ARGUS_NO_NETWORK=1`) the viewer behaves exactly as before, just without the
 badges.
+
+## Triage & suppression (`S`)
+
+Triage at scale, the way security teams actually do it — but with a durable
+audit trail instead of a spreadsheet. Multi-select findings (`space` / `a`)
+or focus a single one, press `S` (shift+s), pick a **status**, and type a
+**reason**:
+
+| Status | OpenVEX mapping |
+|---|---|
+| False positive | `not_affected` · justification `vulnerable_code_not_present` |
+| Not exploitable | `not_affected` · justification `vulnerable_code_not_in_execute_path` |
+| Accept risk | `affected` · your reason recorded as the `action_statement` |
+| Under investigation | `under_investigation` |
+
+Argus writes the decision to two places:
+
+- **`argus-results.openvex.json`** — an OpenVEX document (the audit trail:
+  per-CVE status, justification, your reason, author, timestamp). Re-triaging
+  the same finding *updates* its statement and bumps the document version
+  rather than duplicating it; an existing VEX file is merged, not clobbered.
+- **`.trivyignore` / `.gitleaksignore`** — so the *next scan* honours the
+  decision. CVE findings append to `.trivyignore` (with your reason as a
+  comment); secret findings append their fingerprint to `.gitleaksignore`.
+  `Under investigation` records a VEX statement but writes no ignore entry.
+
+This reuses the same OpenVEX vocabulary as Argus's signed scan attestations,
+so a TUI triage decision and a CI-generated VEX speak the same language.
 
 ## Mouse interactions
 


### PR DESCRIPTION
## Description
Phase 7 — **bulk triage at scale** with a durable audit trail. Multi-select findings (or focus one), press `S`, pick a status + reason, and Argus records the decision to **OpenVEX** + scanner **ignore files**. Targets the integration branch (`feat/tui-explorer-and-scan-runner`, PR #261).

This answers the "where do `not_affected` / `fixed` triage decisions come from?" question the OpenVEX *reporter* (`argus/reporters/openvex.py`, #229) deliberately left open.

## Changes Made
- [x] Added new core module (`argus/core/suppressions.py`)
- [x] Modified existing scanner/workflow (terminal viewer)
- [x] Updated documentation

### Details
- **`argus/core/suppressions.py`** (UI-free): `decision_for(action, …)` maps a triage action → `TriageDecision`; `to_vex_statement` / `build_vex_document` / `merge_vex_documents` emit + merge an **OpenVEX v0.2.0** doc (audit trail = status + justification + reason + author + timestamp, keyed by CVE+product, idempotent content `@id`); `trivyignore_entries` / `gitleaksignore_entries` + `write_suppressions` append to `.trivyignore` / `.gitleaksignore` (**never clobber**, merges existing VEX). Reuses the OpenVEX vocabulary of the signed-attestation reporter — a TUI decision and a CI VEX speak the same language.
- **Status → VEX mapping:** false-positive → `not_affected`/`vulnerable_code_not_present`; not-exploitable → `not_affected`/`vulnerable_code_not_in_execute_path`; accept-risk → `affected` + `action_statement`; under-investigation → `under_investigation` (VEX only, no ignore entry).
- **Viewer** (`app.py`): `S` opens a status+reason modal (`SuppressScreen`) over the focused finding or the multi-select set; writes to the repo root; toasts the artifacts written. Command-palette entry mirrors it.
- **Follow-on (noted):** a "hide suppressed" filter view (touches the pure filter/sort core).

## Testing
- [x] Unit tests added/updated — `test_suppressions.py` (20 tests): action mapping, VEX statement/document shape, **deterministic `@id`**, **merge dedup + version bump**, CVE-less skip, ignore-entry formatting, and `write_suppressions` (VEX + trivy + gitleaks, merge-existing, append-without-clobber, under-investigation writes no ignore).
- [x] Manual testing — real-Textual `Pilot`: a Log4Shell CVE → VEX `not_affected` + `.trivyignore`; a gitleaks finding (no CVE) → `.gitleaksignore` fingerprint, correctly excluded from VEX.
- Full suite: **4106 passed, 21 skipped**, coverage gate met. (3 local-only `viewers/browser` failures are pre-existing + green in CI.)

## Security Considerations
- [x] Security enhancement — turns ad-hoc triage into a reviewable, machine-readable VEX audit trail; writes are append/merge (never clobber); under-investigation never silently suppresses (records VEX, writes no ignore entry).

## AI Context Updates (.ai/)
- [x] `.ai/architecture.yaml` updated (`core/suppressions.py` + viewer `S` action, both mirror blocks)

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (`docs/view-terminal.md` — keybind + "Triage & suppression" section)
- [ ] Changelog updated (handled by release-it)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Console epic — `docs/developer/CONSOLE-ROADMAP.md`, Phase 7. Builds on the OpenVEX reporter (#229).
