### PR TITLE
feat(view): dependency-free visual analytics on the dashboard (Phase 8)

### DIFF
--- a/.ai/architecture.yaml
+++ b/.ai/architecture.yaml
@@ -108,6 +108,11 @@ components:
         justification, reason, author, timestamp; keyed by CVE+product, idempotent @id); trivyignore_entries /
         gitleaksignore_entries + write_suppressions append to .trivyignore/.gitleaksignore (never clobber). Reuses
         the OpenVEX vocabulary of the reporters/attest layer; drives the terminal viewer's ``S`` Suppress action.
+      core/trends.py: UI-free dependency-free visual analytics (Phase 8). sparkline (Unicode ▁-█) +
+        bar_chart (Unicode █ bars), severity_breakdown / scanner_breakdown over findings, run_count_series /
+        trend_summary over discover_runs history (findings-over-time + are-we-improving delta). No chart
+        library — renders in any terminal, keeping the dependency surface minimal. Drives the terminal
+        dashboard's (``d``) charts.
       viewers/: '`argus view` interfaces (optional extras)'
       viewers/__init__.py: ViewerUnavailable shared exception
       viewers/terminal/: '`argus view --interface=terminal` — Textual TUI ([terminal] extra). Includes
@@ -725,6 +730,11 @@ docsite:
         justification, reason, author, timestamp; keyed by CVE+product, idempotent @id); trivyignore_entries /
         gitleaksignore_entries + write_suppressions append to .trivyignore/.gitleaksignore (never clobber). Reuses
         the OpenVEX vocabulary of the reporters/attest layer; drives the terminal viewer's ``S`` Suppress action.
+      core/trends.py: UI-free dependency-free visual analytics (Phase 8). sparkline (Unicode ▁-█) +
+        bar_chart (Unicode █ bars), severity_breakdown / scanner_breakdown over findings, run_count_series /
+        trend_summary over discover_runs history (findings-over-time + are-we-improving delta). No chart
+        library — renders in any terminal, keeping the dependency surface minimal. Drives the terminal
+        dashboard's (``d``) charts.
       viewers/: '`argus view` interfaces (optional extras)'
       viewers/__init__.py: ViewerUnavailable shared exception
       viewers/terminal/: '`argus view --interface=terminal` — Textual TUI ([terminal] extra). Includes

