### PR TITLE
feat(core): terminal graphics capability detection (Phase 9 foundation)

### DIFF
--- a/.ai/architecture.yaml
+++ b/.ai/architecture.yaml
@@ -113,6 +113,10 @@ components:
         trend_summary over discover_runs history (findings-over-time + are-we-improving delta). No chart
         library — renders in any terminal, keeping the dependency surface minimal. Drives the terminal
         dashboard's (``d``) charts.
+      core/terminal_caps.py: UI-free terminal capability detection (Phase 9 graphics foundation). detect_graphics
+        (kitty/iterm/sixel/none from env), supports_graphics / supports_hyperlinks / supports_truecolor,
+        capability_summary. Env-only (no escape probing), dependency-free; the foundation richer inline-image
+        rendering (textual-image, capability-gated, ASCII fallback) would build on. Surfaced in the Console help.
       viewers/: '`argus view` interfaces (optional extras)'
       viewers/__init__.py: ViewerUnavailable shared exception
       viewers/terminal/: '`argus view --interface=terminal` — Textual TUI ([terminal] extra). Includes
@@ -735,6 +739,10 @@ docsite:
         trend_summary over discover_runs history (findings-over-time + are-we-improving delta). No chart
         library — renders in any terminal, keeping the dependency surface minimal. Drives the terminal
         dashboard's (``d``) charts.
+      core/terminal_caps.py: UI-free terminal capability detection (Phase 9 graphics foundation). detect_graphics
+        (kitty/iterm/sixel/none from env), supports_graphics / supports_hyperlinks / supports_truecolor,
+        capability_summary. Env-only (no escape probing), dependency-free; the foundation richer inline-image
+        rendering (textual-image, capability-gated, ASCII fallback) would build on. Surfaced in the Console help.
       viewers/: '`argus view` interfaces (optional extras)'
       viewers/__init__.py: ViewerUnavailable shared exception
       viewers/terminal/: '`argus view --interface=terminal` — Textual TUI ([terminal] extra). Includes

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
           --skip=**/package-lock.json,
           --skip=pnpm-lock.yaml,
           --skip=**/pnpm-lock.yaml,
-          "--ignore-words-list=assertIn,froms,intoto",
+          "--ignore-words-list=assertIn,froms,intoto,iterm",
           -w
         ]
   # renovate: datasource=github-tags depName=adrienverge/yamllint versioning=semver

