### PR TITLE
feat(view): AI-assisted triage — explain a finding (Phase 10 foundation)

### DIFF
--- a/.ai/architecture.yaml
+++ b/.ai/architecture.yaml
@@ -117,6 +117,12 @@ components:
         (kitty/iterm/sixel/none from env), supports_graphics / supports_hyperlinks / supports_truecolor,
         capability_summary. Env-only (no escape probing), dependency-free; the foundation richer inline-image
         rendering (textual-image, capability-gated, ASCII fallback) would build on. Surfaced in the Console help.
+      core/ai_triage.py: UI-free AI-assisted triage (Phase 10 foundation). Reuses scn/ai.py providers
+        (create_provider / resolve_api_key, provider.call(prompt)). explain_prompt / fix_prompt + triage_explain /
+        triage_fix run against an injected provider (mocked in tests). provider_from_env is local-first —
+        ARGUS_AI_LOCAL/OLLAMA_HOST gives a keyless local Ollama endpoint, ARGUS_AI_PROVIDER + key gives cloud,
+        else off. Drives the terminal viewer's ``x`` Explain overlay; model output is advisory (fixes still gate
+        through the Phase-1 diff preview, never auto-applied).
       viewers/: '`argus view` interfaces (optional extras)'
       viewers/__init__.py: ViewerUnavailable shared exception
       viewers/terminal/: '`argus view --interface=terminal` — Textual TUI ([terminal] extra). Includes
@@ -743,6 +749,12 @@ docsite:
         (kitty/iterm/sixel/none from env), supports_graphics / supports_hyperlinks / supports_truecolor,
         capability_summary. Env-only (no escape probing), dependency-free; the foundation richer inline-image
         rendering (textual-image, capability-gated, ASCII fallback) would build on. Surfaced in the Console help.
+      core/ai_triage.py: UI-free AI-assisted triage (Phase 10 foundation). Reuses scn/ai.py providers
+        (create_provider / resolve_api_key, provider.call(prompt)). explain_prompt / fix_prompt + triage_explain /
+        triage_fix run against an injected provider (mocked in tests). provider_from_env is local-first —
+        ARGUS_AI_LOCAL/OLLAMA_HOST gives a keyless local Ollama endpoint, ARGUS_AI_PROVIDER + key gives cloud,
+        else off. Drives the terminal viewer's ``x`` Explain overlay; model output is advisory (fixes still gate
+        through the Phase-1 diff preview, never auto-applied).
       viewers/: '`argus view` interfaces (optional extras)'
       viewers/__init__.py: ViewerUnavailable shared exception
       viewers/terminal/: '`argus view --interface=terminal` — Textual TUI ([terminal] extra). Includes

