### PR TITLE
docs: browser & reporting roadmap; retire Console Phase 11 (web serve)

### DIFF
--- a/docs/developer/BROWSER-ROADMAP.md
+++ b/docs/developer/BROWSER-ROADMAP.md
@@ -46,10 +46,50 @@ scanned and what we found."
 
 ---
 
+## Phase B0 — Design system & motion foundation (lands first)
+
+The investment that makes the difference between "internal tool" and
+"product built by a large, mature company" — and the base the charts (B1)
+and report (B4) sit on. All dependency-light: CSS custom properties, the
+native View Transitions API, SVG, and small vanilla JS. No React / GSAP /
+Tailwind.
+
+**Build**
+- **Design tokens** (`argus.css` custom properties): a disciplined colour
+  system (brand dark base + a consistent **severity scale** — crit
+  `#e74c3c`, high `#e67e22`, med `#f1c40f`, low `#3498db`, info muted — used
+  identically across badge, row accent, donut, chart), a type scale, an 8px
+  spacing scale, radii, an elevation/shadow system, and `:focus-visible`
+  rings. The quiet craft that signals intention (Linear / Vercel / Stripe).
+- **Information architecture**: a persistent left sidebar (Overview ·
+  Findings · Diff · Report) + a sticky top bar carrying scan context
+  (project · commit · timestamp); overview→drilldown so every dashboard tile
+  links into a pre-filtered findings view (Snyk / GitHub Security / Wiz
+  pattern).
+- **Command palette** (Cmd/Ctrl-K, vanilla JS) — browser parity with the
+  TUI's `Ctrl+P`; jump to any view / filter.
+- **Motion primitives**, each gated behind
+  `@media (prefers-reduced-motion: no-preference)`:
+  - **View Transitions API** (`@view-transition { navigation: auto; }`) —
+    cross-document page transitions that make a server-rendered MPA feel
+    SPA-smooth with zero JS framework. The headline; almost no security tool
+    does this.
+  - Animated **count-up** for exec numbers (tiny JS), **staggered reveal**
+    of finding rows/cards (CSS `animation-delay` by index), **skeleton
+    shimmer** loading states (CSS), premium easing on hover/focus/select
+    (`cubic-bezier(0.4, 0, 0.2, 1)`, 150–250ms).
+- **Crafted empty states** (not blank pages) + a theme toggle that animates.
+
+**Effort/Risk** — moderate; pure front-end, no new dependency, fully
+reduced-motion-accessible. The reusable bits (tokens, transition rules,
+count-up/stagger helpers) make every later phase faster.
+
 ## Phase B1 — Real charts on the dashboard
 
 The dashboard has no visualisations today. The browser is where charts
