### PR TITLE
feat(view): reachability heuristic — is the dependency imported? (Phase 12 first cut)

### DIFF
--- a/.ai/architecture.yaml
+++ b/.ai/architecture.yaml
@@ -123,6 +123,11 @@ components:
         ARGUS_AI_LOCAL/OLLAMA_HOST gives a keyless local Ollama endpoint, ARGUS_AI_PROVIDER + key gives cloud,
         else off. Drives the terminal viewer's ``x`` Explain overlay; model output is advisory (fixes still gate
         through the Phase-1 diff preview, never auto-applied).
+      core/reachability.py: UI-free reachability heuristic (Phase 12 first cut). is_imported(package, ecosystem,
+        root) + reachability_of(finding) answer "is the vulnerable dependency even imported in source?" via a
+        bounded, dependency-free pip/npm import scan (build/vendor dirs skipped, early-exit, cached). Returns
+        imported / not-imported / unknown; labelled "imported in source" (NOT "reachable" — true call-graph
+        reachability stays roadmap research). Shows a Reachability row in the terminal viewer's detail pane.
       viewers/: '`argus view` interfaces (optional extras)'
       viewers/__init__.py: ViewerUnavailable shared exception
       viewers/terminal/: '`argus view --interface=terminal` — Textual TUI ([terminal] extra). Includes
@@ -755,6 +760,11 @@ docsite:
         ARGUS_AI_LOCAL/OLLAMA_HOST gives a keyless local Ollama endpoint, ARGUS_AI_PROVIDER + key gives cloud,
         else off. Drives the terminal viewer's ``x`` Explain overlay; model output is advisory (fixes still gate
         through the Phase-1 diff preview, never auto-applied).
+      core/reachability.py: UI-free reachability heuristic (Phase 12 first cut). is_imported(package, ecosystem,
+        root) + reachability_of(finding) answer "is the vulnerable dependency even imported in source?" via a
+        bounded, dependency-free pip/npm import scan (build/vendor dirs skipped, early-exit, cached). Returns
+        imported / not-imported / unknown; labelled "imported in source" (NOT "reachable" — true call-graph
+        reachability stays roadmap research). Shows a Reachability row in the terminal viewer's detail pane.
       viewers/: '`argus view` interfaces (optional extras)'
       viewers/__init__.py: ViewerUnavailable shared exception
       viewers/terminal/: '`argus view --interface=terminal` — Textual TUI ([terminal] extra). Includes