--- a/argus/core/ai_triage.py
+++ b/argus/core/ai_triage.py
@@ -1,0 +1,136 @@
+"""AI-assisted triage — explain a finding / draft a fix (Phase 10 foundation).
+
+Reuses the existing provider abstraction (``argus/scn/ai.py``:
+``create_provider`` / ``resolve_api_key``, providers expose ``call(prompt)``)
+— no new AI layer. **Local-first**: with ``ARGUS_AI_LOCAL=1`` (or
+``OLLAMA_HOST``) it talks to a local OpenAI-compatible endpoint (Ollama) so
+**no API key is required**; cloud providers are opt-in via the usual env
+vars. With nothing configured, AI is simply *off* and the caller falls back
+to the deterministic context it already has (Phase-6 enrichment, Phase-1 Fix).
+
+UI-free: prompt builders + a thin orchestrator over a provider's ``call``.
+The provider is injected, so tests never hit the network. **Model output is
+untrusted** — an explanation is advisory, and any suggested fix must flow
+through the Phase-1 diff-preview gate, never auto-applied.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Mapping, Protocol
+
+from argus.core.models import Finding
+
+# Local-first defaults: Ollama's OpenAI-compatible endpoint, no key required.
+DEFAULT_LOCAL_BASE_URL = "http://localhost:11434/v1"
+DEFAULT_LOCAL_MODEL = "llama3.1"
+_DEFAULT_MAX_TOKENS = 1024
+_CLOUD_MODELS = {"anthropic": "claude-3-5-haiku-latest", "openai": "gpt-4o-mini"}
+
+
+class Provider(Protocol):
+    def call(self, prompt: str) -> str: ...
+
+
+def explain_prompt(finding: Finding, *, enrichment_summary: str = "") -> str:
+    """Prompt asking the model to explain a finding in this repo's context."""
+    lines = [
+        "You are a security engineer triaging a scanner finding. Explain it "
+        "concisely for a developer: what it is, why it matters here, and the "
+        "most likely real-world impact. Be specific and practical; do not "
+        "invent details that aren't given.",
+        "",
+        f"Scanner: {finding.scanner or 'unknown'}",
+        f"Severity: {finding.severity.value}",
+        f"ID: {finding.id}",
+    ]
+    if finding.cve:
+        lines.append(f"CVE: {finding.cve}")
+    if finding.location:
+        lines.append(f"Location: {finding.location}")
+    lines.append(f"Title: {finding.title}")
+    if finding.description and finding.description != finding.title:
+        lines.append(f"Description: {finding.description}")
+    if enrichment_summary:
+        lines.append(f"Exploit intelligence: {enrichment_summary}")
+    return "\n".join(lines)
+
+
+def fix_prompt(finding: Finding) -> str:
+    """Prompt asking the model to propose a fix as a reviewable diff."""
+    return (
+        "Propose a minimal, safe fix for the security finding below, as a "
+        "unified diff if you can infer the file, otherwise as concrete steps. "
+        "Do not weaken other behaviour. The fix will be reviewed and tested "
+        "before it is applied — never assume it is auto-applied.\n\n"
+        f"Scanner: {finding.scanner or 'unknown'}\n"
+        f"Severity: {finding.severity.value}\n"
+        f"ID: {finding.id}\n"
+        + (f"Location: {finding.location}\n" if finding.location else "")
+        + f"Title: {finding.title}\n"
+        + (f"Description: {finding.description}\n" if finding.description else "")
+    )
+
+
+def triage_explain(
+    finding: Finding, *, provider: Provider, enrichment_summary: str = "",
+) -> str:
+    """Ask ``provider`` to explain ``finding``; returns the model's text."""
+    return provider.call(explain_prompt(finding, enrichment_summary=enrichment_summary))
+
+
+def triage_fix(finding: Finding, *, provider: Provider) -> str:
+    """Ask ``provider`` to draft a fix for ``finding`` (advisory; review first)."""
+    return provider.call(fix_prompt(finding))
+
+
+def provider_from_env(env: Mapping[str, str] | None = None) -> tuple[object | None, str]:
+    """Resolve a provider from the environment → ``(provider, label)``.
+
+    Resolution order (local-first, key-optional):
+      1. ``ARGUS_AI_PROVIDER=anthropic|openai`` *and* a resolvable API key →
+         that cloud provider.
+      2. ``ARGUS_AI_LOCAL=1`` or ``OLLAMA_HOST`` → a local OpenAI-compatible
+         endpoint (Ollama), **no key required**.
+      3. otherwise ``(None, "off")`` — AI is disabled, caller degrades.
+
+    Construction only — never makes a network call here, so it's safe to call
+    on every screen open.
+    """
+    e = os.environ if env is None else env
+    name = (e.get("ARGUS_AI_PROVIDER") or "").strip().lower()
+
+    if name in ("anthropic", "openai"):
+        try:
+            from argus.scn.ai import create_provider, resolve_api_key
+            key = resolve_api_key(name)
+            if key:
+                model = e.get("ARGUS_AI_MODEL") or _CLOUD_MODELS[name]
+                config = {"model": model, "max_tokens": _DEFAULT_MAX_TOKENS}
+                if e.get("ARGUS_AI_BASE_URL"):
+                    config["api_base_url"] = e["ARGUS_AI_BASE_URL"]
+                return create_provider(name, key, config), f"{name}:{model}"
+        except Exception:
+            return None, "off"
+
+    if e.get("ARGUS_AI_LOCAL") or e.get("OLLAMA_HOST"):
+        try:
+            from argus.scn.ai import create_provider
+            base = e.get("ARGUS_AI_BASE_URL") or _ollama_base(e.get("OLLAMA_HOST"))
+            model = e.get("ARGUS_AI_MODEL") or DEFAULT_LOCAL_MODEL
+            config = {
+                "model": model, "max_tokens": _DEFAULT_MAX_TOKENS, "api_base_url": base,
+            }
+            # Local endpoints don't need a real key; send a placeholder.
+            return create_provider("openai", e.get("ARGUS_AI_KEY", "local"), config), f"local:{model}"
+        except Exception:
+            return None, "off"
+
+    return None, "off"
+
+
+def _ollama_base(host: str | None) -> str:
+    if not host:
+        return DEFAULT_LOCAL_BASE_URL
+    host = host.rstrip("/")
+    return host if host.endswith("/v1") else f"{host}/v1"