--- a/argus/core/trends.py
+++ b/argus/core/trends.py
@@ -1,0 +1,91 @@
+"""Visual analytics for the dashboard — sparklines + bar charts (Phase 8).
+
+Pure, dependency-free, UI-free. Charts are rendered with Unicode block
+characters (▁▂▃▄▅▆▇█ for sparklines, █ for bars), so they work in any
+terminal with no extra package — the most security-conscious default for a
+supply-chain tool (no new dependency surface). The terminal dashboard
+renders the strings these functions return; richer ``textual-plotext`` charts
+are a possible future opt-in, not a requirement.
+
+Two data sources:
+- ``discover_runs`` history → a findings-over-time **sparkline** + a
+  "are we getting more or less secure?" delta.
+- the current findings → **bar charts** by severity and by scanner.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Iterable, Sequence
+
+from argus.core.models import Finding, Severity
+
+_SPARK = "▁▂▃▄▅▆▇█"
+
+
+def sparkline(values: Sequence[float]) -> str:
+    """Render a Unicode sparkline for ``values`` (left→right order given).
+
+    All-equal (or single) series render as a flat mid-height line; an empty
+    series is an empty string.
+    """
+    nums = [float(v) for v in values]
+    if not nums:
+        return ""
+    low, high = min(nums), max(nums)
+    if high == low:
+        return _SPARK[len(_SPARK) // 2] * len(nums)
+    span = high - low
+    last = len(_SPARK) - 1
+    return "".join(_SPARK[int((v - low) / span * last + 0.5)] for v in nums)
+
+
+def bar_chart(items: Sequence[tuple[str, int]], *, width: int = 22) -> list[str]:
+    """Horizontal Unicode bar chart: ``"label   ████····  12"`` per row.
+
+    Bars are scaled to the largest value. Empty input → ``[]``.
+    """
+    if not items:
+        return []
+    largest = max((v for _, v in items), default=0) or 1
+    label_w = max(len(label) for label, _ in items)
+    rows: list[str] = []
+    for label, value in items:
+        filled = int(round(value / largest * width))
+        bar = "█" * filled + "·" * (width - filled)
+        rows.append(f"{label:<{label_w}}  {bar}  {value}")
+    return rows
+
+
+def severity_breakdown(findings: Iterable[Finding]) -> list[tuple[Severity, int]]:
+    """Count findings per severity, ordered most→least severe."""
+    counts: Counter[Severity] = Counter(f.severity for f in findings)
+    return [(sev, counts[sev]) for sev in sorted(counts, reverse=True)]
+
+
+def scanner_breakdown(findings: Iterable[Finding]) -> list[tuple[str, int]]:
+    """Count findings per scanner, ordered by count desc then name."""
+    counts: Counter[str] = Counter((f.scanner or "unknown") for f in findings)
+    return sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))
+
+
+def run_count_series(runs: Sequence[dict]) -> list[int]:
+    """Total findings per run, oldest→newest.
+
+    ``discover_runs`` yields runs newest-first; the sparkline reads
+    left→right as oldest→newest, so we reverse. A run whose count failed to
+    parse (``None``) counts as 0.
+    """
+    return [int(run.get("count") or 0) for run in reversed(list(runs))]
+
+
+def trend_summary(runs: Sequence[dict]) -> str:
+    """One-line "current vs previous run" delta, or ``""`` with <2 runs."""
+    counts = run_count_series(runs)
+    if len(counts) < 2:
+        return ""
+    current, previous = counts[-1], counts[-2]
+    delta = current - previous
+    arrow = "↑" if delta > 0 else ("↓" if delta < 0 else "→")
+    suffix = "no change" if delta == 0 else f"{arrow}{abs(delta)} vs previous run"
+    return f"{current} findings · {suffix}"

--- a/argus/tests/core/test_trends.py
+++ b/argus/tests/core/test_trends.py
@@ -1,0 +1,86 @@
+"""Unit tests for argus.core.trends (Phase 8 — dependency-free charts)."""
+
+from __future__ import annotations
+
+from argus.core.models import Finding, Severity
+from argus.core.trends import (
+    bar_chart,
+    run_count_series,
+    scanner_breakdown,
+    severity_breakdown,
+    sparkline,
+    trend_summary,
+)
+
+
+def _f(severity=Severity.HIGH, scanner="bandit"):
+    return Finding(id="x", severity=severity, title="t", scanner=scanner)
+
+
+class TestSparkline:
+    def test_empty(self):
+        assert sparkline([]) == ""
+
+    def test_monotonic_rises(self):
+        s = sparkline([0, 1, 2, 3, 4, 5, 6, 7])
+        assert s[0] == "▁" and s[-1] == "█" and len(s) == 8
+
+    def test_all_equal_is_flat(self):
+        s = sparkline([4, 4, 4])
+        assert len(set(s)) == 1 and len(s) == 3
+
+    def test_length_matches_input(self):
+        assert len(sparkline([3, 1, 4, 1, 5, 9, 2])) == 7
+
+
+class TestBarChart:
+    def test_empty(self):
+        assert bar_chart([]) == []
+
+    def test_largest_is_full_width(self):
+        rows = bar_chart([("a", 10), ("b", 5)], width=10)
+        assert rows[0].count("█") == 10
+        assert rows[1].count("█") == 5
+        assert rows[0].endswith("10") and rows[1].endswith("5")
+
+    def test_labels_aligned(self):
+        rows = bar_chart([("short", 1), ("longerlabel", 1)])
+        # both bars start at the same column (labels left-padded to width)
+        assert rows[0].index("█") == rows[1].index("█")
+
+
+class TestBreakdowns:
+    def test_severity_ordered_most_severe_first(self):
+        findings = [_f(Severity.LOW), _f(Severity.CRITICAL), _f(Severity.LOW), _f(Severity.HIGH)]
+        out = severity_breakdown(findings)
+        assert out[0] == (Severity.CRITICAL, 1)
+        assert out[-1] == (Severity.LOW, 2)
+
+    def test_scanner_ordered_by_count_desc(self):
+        findings = [_f(scanner="bandit"), _f(scanner="osv"), _f(scanner="bandit")]
+        out = scanner_breakdown(findings)
+        assert out[0] == ("bandit", 2)
+        assert ("osv", 1) in out
+
+    def test_missing_scanner_is_unknown(self):
+        assert scanner_breakdown([_f(scanner="")]) == [("unknown", 1)]
+
+
+class TestRunSeries:
+    def test_oldest_to_newest(self):
+        # discover_runs is newest-first; series reads oldest→newest
+        runs = [{"count": 9}, {"count": 12}, {"count": 5}]
+        assert run_count_series(runs) == [5, 12, 9]
+
+    def test_none_count_is_zero(self):
+        assert run_count_series([{"count": None}, {"count": 3}]) == [3, 0]
+
+    def test_trend_summary_delta(self):
+        assert "↓3 vs previous run" in trend_summary([{"count": 9}, {"count": 12}])
+        assert "↑2 vs previous run" in trend_summary([{"count": 5}, {"count": 3}])
+
+    def test_trend_summary_needs_two_runs(self):
+        assert trend_summary([{"count": 5}]) == ""
+
+    def test_trend_summary_no_change(self):
+        assert "no change" in trend_summary([{"count": 5}, {"count": 5}])

--- a/argus/viewers/terminal/app.py
+++ b/argus/viewers/terminal/app.py
@@ -59,7 +59,7 @@ from argus.core.enrichment import (
     is_cve,
     risk_badge,
 )
-from argus.core import suppressions
+from argus.core import suppressions, trends
 from argus.core.models import Finding, Severity
 
 
@@ -282,10 +282,16 @@ class DashboardScreen(_BackgroundDismissMixin, ModalScreen):
     }
     """
 