--- a/argus/core/reachability.py
+++ b/argus/core/reachability.py
@@ -1,0 +1,150 @@
+"""Reachability heuristic — is a vulnerable dependency actually imported?
+
+Phase 12, first cut. The holy grail of vulnerability noise reduction is "is
+the vulnerable code actually *reachable*?" — true call-graph analysis. That's
+hard and ecosystem-specific, so it stays roadmap-only research. What ships
+here is a cheap, honest proxy: **does the project's source even import the
+vulnerable package?** A dependency that's declared but never imported is a
+strong "likely unused → lower real risk" signal; one that's imported
+everywhere is not exonerated, but it's clearly in play.
+
+Deliberately labelled "imported in source" (not "reachable") so it's never
+over-claimed. UI-free + dependency-free: a bounded, early-exiting source
+scan with the build/vendor dirs skipped. Covers the two ecosystems the Fix
+engine already handles (pip / npm); others report ``unknown``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Iterable
+
+from argus.core.models import Finding
+
+REACHABILITY_IMPORTED = "imported"
+REACHABILITY_NOT_IMPORTED = "not-imported"
+REACHABILITY_UNKNOWN = "unknown"
+
+_PYTHON_GLOBS = ("*.py",)
+_JS_GLOBS = ("*.js", "*.ts", "*.jsx", "*.tsx", "*.mjs", "*.cjs")
+
+_SKIP_DIRS = {
+    "node_modules", ".git", "__pycache__", ".venv", "venv", ".tox",
+    "dist", "build", ".eggs", "vendor", ".mypy_cache", "htmlcov",
+}
+
+_LABELS = {
+    REACHABILITY_IMPORTED: "✓ imported in source",
+    REACHABILITY_NOT_IMPORTED: "not imported (likely unused)",
+    REACHABILITY_UNKNOWN: "unknown",
+}
+
+
+def ecosystem_of(finding: Finding) -> str | None:
+    """Best-effort ecosystem ("python" / "javascript") from a finding.
+
+    Reads the PURL type when present, else the ``ecosystem`` metadata key.
+    Returns ``None`` for ecosystems this heuristic doesn't cover.
+    """
+    meta = finding.metadata or {}
+    purl = (meta.get("purl") or "").lower()
+    if purl.startswith("pkg:pypi/"):
+        return "python"
+    if purl.startswith("pkg:npm/"):
+        return "javascript"
+    eco = (meta.get("ecosystem") or "").strip().lower()
+    if eco in ("pypi", "python", "pip"):
+        return "python"
+    if eco in ("npm", "node", "javascript"):
+        return "javascript"
+    return None
+
+
+def package_of(finding: Finding) -> str:
+    """The package name a finding is about, or ``""`` for non-dependency findings."""
+    meta = finding.metadata or {}
+    return (meta.get("package") or meta.get("package_name") or "").strip()
+
+
+def _python_patterns(package: str) -> list[re.Pattern[str]]:
+    # PyPI dist name → import name: hyphens become underscores; take the top
+    # package. Best-effort (some dists import under a different name).
+    module = re.split(r"[\[<>=!;\s]", package, 1)[0].replace("-", "_").lower()
+    top = module.split(".")[0]
+    if not top:
+        return []
+    return [re.compile(rf"^\s*(?:import|from)\s+{re.escape(top)}(?:[.\s]|$)", re.MULTILINE)]
+
+
+def _js_patterns(package: str) -> list[re.Pattern[str]]:
+    pkg = re.escape(package)
+    return [re.compile(
+        rf"""(?:require\(\s*['"]{pkg}(?:/[^'"]*)?['"]"""
+        rf"""|(?:import|export)[^;\n]*['"]{pkg}(?:/[^'"]*)?['"])"""
+    )]
+
+
+def _patterns(package: str, ecosystem: str) -> list[re.Pattern[str]]:
+    if ecosystem == "python":
+        return _python_patterns(package)
+    if ecosystem == "javascript":
+        return _js_patterns(package)
+    return []
+
+
+def _globs(ecosystem: str) -> tuple[str, ...]:
+    return _PYTHON_GLOBS if ecosystem == "python" else _JS_GLOBS
+
+
+def _source_files(root: Path, globs: Iterable[str], max_files: int) -> Iterable[Path]:
+    count = 0
+    for pattern in globs:
+        for path in root.rglob(pattern):
+            if any(part in _SKIP_DIRS for part in path.parts):
+                continue
+            yield path
+            count += 1
+            if count >= max_files:
+                return
+
+
+def is_imported(
+    package: str, ecosystem: str | None, *, root: Path, max_files: int = 3000,
+) -> str:
+    """Heuristically classify whether ``package`` is imported under ``root``.
+
+    Returns ``REACHABILITY_IMPORTED`` on the first matching import,
+    ``REACHABILITY_NOT_IMPORTED`` if none match after scanning, or
+    ``REACHABILITY_UNKNOWN`` when the ecosystem/package is unsupported. The
+    scan is bounded (``max_files``) and early-exits on the first hit.
+    """
+    patterns = _patterns(package, ecosystem or "")
+    if not package or not patterns:
+        return REACHABILITY_UNKNOWN
+    scanned = 0
+    for path in _source_files(root, _globs(ecosystem), max_files):
+        scanned += 1
+        try:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        if any(p.search(text) for p in patterns):
+            return REACHABILITY_IMPORTED
+    return REACHABILITY_NOT_IMPORTED if scanned else REACHABILITY_UNKNOWN
+
+
+def reachability_label(status: str) -> str:
+    """Human label for a reachability status."""
+    return _LABELS.get(status, _LABELS[REACHABILITY_UNKNOWN])
+
+
+def reachability_of(finding: Finding, *, root: Path, max_files: int = 3000) -> str:
+    """Convenience: classify a finding's package reachability under ``root``.
+
+    Non-dependency findings (no package) return ``REACHABILITY_UNKNOWN``.
+    """
+    package = package_of(finding)
+    if not package:
+        return REACHABILITY_UNKNOWN
+    return is_imported(package, ecosystem_of(finding), root=root, max_files=max_files)

--- a/argus/tests/core/test_reachability.py
+++ b/argus/tests/core/test_reachability.py
@@ -1,0 +1,114 @@
+"""Unit tests for argus.core.reachability (Phase 12 — import heuristic)."""
+
+from __future__ import annotations
+
+from argus.core.models import Finding, Severity
+from argus.core.reachability import (
+    REACHABILITY_IMPORTED,
+    REACHABILITY_NOT_IMPORTED,
+    REACHABILITY_UNKNOWN,
+    ecosystem_of,
+    is_imported,
+    package_of,
+    reachability_label,
+    reachability_of,
+)
+
+
+def _dep_finding(package="requests", purl="pkg:pypi/requests@2.0", ecosystem=None):
+    meta = {"package": package}
+    if purl:
+        meta["purl"] = purl
+    if ecosystem:
+        meta["ecosystem"] = ecosystem
+    return Finding(id="CVE-1-1", severity=Severity.HIGH, title="t", cve="CVE-1-1", metadata=meta)
+
+
+class TestEcosystemAndPackage:
+    def test_ecosystem_from_purl(self):
+        assert ecosystem_of(_dep_finding(purl="pkg:pypi/x@1")) == "python"
+        assert ecosystem_of(_dep_finding(purl="pkg:npm/x@1")) == "javascript"
+
+    def test_ecosystem_from_metadata(self):
+        assert ecosystem_of(_dep_finding(purl=None, ecosystem="PyPI")) == "python"
+        assert ecosystem_of(_dep_finding(purl=None, ecosystem="npm")) == "javascript"
+
+    def test_unsupported_ecosystem_none(self):
+        assert ecosystem_of(_dep_finding(purl="pkg:golang/x@1")) is None
+
+    def test_package_of(self):
+        assert package_of(_dep_finding(package="flask")) == "flask"
+        assert package_of(Finding(id="x", severity=Severity.LOW, title="t")) == ""
+
+
+class TestPythonImports:
+    def test_detects_import(self, tmp_path):
+        (tmp_path / "app.py").write_text("import requests\nrequests.get('x')\n")
+        assert is_imported("requests", "python", root=tmp_path) == REACHABILITY_IMPORTED
+
+    def test_detects_from_import(self, tmp_path):
+        (tmp_path / "app.py").write_text("from flask import Flask\n")
+        assert is_imported("flask", "python", root=tmp_path) == REACHABILITY_IMPORTED
+
+    def test_hyphen_dist_name_maps_to_underscore(self, tmp_path):
+        # Dist names whose import is the underscored form (e.g.
+        # typing-extensions → typing_extensions) map cleanly.
+        (tmp_path / "a.py").write_text("import typing_extensions\n")
+        assert is_imported("typing-extensions", "python", root=tmp_path) == REACHABILITY_IMPORTED
+
+    def test_not_imported(self, tmp_path):
+        (tmp_path / "app.py").write_text("import os\n")
+        assert is_imported("requests", "python", root=tmp_path) == REACHABILITY_NOT_IMPORTED
+
+    def test_skips_vendor_dirs(self, tmp_path):
+        (tmp_path / "app.py").write_text("import os\n")  # real source, no match
+        vendored = tmp_path / "node_modules" / "x"
+        vendored.mkdir(parents=True)
+        (vendored / "dep.py").write_text("import requests\n")  # match only in vendored
+        # the only match is in a skipped dir → not imported in real source
+        assert is_imported("requests", "python", root=tmp_path) == REACHABILITY_NOT_IMPORTED
+
+    def test_substring_not_falsely_matched(self, tmp_path):
+        (tmp_path / "app.py").write_text("import requests_oauthlib\n")
+        # "requests" should not match "requests_oauthlib" as a top import
+        assert is_imported("requests", "python", root=tmp_path) == REACHABILITY_NOT_IMPORTED
+
+
+class TestJsImports:
+    def test_require(self, tmp_path):
+        (tmp_path / "a.js").write_text("const lodash = require('lodash');\n")
+        assert is_imported("lodash", "javascript", root=tmp_path) == REACHABILITY_IMPORTED
+
+    def test_es_import(self, tmp_path):
+        (tmp_path / "a.ts").write_text("import axios from 'axios';\n")
+        assert is_imported("axios", "javascript", root=tmp_path) == REACHABILITY_IMPORTED
+
+    def test_subpath_import(self, tmp_path):
+        (tmp_path / "a.js").write_text("import x from 'lodash/merge';\n")
+        assert is_imported("lodash", "javascript", root=tmp_path) == REACHABILITY_IMPORTED
+
+    def test_not_imported(self, tmp_path):
+        (tmp_path / "a.js").write_text("console.log('hi');\n")
+        assert is_imported("lodash", "javascript", root=tmp_path) == REACHABILITY_NOT_IMPORTED
+
+
+class TestUnknownAndLabels:
+    def test_unsupported_ecosystem_unknown(self, tmp_path):
+        assert is_imported("x", "golang", root=tmp_path) == REACHABILITY_UNKNOWN
+        assert is_imported("x", None, root=tmp_path) == REACHABILITY_UNKNOWN
+
+    def test_empty_package_unknown(self, tmp_path):
+        assert is_imported("", "python", root=tmp_path) == REACHABILITY_UNKNOWN
+
+    def test_reachability_of_non_dependency(self, tmp_path):
+        f = Finding(id="x", severity=Severity.LOW, title="t")
+        assert reachability_of(f, root=tmp_path) == REACHABILITY_UNKNOWN
+
+    def test_reachability_of_dependency(self, tmp_path):
+        (tmp_path / "app.py").write_text("import requests\n")
+        assert reachability_of(_dep_finding(), root=tmp_path) == REACHABILITY_IMPORTED
+
+    def test_labels(self):
+        assert "imported" in reachability_label(REACHABILITY_IMPORTED)
+        assert "likely unused" in reachability_label(REACHABILITY_NOT_IMPORTED)
+        assert reachability_label("???") == "unknown"

--- a/argus/viewers/terminal/app.py
+++ b/argus/viewers/terminal/app.py
@@ -59,7 +59,7 @@ from argus.core.enrichment import (
     is_cve,
     risk_badge,
 )
-from argus.core import ai_triage, suppressions, trends
+from argus.core import ai_triage, reachability, suppressions, trends
 from argus.core.models import Finding, Severity
 
 
@@ -1406,6 +1406,7 @@ class FindingDetail(Static):
         f: Finding | None,
         source_block: str | None = None,
         enrichment: "Enrichment | None" = None,
+        reachability: str | None = None,
     ) -> None:
         if f is None:
             self.update("[dim]Select a finding to see details.[/dim]")
@@ -1425,6 +1426,8 @@ class FindingDetail(Static):
         # Enrichment rows (EPSS / KEV / Risk) append after the core rows when
         # the finding's CVE has been enriched; empty otherwise.
         rows = finding_detail_rows(f) + enrichment_detail_rows(f.severity, enrichment)
+        if reachability:
+            rows = rows + [("Reachability", reachability)]
         for label, value in rows:
             rendered = self._linkify_value(label, value)
             lines.append(f"[b]{label}:[/b]".ljust(13) + f" {rendered}")
@@ -1614,6 +1617,10 @@ class BrowseApp(App):
         # AI triage (Phase 10): a (provider, label) override for tests; None ⇒
         # resolved from the environment (local Ollama / cloud key) on demand.
         self._ai_provider_override: tuple[object | None, str] | None = None
+        # Reachability (Phase 12): cache the "imported in source?" heuristic
+        # per ecosystem:package so the bounded source scan runs at most once
+        # per dependency, not on every detail-pane refresh.
+        self._reachability_cache: dict[str, str] = {}
         # Load ``view:`` config (cve_source / open_location / editor)
         # from any argus.yml the user has in cwd or beside results_dir.
         # ArgusConfig.load() auto-detects and falls back to defaults if
@@ -2041,7 +2048,26 @@ class BrowseApp(App):
         enrichment = self._enrichment.get(finding.cve.upper()) if finding.cve else None
         self.query_one("#detail", FindingDetail).update_finding(
             finding, source_block=block, enrichment=enrichment,
+            reachability=self._reachability_label(finding),
         )
+
+    def _reachability_label(self, finding: Finding) -> str | None:
+        """The "imported in source?" label for a dependency finding (Phase 12).
+
+        Returns ``None`` for non-dependency / unsupported-ecosystem findings.
+        Cached per ecosystem:package so the bounded source scan runs once.
+        """
+        package = reachability.package_of(finding)
+        ecosystem = reachability.ecosystem_of(finding)
+        if not package or ecosystem is None:
+            return None
+        key = f"{ecosystem}:{package}"
+        if key not in self._reachability_cache:
+            root = self._resolve_repo_root() or Path.cwd()
+            self._reachability_cache[key] = reachability.is_imported(
+                package, ecosystem, root=root, max_files=1500,
+            )
+        return reachability.reachability_label(self._reachability_cache[key])
 
     def action_enrich(self) -> None:  # pragma: no cover — UI/worker
         """Fetch EPSS + CISA KEV intelligence for the CVEs in view (``i``).

--- a/docs/view-terminal.md
+++ b/docs/view-terminal.md
@@ -160,6 +160,18 @@ only public CVE ids — never your source or secrets. With no network (or
 `ARGUS_NO_NETWORK=1`) the viewer behaves exactly as before, just without the
 badges.
 
+### Reachability
+
+For dependency findings, the detail pane also shows a **Reachability** row —
+a first-cut heuristic answering *is the vulnerable package even imported in
+this project's source?* A declared-but-never-imported dependency
+(`not imported (likely unused)`) is a strong "lower real risk" signal; one
+that's `imported in source` is clearly in play. It's a bounded, dependency-
+free source scan (pip / npm import patterns, build & vendor dirs skipped),
+cached per package. Deliberately labelled "imported in source," **not**
+"reachable" — true call-graph reachability is a harder, ecosystem-specific
+problem tracked as research in the roadmap, not claimed here.
+
 ## Triage & suppression (`S`)
 
 Triage at scale, the way security teams actually do it — but with a durable


### PR DESCRIPTION
## Description
Phase 12 — **reachability-aware prioritization** (first cut). The detail pane gains a **Reachability** row for dependency findings: *is the vulnerable package even imported in this project's source?* Targets the integration branch (`feat/tui-explorer-and-scan-runner`, PR #261).

**Scope, stated plainly:** this ships a cheap, honest *heuristic* — labelled **"imported in source," not "reachable."** True call-graph reachability is a harder, ecosystem-specific problem that stays **roadmap research**, explicitly not claimed here.

## Changes Made
- [x] Added new core module (`argus/core/reachability.py`)
- [x] Modified existing scanner/workflow (detail pane)
- [x] Updated documentation

### Details
- **`argus/core/reachability.py`** (UI-free, **dependency-free**): `is_imported(package, ecosystem, root)` / `reachability_of(finding)` run a **bounded, early-exiting** import scan (pip / npm patterns; build & vendor dirs skipped) → `imported` / `not-imported` / `unknown`. Ecosystem inferred from PURL or `ecosystem` metadata; pip dist→import name mapping is best-effort (hyphen→underscore), unsupported ecosystems return `unknown`.
- **Viewer**: the label is computed lazily and **cached per `ecosystem:package`** (`_reachability_label`), shown as a **Reachability** detail row — no new key, no new dependency, scan runs at most once per dependency.
- A "declared but never imported" dependency is a strong lower-real-risk signal; combined with Phase-6 EPSS/KEV it sharpens triage.

## Testing
- [x] Unit tests added/updated — `test_reachability.py` (19 tests): ecosystem/package extraction, Python `import`/`from`/hyphen-dist mapping/substring-not-matched, JS `require`/ES-import/subpath, vendor-dir skipping, unknown-ecosystem/empty-package, non-dependency findings, labels.
- [x] Manual testing — real-Textual smoke: `requests` (imported) → "✓ imported in source"; `flask` (not imported) → "not imported (likely unused)"; cache populated; non-dependency → no row.
- Full suite: **4166 passed, 21 skipped**, coverage gate met. (3 local-only `viewers/browser` failures are pre-existing + green in CI.)

## Security Considerations
- [x] No security impact — no new dependency, no network; read-only bounded source scan.

## AI Context Updates (.ai/)
- [x] `.ai/architecture.yaml` updated (`core/reachability.py`, both mirror blocks)

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (`docs/view-terminal.md` — Reachability section)
- [ ] Changelog updated (handled by release-it)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Console epic — `docs/developer/CONSOLE-ROADMAP.md`, Phase 12 (first cut; true call-graph reachability remains research).