--- a/argus/core/terminal_caps.py
+++ b/argus/core/terminal_caps.py
@@ -1,0 +1,87 @@
+"""Terminal capability detection (Phase 9 — graphics foundation).
+
+Pure, dependency-free, UI-free. Detects what the host terminal can do —
+inline-image graphics protocol (Kitty / iTerm2 / Sixel), OSC 8 hyperlinks,
+and 24-bit truecolor — from environment variables alone (no escape-sequence
+probing, which would be unsafe to do unsolicited).
+
+This is the foundation the richer graphics work gates on: inline raster
+rendering (a `textual-image`-backed logo / dependency-graph image / QR code)
+is a capability-gated opt-in that builds on `detect_graphics` here, with a
+clean Unicode/ASCII fallback whenever the terminal can't do pixels. Keeping
+detection separate and dependency-free means the fallback path — the common
+case — carries no extra dependency surface, the right default for a
+supply-chain tool.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Mapping
+
+GRAPHICS_NONE = "none"
+GRAPHICS_KITTY = "kitty"
+GRAPHICS_ITERM = "iterm"
+GRAPHICS_SIXEL = "sixel"
+
+
+def _env(env: Mapping[str, str] | None) -> Mapping[str, str]:
+    return os.environ if env is None else env
+
+
+def detect_graphics(env: Mapping[str, str] | None = None) -> str:
+    """Best-effort inline-image protocol for the terminal.
+
+    Returns one of ``GRAPHICS_KITTY`` / ``GRAPHICS_ITERM`` / ``GRAPHICS_SIXEL``
+    / ``GRAPHICS_NONE`` from env hints only. Kitty's protocol (also spoken by
+    Ghostty/WezTerm) is preferred where detected; iTerm2 has its own inline
+    image protocol; a few terminals do Sixel.
+    """
+    e = _env(env)
+    term = (e.get("TERM") or "").lower()
+    term_program = (e.get("TERM_PROGRAM") or "").lower()
+
+    if e.get("KITTY_WINDOW_ID") or term.startswith("xterm-kitty") or "kitty" in term:
+        return GRAPHICS_KITTY
+    if "ghostty" in term or term_program == "ghostty":
+        return GRAPHICS_KITTY
+    if term_program == "wezterm" or e.get("WEZTERM_PANE"):
+        return GRAPHICS_KITTY
+    if term_program == "iterm.app" or e.get("ITERM_SESSION_ID"):
+        return GRAPHICS_ITERM
+    if term in ("foot", "xterm-foot") or "contour" in term_program or e.get("MLTERM"):
+        return GRAPHICS_SIXEL
+    return GRAPHICS_NONE
+
+
+def supports_graphics(env: Mapping[str, str] | None = None) -> bool:
+    """True when the terminal can render inline pixel images."""
+    return detect_graphics(env) != GRAPHICS_NONE
+
+
+def supports_hyperlinks(env: Mapping[str, str] | None = None) -> bool:
+    """True when the terminal is likely to honour OSC 8 hyperlinks.
+
+    Conservative: the dumb terminal and the Linux text console don't; an
+    explicit ``NO_HYPERLINKS`` opt-out is respected. Everything else with a
+    real ``TERM`` is assumed capable (OSC 8 is widely supported and degrades
+    to plain text where it isn't).
+    """
+    e = _env(env)
+    if e.get("NO_HYPERLINKS"):
+        return False
+    term = (e.get("TERM") or "").lower()
+    return bool(term) and term not in ("dumb", "linux")
+
+
+def supports_truecolor(env: Mapping[str, str] | None = None) -> bool:
+    """True when the terminal advertises 24-bit colour via ``COLORTERM``."""
+    return (_env(env).get("COLORTERM") or "").lower() in ("truecolor", "24bit")
+
+
+def capability_summary(env: Mapping[str, str] | None = None) -> str:
+    """One-line human summary for a Help / diagnostics screen."""
+    graphics = detect_graphics(env)
+    links = "yes" if supports_hyperlinks(env) else "no"
+    color = "yes" if supports_truecolor(env) else "no"
+    return f"graphics={graphics} · hyperlinks={links} · truecolor={color}"

--- a/argus/tests/core/test_terminal_caps.py
+++ b/argus/tests/core/test_terminal_caps.py
@@ -1,0 +1,79 @@
+"""Unit tests for argus.core.terminal_caps (Phase 9 — graphics foundation)."""
+
+from __future__ import annotations
+
+import pytest
+
+from argus.core.terminal_caps import (
+    GRAPHICS_ITERM,
+    GRAPHICS_KITTY,
+    GRAPHICS_NONE,
+    GRAPHICS_SIXEL,
+    capability_summary,
+    detect_graphics,
+    supports_graphics,
+    supports_hyperlinks,
+    supports_truecolor,
+)
+
+
+class TestDetectGraphics:
+    @pytest.mark.parametrize("env", [
+        {"KITTY_WINDOW_ID": "1"},
+        {"TERM": "xterm-kitty"},
+        {"TERM_PROGRAM": "ghostty"},
+        {"WEZTERM_PANE": "0"},
+    ])
+    def test_kitty_family(self, env):
+        assert detect_graphics(env) == GRAPHICS_KITTY
+
+    def test_iterm(self):
+        assert detect_graphics({"TERM_PROGRAM": "iTerm.app"}) == GRAPHICS_ITERM
+        assert detect_graphics({"ITERM_SESSION_ID": "w0"}) == GRAPHICS_ITERM
+
+    def test_sixel(self):
+        assert detect_graphics({"TERM": "foot"}) == GRAPHICS_SIXEL
+        assert detect_graphics({"MLTERM": "3.9"}) == GRAPHICS_SIXEL
+
+    def test_none_for_plain(self):
+        assert detect_graphics({"TERM": "xterm-256color"}) == GRAPHICS_NONE
+        assert detect_graphics({}) == GRAPHICS_NONE
+
+    def test_supports_graphics(self):
+        assert supports_graphics({"TERM": "xterm-kitty"}) is True
+        assert supports_graphics({"TERM": "dumb"}) is False
+
+
+class TestHyperlinks:
+    def test_modern_terminal_yes(self):
+        assert supports_hyperlinks({"TERM": "xterm-256color"}) is True
+
+    def test_dumb_and_linux_console_no(self):
+        assert supports_hyperlinks({"TERM": "dumb"}) is False
+        assert supports_hyperlinks({"TERM": "linux"}) is False
+
+    def test_explicit_optout(self):
+        assert supports_hyperlinks({"TERM": "xterm", "NO_HYPERLINKS": "1"}) is False
+
+    def test_no_term_no(self):
+        assert supports_hyperlinks({}) is False
+
+
+class TestTruecolor:
+    def test_truecolor_env(self):
+        assert supports_truecolor({"COLORTERM": "truecolor"}) is True
+        assert supports_truecolor({"COLORTERM": "24bit"}) is True
+
+    def test_absent_or_basic(self):
+        assert supports_truecolor({}) is False
+        assert supports_truecolor({"COLORTERM": "8bit"}) is False
+
+
+class TestSummary:
+    def test_summary_shape(self):
+        s = capability_summary({"TERM": "xterm-kitty", "COLORTERM": "truecolor"})
+        assert "graphics=kitty" in s and "hyperlinks=yes" in s and "truecolor=yes" in s
+
+    def test_summary_plain(self):
+        s = capability_summary({"TERM": "dumb"})
+        assert "graphics=none" in s and "hyperlinks=no" in s

--- a/argus/viewers/terminal/console.py
+++ b/argus/viewers/terminal/console.py
@@ -31,7 +31,7 @@ from textual.theme import Theme
 from textual.widgets import Footer, OptionList, Static
 from textual.widgets.option_list import Option
 
-from argus.core import console_config
+from argus.core import console_config, terminal_caps
 from argus.core.console_config import ConsoleSettings
 from argus.viewers.terminal import config_editor, console_model, init_wizard
 
@@ -125,6 +125,9 @@ class DocsScreen(ModalScreen):
     def compose(self) -> ComposeResult:  # pragma: no cover — UI
         with VerticalScroll(id="docs-body"):
             yield Static(_DOCS_TEXT)
+            yield Static(
+                f"\n[b]Terminal[/b]\n  [dim]{terminal_caps.capability_summary()}[/dim]",
+            )
 
     def on_mount(self) -> None:  # pragma: no cover — UI
         self.query_one("#docs-body", VerticalScroll).focus()

--- a/docs/console.md
+++ b/docs/console.md
@@ -35,7 +35,7 @@ argus scan ...   # every subcommand is unchanged
   | Configure | Opens the form editor for `argus.yml` (see below). |
   | Initialize | Guided first-run wizard — detect the project, review, write `argus.yml` (see below). |
   | Settings | Theme, accent colour, animations, notifications. |
-  | Help & docs | Keybindings and where to learn more. |
+  | Help & docs | Keybindings, where to learn more, and your terminal's detected graphics / hyperlink / truecolor support. |
   | Quit | Leave the console. |
 
 - **Command palette** (`Ctrl+P`) — fuzzy-search and run any menu action


### PR DESCRIPTION
## Description
Phase 9 — the **graphics foundation**, dependency-free. `argus/core/terminal_caps.py` detects what the host terminal can do (inline-image protocol, OSC 8 hyperlinks, truecolor) from environment variables, and the Console help overlay now reports it. Targets the integration branch (`feat/tui-explorer-and-scan-runner`, PR #261).

**Scope, stated plainly:** this ships the *detection* foundation, **not** raster rendering. Inline pixel images (a `textual-image`-backed logo / dependency graph / QR) are a capability-gated opt-in that builds on `detect_graphics`, with a Unicode/ASCII fallback. They'd add a dependency for a marginal win, so they're deliberately **deferred** rather than forced onto every user of a *supply-chain* tool — the dep-conscious default. The roadmap's Phase 9 retains the raster path as the next opt-in.

## Changes Made
- [x] Added new core module (`argus/core/terminal_caps.py`)
- [x] Modified existing scanner/workflow (Console help)
- [x] Updated documentation

### Details
- **`terminal_caps.py`** (UI-free, dep-free): `detect_graphics` (kitty / iterm / sixel / none), `supports_graphics` / `supports_hyperlinks` / `supports_truecolor`, `capability_summary`. Env-only — no escape-probing (which would be unsafe unsolicited).
- **Console** help overlay (`DocsScreen`) shows `graphics=… · hyperlinks=… · truecolor=…` so users know what their terminal supports.

## Testing
- [x] Unit tests added/updated — `test_terminal_caps.py` (16 tests): kitty family (KITTY_WINDOW_ID / xterm-kitty / ghostty / wezterm), iTerm, sixel (foot / mlterm), none-for-plain, hyperlink yes/no (dumb/linux/opt-out), truecolor, summary.
- Full suite: **4137 passed, 21 skipped**, coverage gate met. (3 local-only `viewers/browser` failures are pre-existing + green in CI.)

## Security Considerations
- [x] No security impact — no new dependency, no network, env-read only (no escape-sequence probing).

## AI Context Updates (.ai/)
- [x] `.ai/architecture.yaml` updated (`core/terminal_caps.py`, both mirror blocks)

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (`docs/console.md` — help shows terminal capabilities)
- [ ] Changelog updated (handled by release-it)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Console epic — `docs/developer/CONSOLE-ROADMAP.md`, Phase 9 (foundation; raster rendering deferred as a dep-gated opt-in).