-    def __init__(self, all_findings: list[Finding], source_label: str):
+    def __init__(
+        self,
+        all_findings: list[Finding],
+        source_label: str,
+        runs: list[dict] | None = None,
+    ):
         super().__init__()
         self._findings = all_findings
         self._source_label = source_label
+        self._runs = runs or []
 
     def compose(self) -> ComposeResult:
         summary = compute_summary(self._findings, top_n=3)
@@ -309,6 +315,10 @@ class DashboardScreen(_BackgroundDismissMixin, ModalScreen):
         if sev_parts:
             lines.append("  " + "   ".join(sev_parts))
         lines.append("")
+
+        # Trend + charts (Phase 8) — dependency-free Unicode visuals.
+        for chart_line in self._chart_lines():
+            lines.append(chart_line)
 
         # Quality warnings (SPDX-2.1, purl coverage, "unknown scan
         # subject" from grype, ...) — loud so execs don't misread an
@@ -358,6 +368,32 @@ class DashboardScreen(_BackgroundDismissMixin, ModalScreen):
 
         with Container(id="dashboard-body"):
             yield Static("\n".join(lines))
+
+    def _chart_lines(self) -> list[str]:
+        """Dependency-free Unicode charts for the dashboard (Phase 8)."""
+        out: list[str] = []
+        series = trends.run_count_series(self._runs)
+        if len(series) >= 2:
+            out.append("[b]Findings over time[/b]")
+            out.append(
+                f"  {trends.sparkline(series)}   "
+                f"[dim]{trends.trend_summary(self._runs)}[/dim]"
+            )
+            out.append("")
+        sev_items = [
+            (f"{_SEVERITY_GLYPH.get(sev, '?')} {sev.value.capitalize()}", count)
+            for sev, count in trends.severity_breakdown(self._findings)
+        ]
+        if sev_items:
+            out.append("[b]By severity[/b]")
+            out.extend(f"  {row}" for row in trends.bar_chart(sev_items))
+            out.append("")
+        scanner_items = trends.scanner_breakdown(self._findings)[:8]
+        if scanner_items:
+            out.append("[b]By scanner[/b]")
+            out.extend(f"  {row}" for row in trends.bar_chart(scanner_items))
+            out.append("")
+        return out
 
 
 class ProductPickerScreen(_BackgroundDismissMixin, ModalScreen[str | None]):