-belong (the terminal only got Unicode bars out of necessity).
+belong (the terminal only got Unicode bars out of necessity). Charts also
+get **draw-on animation** (animating SVG `stroke-dashoffset` for the donut
+ring + trend line) on the B0 motion foundation — reduced-motion-gated.
 
 **Build** — inline **SVG** charts (hand-rolled, **no** `d3`/`plotly`/chart
 library — matches the viewer's vanilla `argus.css` + JS): a severity donut,
@@ -119,10 +159,11 @@ tablet / projector for the non-technical / exec audience the browser serves.
 
 ## Build order
 
-Merge-train into `feat/tui-explorer-and-scan-runner`, value-first:
-**B1 → B2 → B3 → B4 → B5**. B1's SVG charts are reused by B4's report, so
-they come first; B4 (the formal report) is the centrepiece everything builds
-toward; B5 polishes the surface once the content is there.
+Merge-train into `feat/tui-explorer-and-scan-runner`, foundation-first:
+**B0 → B1 → B2 → B3 → B4 → B5**. B0 (design system + motion) lands first
+because the charts and report sit on it; B1's SVG charts are reused by B4's
+report; B4 (the formal report) is the centrepiece everything builds toward;
+B5 finishes the accessibility/responsive pass once the content is there.
 
 ## Decisions
 
@@ -134,3 +175,9 @@ toward; B5 polishes the surface once the content is there.
   zero-new-dep posture for everything except the isolated PDF extra.
 - **Enrichment in the browser is opt-in** (server-side egress of public CVE
   ids) — same posture as the terminal's `i` action.
+- **Motion stack = native web only** (decided, B0): CSS custom properties +
+  the View Transitions API + CSS animations + small vanilla JS. No
+  React / GSAP / framer-motion / Tailwind. Every animation is gated behind
+  `prefers-reduced-motion` so it degrades to a static, fully-accessible UI.
+  This keeps the "feels like a mature product" polish at zero new runtime
+  dependency — the same discipline the Console epic held.

--- a/docs/developer/BROWSER-ROADMAP.md
+++ b/docs/developer/BROWSER-ROADMAP.md
@@ -1,0 +1,136 @@
+# Argus Browser & Reporting Roadmap
+
+The browser viewer (`argus view --interface=browser`) is the right surface
+for an audience the terminal isn't built for: stakeholders who want to *see*
+the security posture, and auditors who need an authoritative artifact. This
+roadmap turns it from a read-only findings viewer into the **report-and-share
+surface** — culminating in a formal, government-grade PDF vulnerability
+report.
+
+It's the deliberate alternative to a web Console (see
+[`CONSOLE-ROADMAP.md`](CONSOLE-ROADMAP.md) Phase 11, *not pursued*): rather
+than serving the operate-from TUI over a browser — clunky, and a security
+surface — we invest in what the browser does that a terminal fundamentally
+can't.
+
+This is an epic, built the same way as the Console: each phase its own green
+PR with tests + docs, merged into the integration branch
+(`feat/tui-explorer-and-scan-runner`).
+
+---
+
+## Principles
+
+- **The read-only boundary holds.** The browser viewer stays read-only,
+  `127.0.0.1`, no repo mutation. Nothing here runs scans, writes config, or
+  applies fixes — that's the terminal's trusted-shell job.
+- **Reuse the shared UI-free cores.** Charts, risk, and reachability come
+  from `argus/core/` modules built for the Console epic
+  (`trends`, `enrichment`, `reachability`) — the browser is just another
+  front-end over the same logic. No console code is imported.
+- **Dependency-conscious, with one deliberate exception.** Everything is
+  zero-new-runtime-dep (inline SVG, vanilla JS — the viewer's existing
+  style) *except* the formal PDF, whose engine lives behind an opt-in
+  `[report]` extra (see Phase B4). A supply-chain tool minimises its own
+  surface; the one heavy dependency is isolated and justified.
+
+## North star
+
+A teammate runs `argus scan`, opens the browser viewer, and can: read the
+findings with real charts; sort by real-world risk (EPSS/KEV) and see which
+deps are actually imported; share a URL to an exact filtered slice; and
+generate **one PDF** — counts, trends, charts, breakdowns, full findings,
+and the cryptographic provenance of the scan — that they can hand to an
+auditor or a government body as the authoritative record of "this is what we
+scanned and what we found."
+
+---
+
+## Phase B1 — Real charts on the dashboard
+
+The dashboard has no visualisations today. The browser is where charts
+belong (the terminal only got Unicode bars out of necessity).
+
+**Build** — inline **SVG** charts (hand-rolled, **no** `d3`/`plotly`/chart
+library — matches the viewer's vanilla `argus.css` + JS): a severity donut,
+a findings-over-runs trend line, and by-scanner / by-package bars. The data
+comes from `argus.core.trends` (already unit-tested); a small UI-free
+`svg`-string helper (testable) emits the markup, the Jinja template embeds
+it. Degrades to the existing tables where data is absent.
+
+## Phase B2 — Risk & reachability columns
+
+**Build** — surface the Console epic's intelligence in the read-only viewer:
+an **EPSS / KEV risk** badge + sortable risk column (`argus.core.enrichment`)
+and an **"imported in source"** reachability indicator
+(`argus.core.reachability`). Enrichment is a *server-side* fetch (public CVE
+ids only, cached) — **opt-in** (a config/flag), honouring the same offline
+posture as the terminal. Read-only: these annotate, never mutate.
+
+## Phase B3 — URL-addressable views & dependency drilldown
+
+**Build** — lean into the browser's superpower, the URL: bookmarkable,
+shareable links for a filtered slice (`/findings?severity=high&scanner=osv`)
+and a deep-link/anchor to a specific finding, so "here are the 3 criticals to
+look at" is a pasteable link. Plus an interactive, collapsible
+**dependency-tree / SBOM drilldown** ("why is this package here?") — HTML
+does nesting + expand/collapse far better than a TUI.
+
+## Phase B4 — Formal PDF vulnerability report (the centrepiece)
+
+A comprehensive, **authoritative** PDF — the artifact you hand to an auditor
+or government body to make formal policy decisions about scanned software.
+
+**Build**
+- A new report **route + template** assembling: a **cover page** (project,
+  scan timestamp, argus version), an **executive summary** (counts +
+  severity breakdown + trend), **charts** (reusing B1's SVG), per-severity /
+  per-scanner / per-product **breakdowns**, the **full findings** tables
+  (with CVE/CWE/location/package/fix), and a **provenance appendix**.
+- **Provenance appendix — the authoritative facts**, pulled from what Argus
+  already records: **argus version** (`core/version.py`), **scanner
+  toolchain provenance** (`core/toolchain.py` — the `toolchain` block:
+  per-scanner image digests + signature-verification status, #243), the
+  **signed scan attestation** (`core/attest.py` — OpenVEX in-toto, subject =
+  image digests + repo commit, #244), and **commit SHA / repo root**
+  (`ScanSummary`). This is what makes the PDF *authoritative*, not just
+  pretty.
+- **Server-side one-click PDF** via **WeasyPrint** (HTML/CSS/SVG → PDF),
+  behind an opt-in **`[report]` extra** — its native stack (pango/cairo)
+  can't be a core dependency, so the feature errors with a clear
+  `pip install 'argus-security[report]'` hint when absent (the same
+  guarded-extra pattern the Console epic used). The report's HTML doubles as
+  an on-screen view; the PDF is the frozen, signed-provenance record.
+- **UI-free core** (`argus/core/report.py`, testable without WeasyPrint):
+  assembles the report *model* (sections, provenance facts, chart data) from
+  a `ScanSummary`; the HTML render + PDF conversion are the thin,
+  dependency-bearing edges.
+
+**Effort/Risk** — the largest phase; the provenance assembly + report model
+are pure/tested, the WeasyPrint edge is guarded and smoke-tested.
+
+## Phase B5 — Accessibility & responsive polish
+
+**Build** — screen-reader semantics (ARIA on charts/tables), keyboard
+navigation, and a responsive layout so the read-only report reads well on a
+tablet / projector for the non-technical / exec audience the browser serves.
+
+---
+
+## Build order
+
+Merge-train into `feat/tui-explorer-and-scan-runner`, value-first:
+**B1 → B2 → B3 → B4 → B5**. B1's SVG charts are reused by B4's report, so
+they come first; B4 (the formal report) is the centrepiece everything builds
+toward; B5 polishes the surface once the content is there.
+
+## Decisions
+
+- **PDF engine = WeasyPrint, behind a `[report]` extra** (decided). Chosen
+  for HTML/CSS/SVG fidelity so the report and the on-screen HTML share one
+  template. Native-lib install is documented; the feature is opt-in, never a
+  core dependency.
+- **Charts = inline SVG, no chart library** (decided) — keeps the
+  zero-new-dep posture for everything except the isolated PDF extra.
+- **Enrichment in the browser is opt-in** (server-side egress of public CVE
+  ids) — same posture as the terminal's `i` action.

--- a/docs/developer/CONSOLE-ROADMAP.md
+++ b/docs/developer/CONSOLE-ROADMAP.md
@@ -361,17 +361,29 @@ SDK-or-HTTP, OpenAI-compatible base URL) — no new AI layer.
 **Effort/Risk** — high; ships as a tested foundation (provider wiring +
 streaming panel + explain flow), with fix-suggestion polish iterative.
 
-## Phase 11 — Console on the web (`textual serve`)
+## Phase 11 — Console on the web (`textual serve`) — NOT PURSUED
 
-**Build** — one codebase, three surfaces: `argus console --web` runs the
-*same* Console in a browser via `textual-serve`, yielding a shareable URL
-for read-only triage. **Security-gated hard:** bind `127.0.0.1` by default,
-require an auth token, and reuse the browser viewer's read-only boundary —
-mutating actions (scan/fix/config/suppress) are disabled in web mode unless
-explicitly, separately authorized. This is an ADR (it widens the
-attack surface the browser-viewer ADR deliberately fenced off).
-**Effort/Risk** — moderate to wire, high to get the security story right;
-the gating is the feature.
+Considered and **dropped** after weighing it against the existing browser
+viewer. The idea was `argus console --web` serving the Console over
+`textual-serve`. The problem: it's squeezed from both sides.
+
+- A **read-only** web Console is essentially the browser viewer we already
+  ship (`argus view --interface=browser`: FastAPI, localhost, read-only) —
+  serving the *Console* over it adds a "same TUI in a browser" demo and
+  little real capability.
+- A **mutating** web Console (run scans / write config / apply fixes from a
+  browser) is clunky *and* crosses the boundary the browser-viewer ADR
+  deliberately fenced off — and the genuine multi-user / auth / RBAC /
+  orchestration value that would justify it belongs in a hosted **SaaS**
+  product, not a localhost `textual-serve` process.
+
+The real need this was reaching for — a shareable, stakeholder-facing view
+and an authoritative report — is served far better by investing in the
+**browser viewer** instead. That work is tracked in
+[`BROWSER-ROADMAP.md`](BROWSER-ROADMAP.md) (charts, risk/reachability
+columns, URL-addressable views, dependency drilldown, and a formal
+PDF vulnerability report). The speculative `web_serve.py` gating core built
+in anticipation was removed.
 
 ## Phase 12 — Reachability-aware prioritization (research + first cut)
 


### PR DESCRIPTION
## Description
Pivots the "shareable / stakeholder-facing" need away from a web Console (Console Phase 11 — **dropped**) toward investing in the **browser viewer** itself. Docs-only; targets the integration branch (`feat/tui-explorer-and-scan-runner`, PR #261). Follow-on feature PRs merge into the same branch.

**Why Phase 11 was dropped:** a read-only web Console just duplicates the existing browser viewer; a mutating one is clunky and crosses the boundary the browser-viewer ADR deliberately fenced off; and the genuine multi-user / auth / orchestration value belongs in a hosted **SaaS** product, not a localhost `textual-serve`.

## Changes Made
- [x] Updated documentation
- [x] Other: new roadmap (`BROWSER-ROADMAP.md`); Console Phase 11 marked *not pursued*; removed speculative `web_serve.py`

### Details — the browser & reporting epic
- **B1** — real **SVG charts** on the dashboard (inline, **no** chart-lib dep): severity donut, findings-over-runs trend, by-scanner/package bars (data from `core/trends.py`).
- **B2** — **EPSS/KEV risk** + **reachability** columns, reusing the UI-free cores (`core/enrichment.py`, `core/reachability.py`); read-only, enrichment opt-in (server-side, public CVE ids only).
- **B3** — **URL-addressable** bookmarkable/shareable filtered views + deep-link to a finding; collapsible **dependency-tree / SBOM** drilldown.
- **B4 (centrepiece)** — a formal, **authoritative PDF vulnerability report**: cover, exec counts, trends, charts, per-severity/scanner/product breakdowns, full findings, and a **provenance appendix** (argus version, scanner toolchain provenance #243, signed attestation #244, commit SHA) — the artifact you hand to an auditor / government body. Server-rendered via **WeasyPrint** behind an **opt-in `[report]` extra** (its native stack can't be a core dep; clear install hint otherwise).
- **B5** — accessibility + responsive polish.

Everything is **zero-new-runtime-dep** except the isolated, opt-in PDF engine — keeping a supply-chain tool's own surface minimal.

## Testing
- [ ] Unit tests (none — docs only; per-phase PRs add tests)
- [x] Manual: markdown reviewed; cross-links to `CONSOLE-ROADMAP.md` valid.

## Security Considerations
- [x] Security enhancement (forward-looking): keeps the browser viewer read-only / `127.0.0.1`; the only new dependency (PDF engine) is opt-in and isolated; the formal report surfaces cryptographic provenance rather than adding attack surface.

## AI Context Updates (.ai/)
- [x] N/A — planning doc; per-phase PRs update `.ai/` as modules land.

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated
- [ ] Changelog updated (handled by release-it)
- [x] All tests pass (docs-only)
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Successor track to the Console epic — `docs/developer/BROWSER-ROADMAP.md`; retires `CONSOLE-ROADMAP.md` Phase 11.