--- a/argus/tests/core/test_ai_triage.py
+++ b/argus/tests/core/test_ai_triage.py
@@ -1,0 +1,88 @@
+"""Unit tests for argus.core.ai_triage (Phase 10 — AI assistant foundation).
+
+Network-free: the prompt builders are pure, and the orchestrator runs
+against a fake provider. ``provider_from_env`` is checked for the off/local
+resolution without any real call.
+"""
+
+from __future__ import annotations
+
+from argus.core.ai_triage import (
+    DEFAULT_LOCAL_MODEL,
+    explain_prompt,
+    fix_prompt,
+    provider_from_env,
+    triage_explain,
+    triage_fix,
+)
+from argus.core.models import Finding, Severity
+
+
+def _finding(**kw):
+    base = dict(id="CVE-2021-44228", severity=Severity.HIGH, title="Log4Shell RCE",
+                cve="CVE-2021-44228", scanner="osv", location="pom.xml")
+    base.update(kw)
+    return Finding(**base)
+
+
+class _FakeProvider:
+    def __init__(self):
+        self.prompts: list[str] = []
+
+    def call(self, prompt: str) -> str:
+        self.prompts.append(prompt)
+        return "explanation text"
+
+
+class TestPrompts:
+    def test_explain_includes_key_fields(self):
+        p = explain_prompt(_finding(), enrichment_summary="EPSS 97% · KEV")
+        assert "osv" in p and "high" in p and "CVE-2021-44228" in p
+        assert "pom.xml" in p and "Log4Shell RCE" in p
+        assert "EPSS 97% · KEV" in p
+
+    def test_explain_omits_absent_fields(self):
+        p = explain_prompt(_finding(cve=None, location=None))
+        assert "CVE:" not in p and "Location:" not in p
+
+    def test_fix_prompt_asks_for_diff_and_review(self):
+        p = fix_prompt(_finding())
+        assert "unified diff" in p and "reviewed and tested" in p
+
+
+class TestOrchestrator:
+    def test_triage_explain_calls_provider(self):
+        provider = _FakeProvider()
+        out = triage_explain(_finding(), provider=provider, enrichment_summary="KEV")
+        assert out == "explanation text"
+        assert "KEV" in provider.prompts[0]
+
+    def test_triage_fix_calls_provider(self):
+        provider = _FakeProvider()
+        triage_fix(_finding(), provider=provider)
+        assert "unified diff" in provider.prompts[0]
+
+
+class TestProviderFromEnv:
+    def test_off_by_default(self):
+        provider, label = provider_from_env({})
+        assert provider is None and label == "off"
+
+    def test_local_when_flag_set(self):
+        provider, label = provider_from_env({"ARGUS_AI_LOCAL": "1"})
+        assert provider is not None
+        assert label == f"local:{DEFAULT_LOCAL_MODEL}"
+
+    def test_local_via_ollama_host(self):
+        provider, label = provider_from_env({"OLLAMA_HOST": "http://box:11434"})
+        assert provider is not None and label.startswith("local:")
+
+    def test_cloud_without_key_is_off(self):
+        # Provider named but no key resolvable → off (no env key set).
+        provider, label = provider_from_env({"ARGUS_AI_PROVIDER": "anthropic"})
+        assert provider is None and label == "off"
+
+    def test_cloud_with_key(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        provider, label = provider_from_env({"ARGUS_AI_PROVIDER": "anthropic"})
+        assert provider is not None and label.startswith("anthropic:")

--- a/argus/viewers/terminal/app.py
+++ b/argus/viewers/terminal/app.py
@@ -59,7 +59,7 @@ from argus.core.enrichment import (
     is_cve,
     risk_badge,
 )
-from argus.core import suppressions, trends
+from argus.core import ai_triage, suppressions, trends
 from argus.core.models import Finding, Severity
 
 
@@ -915,6 +915,67 @@ class SpanContextMenuScreen(_BackgroundDismissMixin, ModalScreen[str | None]):
         self.dismiss(event.option.id or None)
 
 
+_EXPLAIN_CSS = """
+ExplainScreen { align: center middle; }
+ExplainScreen > Vertical {
+    width: 88%; max-width: 110; height: 70%;
+    border: thick $accent; background: $surface; padding: 1 2;
+}
+ExplainScreen #explain-title { text-style: bold; padding: 0 0 1 0; }
+ExplainScreen #explain-scroll { height: 1fr; border: solid $accent; padding: 0 1; }
+ExplainScreen #explain-hint { color: $text-muted; padding: 1 0 0 0; }
+"""
+
+
+class ExplainScreen(_BackgroundDismissMixin, ModalScreen):
+    """AI explanation overlay for a finding (Phase 10).
+
+    Runs the model call in a thread so the UI never blocks, then shows the
+    text. The runner is injectable for tests; model output is advisory only
+    (a suggested fix would still go through the Phase-1 diff gate).
+    """
+
+    CSS = _EXPLAIN_CSS
+    BINDINGS = [
+        Binding("escape", "dismiss", "Close", show=True),
+        Binding("q", "dismiss", show=False),
+    ]
+
+    def __init__(self, finding, provider, *, enrichment_summary="", runner=None, label=""):
+        super().__init__()
+        self._finding = finding
+        self._provider = provider
+        self._enrichment_summary = enrichment_summary
+        self._runner = runner or ai_triage.triage_explain
+        self._label = label
+
+    def compose(self) -> ComposeResult:  # pragma: no cover — UI
+        with Vertical():
+            title = f"🤖 Explain · {self._finding.id}"
+            if self._label:
+                title += f"   [dim]{self._label}[/dim]"
+            yield Static(title, id="explain-title")
+            with VerticalScroll(id="explain-scroll"):
+                yield Static("[dim]Thinking…[/dim]", id="explain-text")
+            yield Static("esc to close  ·  AI output is advisory — verify before acting", id="explain-hint")
+
+    def on_mount(self) -> None:  # pragma: no cover — UI/worker
+        self.run_worker(self._work, thread=True, exclusive=True)
+
+    def _work(self) -> None:  # pragma: no cover — worker thread
+        try:
+            text = self._runner(
+                self._finding, provider=self._provider,
+                enrichment_summary=self._enrichment_summary,
+            )
+        except Exception as exc:  # model/network failure → show, don't crash
+            text = f"[red]AI request failed:[/red] {exc}"
+        self.call_from_thread(self._show, text or "[dim](no response)[/dim]")
+
+    def _show(self, text: str) -> None:  # pragma: no cover — UI
+        self.query_one("#explain-text", Static).update(text)
+
+
 _SUPPRESS_CSS = """
 SuppressScreen { align: center middle; }
 SuppressScreen > Vertical {
@@ -1254,6 +1315,7 @@ class ArgusBrowseCommands(Provider):
             ("Fix: Apply a Tier-1 dependency bump", "Propose + preview + apply a deterministic fix for the focused finding or selection (shift+f)", app.action_fix),
             ("Intel: Enrich with EPSS + CISA KEV", "Fetch exploit-probability + known-exploited intelligence for the CVEs in view (i)", app.action_enrich),
             ("Triage: Suppress / accept-risk (VEX)", "Record a triage decision to OpenVEX + .trivyignore/.gitleaksignore for the focused finding or selection (shift+s)", app.action_suppress),
+            ("AI: Explain this finding", "Ask a local (Ollama) or cloud model to explain the focused finding (x)", app.action_explain),
             ("Search findings",          "Focus the search box", app.action_focus_search),
             ("Filter: Critical only",    "Show only CRITICAL findings", app.action_filter_critical),
             ("Filter: High severity and above", "Show HIGH + CRITICAL findings", app.action_filter_high),
@@ -1502,6 +1564,10 @@ class BrowseApp(App):
         # whole selection, writing an OpenVEX audit trail + scanner ignore
         # entries so the next scan honours it.
         Binding("S", "suppress", "Suppress", show=True),
+        # AI-assisted triage: ask a local (Ollama) or cloud model to explain
+        # the focused finding. Opt-in, local-first, no key required to use
+        # Argus — stays off with a hint when nothing is configured.
+        Binding("x", "explain", "Explain", show=True),
         # Multi-select — drives the bulk-action workflows (export N rows,
         # paste a CVE list into a bug tracker). ``space``/``a``/``A``
         # manage the selection set; ``c`` copies CVEs from it. ``e``
@@ -1545,6 +1611,9 @@ class BrowseApp(App):
         # Injectable for tests; None ⇒ a default service (env-driven offline
         # detection, on-disk cache) is built on first ``action_enrich``.
         self._enrichment_service: EnrichmentService | None = None
+        # AI triage (Phase 10): a (provider, label) override for tests; None ⇒
+        # resolved from the environment (local Ollama / cloud key) on demand.
+        self._ai_provider_override: tuple[object | None, str] | None = None
         # Load ``view:`` config (cve_source / open_location / editor)
         # from any argus.yml the user has in cwd or beside results_dir.
         # ArgusConfig.load() auto-detects and falls back to defaults if
@@ -2073,6 +2142,31 @@ class BrowseApp(App):
     def _suppress_product(finding: Finding) -> str:  # pragma: no cover — UI
         meta = finding.metadata or {}
         return (meta.get("purl") or meta.get("fingerprint") or "").strip()
+
+    def action_explain(self) -> None:  # pragma: no cover — UI
+        """Ask a local/cloud model to explain the focused finding (``x``).
+
+        Local-first and opt-in: uses a local Ollama endpoint when enabled,
+        a cloud provider when a key is set, and otherwise stays off with a
+        hint (no silent egress, no key required to use Argus).
+        """
+        row = self.query_one(DataTable).cursor_row
+        if not (0 <= row < len(self._visible)):
+            self.notify("Select a finding to explain.", severity="information")
+            return
+        finding = self._visible[row]
+        provider, label = self._ai_provider_override or ai_triage.provider_from_env()
+        if provider is None:
+            self.notify(
+                "AI is off — set ARGUS_AI_LOCAL=1 for a local Ollama model, "
+                "or ARGUS_AI_PROVIDER + an API key for a cloud model.",
+                severity="warning", timeout=8,
+            )
+            return
+        enr = self._enrichment.get(finding.cve.upper()) if finding.cve else None
+        self.push_screen(ExplainScreen(
+            finding, provider, enrichment_summary=risk_badge(enr), label=label,
+        ))
 
     def _source_context_block(self, finding: Finding) -> str | None:
         """Render the ``[bold]Source[/bold]`` block for the detail pane.

--- a/docs/view-terminal.md
+++ b/docs/view-terminal.md
@@ -74,6 +74,7 @@ Press `?` inside the TUI for the same reference, grouped by purpose.
 | `F` (shift+f) | fix — propose a dependency bump for the finding (or selection), preview the diff, apply |
 | `i` | enrich — fetch EPSS + CISA KEV intelligence for the CVEs in view (see below) |
 | `S` (shift+s) | triage — suppress / accept-risk the finding (or selection), writing OpenVEX + ignore files (see below) |
+| `x` | explain — ask a local (Ollama) or cloud model to explain the focused finding (see below) |
 | **Other** | |
 | `d` | executive dashboard overlay |
 | `D` (shift+d) | scan-over-scan diff — pick another `argus-results.json` and bucket changes |
@@ -186,6 +187,29 @@ Argus writes the decision to two places:
 
 This reuses the same OpenVEX vocabulary as Argus's signed scan attestations,
 so a TUI triage decision and a CI-generated VEX speak the same language.
+
+## AI explanation (`x`)
+
+Press `x` to ask a model to explain the focused finding — what it is, why it
+matters *here*, and the likely real-world impact, with the Phase-6 exploit
+intelligence (EPSS / KEV) folded into the prompt when present.
+
+**Local-first and opt-in — no API key required to use Argus.** AI is off by
+default. Two ways to turn it on:
+
+- **Local model (recommended):** `export ARGUS_AI_LOCAL=1` to use a local
+  [Ollama](https://ollama.com) endpoint (or set `OLLAMA_HOST`). Nothing
+  leaves your machine.
+- **Cloud model:** `export ARGUS_AI_PROVIDER=anthropic` (or `openai`) plus
+  the provider's API key (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY`). Override
+  the model with `ARGUS_AI_MODEL`.
+
+With neither configured, `x` shows a hint and does nothing else — no silent
+network calls. Model output is **advisory**: it's there to speed up triage,
+not to be trusted blindly, and any AI-suggested *fix* would still go through
+the same diff-preview gate as the deterministic `F` fix (never auto-applied).
+This reuses the provider abstraction already behind `argus classify`, so
+there's one AI integration across the tool.
 
 ## Mouse interactions
 


### PR DESCRIPTION
## Description
Phase 10 — **AI-assisted triage** (foundation). Press `x` to ask a model to explain the focused finding in this repo's context. **Local-first, opt-in, no API key required to use Argus.** Reuses the existing provider abstraction (`argus/scn/ai.py`) — no new AI layer. Targets the integration branch (`feat/tui-explorer-and-scan-runner`, PR #261).

## Changes Made
- [x] Added new core module (`argus/core/ai_triage.py`)
- [x] Modified existing scanner/workflow (terminal viewer)
- [x] Updated documentation

### Details
- **`argus/core/ai_triage.py`** (UI-free): `explain_prompt` / `fix_prompt` (fold in Phase-6 EPSS/KEV intel), `triage_explain` / `triage_fix` over an **injected** provider's `call(prompt)`, and `provider_from_env` — local-first resolution: `ARGUS_AI_LOCAL=1` / `OLLAMA_HOST` → keyless local Ollama; `ARGUS_AI_PROVIDER` + key → cloud; else `off`. Construction never makes a network call.
- **Viewer** (`app.py`): `x` → `ExplainScreen`, which runs the model call in a **thread** (UI never blocks) and shows the text; command-palette entry mirrors it. With nothing configured, `x` shows a hint and makes **no network call**.
- **Trust posture:** model output is advisory; an AI-suggested *fix* would still flow through the Phase-1 diff-preview gate, never auto-applied. Reuses the provider abstraction already behind `argus classify`, so there's one AI integration across the tool.
- **Follow-ons (noted):** token-streaming output + a fix-draft action.

## Testing
- [x] Unit tests added/updated — `test_ai_triage.py` (10 tests): prompt builders (fields included / omitted, fix asks for diff+review), orchestrator over a fake provider, and `provider_from_env` (off-by-default, local via flag / `OLLAMA_HOST`, cloud-without-key→off, cloud-with-key). **Zero network.**
- [x] Manual testing — real-Textual smoke: `x` with an injected provider pushes `ExplainScreen` and renders the model text; the off-path shows the `ARGUS_AI_LOCAL` hint.
- Full suite: **4147 passed, 21 skipped**, coverage gate met. (3 local-only `viewers/browser` failures are pre-existing + green in CI.)

## Security Considerations
- [x] Potential security implications (explain below)

### Security Details
Adds **opt-in** AI calls. Mitigations: **off by default** (no key, no daemon, no egress unless explicitly enabled); **local-first** (Ollama keeps data on-device); only the finding's own fields + public EPSS/KEV summary go in the prompt; the worker fails closed (model/network error → shown, never crashes); output is advisory and any fix re-enters the reviewed diff gate. No new dependency — rides the existing `[ai]` provider layer.

## AI Context Updates (.ai/)
- [x] `.ai/architecture.yaml` updated (`core/ai_triage.py`, both mirror blocks)

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (`docs/view-terminal.md` — keybind + "AI explanation" section)
- [ ] Changelog updated (handled by release-it)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Console epic — `docs/developer/CONSOLE-ROADMAP.md`, Phase 10 (the deferred Tier-2 of the Fix work, as an interactive assistant).