@@ -2307,7 +2343,9 @@ class BrowseApp(App):
 
     def action_show_dashboard(self) -> None:
         self.push_screen(
-            DashboardScreen(self.all_findings, source_label=self.sub_title or ""),
+            DashboardScreen(
+                self.all_findings, source_label=self.sub_title or "", runs=self._runs,
+            ),
         )
 
     def action_diff_against(self) -> None:

--- a/docs/view-terminal.md
+++ b/docs/view-terminal.md
@@ -291,6 +291,11 @@ answer to "what's the state of our security posture?":
 - Quality warnings — SPDX-2.1 SBOMs Trivy can't read, SBOMs missing purl
   refs, Grype's "couldn't identify scan subject" warnings — surfaced loudly
   so an empty scan isn't misread as "we're clean"
+- **Visual analytics** — a *findings-over-time* sparkline with a "↑/↓ vs
+  previous run" delta (drawn from the same run history the runs sidebar
+  uses), plus **by-severity** and **by-scanner** bar charts. Rendered with
+  Unicode block characters, so they need no extra dependency and work in any
+  terminal — fitting for a supply-chain tool that minimises its own surface.
 - Per-product breakdown — every SBOM source with total + crit + high counts
   and the top-3 findings
 - Per-scanner contribution counts


### PR DESCRIPTION
## Description
Phase 8 — **visual analytics** on the executive dashboard (`d`): a findings-over-time sparkline + by-severity / by-scanner bar charts. Targets the integration branch (`feat/tui-explorer-and-scan-runner`, PR #261).

**Zero new dependencies.** Charts render with Unicode block characters (`▁▂▃▄▅▆▇█`, `█`), so they work in any terminal — the most security-conscious default for a supply-chain tool. (Richer `textual-plotext` charts remain a possible future opt-in, deliberately not added.)

## Changes Made
- [x] Added new core module (`argus/core/trends.py`)
- [x] Modified existing scanner/workflow (dashboard)
- [x] Updated documentation

### Details
- **`argus/core/trends.py`** (UI-free, pure, dep-free): `sparkline`, `bar_chart`, `severity_breakdown`, `scanner_breakdown`, `run_count_series`, `trend_summary`.
- **Dashboard** (`DashboardScreen`): a *Findings over time* sparkline + "↑/↓ vs previous run" delta (from the same `discover_runs` history the runs sidebar uses), then **By severity** and **By scanner** bar charts. The math lives in the core so a future web dashboard renders identical analytics.

## Testing
- [x] Unit tests added/updated — `test_trends.py` (15 tests): sparkline (empty / monotonic / flat / length), bar chart (full-width scaling, label alignment), breakdowns (severity order, scanner count order, unknown-scanner), run series (oldest→newest, None→0), trend delta (↑/↓/no-change, needs-two-runs).
- [x] Manual testing — real-Textual smoke: dashboard renders `▁█▄ · ↓3 vs previous run` + severity/scanner bars.
- Full suite: **4121 passed, 21 skipped**, coverage gate met. (3 local-only `viewers/browser` failures are pre-existing + green in CI.)

## Security Considerations
- [x] No security impact — no new dependency, no network, pure rendering.

## AI Context Updates (.ai/)
- [x] `.ai/architecture.yaml` updated (`core/trends.py`, both mirror blocks)

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (`docs/view-terminal.md` — dashboard charts)
- [ ] Changelog updated (handled by release-it)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Console epic — `docs/developer/CONSOLE-ROADMAP.md`, Phase 8.
