### PR TITLE
fix(console): Configure screen — column overlap, enum picker, focus loss

### DIFF
--- a/argus/tests/viewers/terminal/test_config_editor.py
+++ b/argus/tests/viewers/terminal/test_config_editor.py
@@ -10,6 +10,7 @@ from argus.viewers.terminal.config_editor import (
     EditRow,
     apply_row,
     editable_rows,
+    row_display,
     set_value,
     validate,
 )
@@ -64,6 +65,38 @@ class TestEditableRows:
 
     def test_non_mapping_returns_empty(self):
         assert editable_rows("- a\n- b\n") == []
+
+
+class TestRowDisplay:
+    def test_long_label_does_not_run_into_value(self):
+        # Regression: `reporting · severity_threshold` (30 chars) overflowed
+        # the old fixed :<26 label column and rendered as
+        # "severity_thresholdhigh". The value column must be padded clear.
+        displays = dict(row_display(editable_rows(SAMPLE)))
+        txt = displays["reporting.severity_threshold"]
+        assert "severity_thresholdhigh" not in txt
+        after_label = txt.split("reporting · severity_threshold", 1)[1]
+        assert after_label.startswith("  ")  # >= 2-space gap before the value
+
+    def test_value_column_is_aligned_across_rows(self):
+        rows = editable_rows(SAMPLE)
+        displays = dict(row_display(rows))
+        label_w = max(len(r.label) for r in rows) + 2
+        # Every row's value begins at the same column (labels left-padded to
+        # label_w); the two chars before it are the gap.
+        for r in rows:
+            txt = displays[r.key]
+            assert txt[label_w - 2:label_w] == "  "
+            assert txt[label_w] != " "
+
+    def test_enum_rows_get_dropdown_affordance(self):
+        displays = dict(row_display(editable_rows(SAMPLE)))
+        # Enum (pick-from-list) rows carry a ▾; toggles do not.
+        assert "high ▾" in displays["reporting.severity_threshold"]
+        assert "▾" not in displays["scanner:bandit"]
+
+    def test_empty_rows(self):
+        assert row_display([]) == []
 
 
 class TestSetValue:

--- a/argus/tests/viewers/terminal/test_console.py
+++ b/argus/tests/viewers/terminal/test_console.py
@@ -171,6 +171,22 @@ class TestConfigScreen:
         assert screen._original == ""
 
 
+class TestChoiceScreen:
+    def test_construction_stores_options(self, console):
+        # The enum dropdown picker — built when Enter is pressed on a
+        # bounded-choice setting so the user selects directly instead of
+        # cycling. Construction stores the title, options, and current value.
+        module, _app, _calls = console
+        screen = module._ChoiceScreen(
+            "reporting · severity_threshold",
+            ["none", "low", "medium", "high", "critical"],
+            "high",
+        )
+        assert screen._title == "reporting · severity_threshold"
+        assert screen._options[-1] == "critical"
+        assert screen._current == "high"
+
+
 class TestCommandPalette:
     def test_provider_registered_on_app(self, console):
         module, _app, _calls = console

--- a/argus/viewers/terminal/config_editor.py
+++ b/argus/viewers/terminal/config_editor.py
@@ -107,6 +107,32 @@ def editable_rows(text: str) -> list[EditRow]:
     return rows
 
 
+def row_display(rows: list[EditRow]) -> list[tuple[str, str]]:
+    """Return ``(id, display-markup)`` per row with aligned columns.
+
+    Sizes the label and value columns to the *widest* entry rather than a
+    fixed width, so a long key (e.g. ``reporting · severity_threshold``, 30
+    chars) can never run into its value. Enum rows carry a ``▾`` affordance
+    marking them as pick-from-a-list (Enter opens a chooser) versus toggles
+    that flip in place. The doc is dimmed and trails the value column.
+
+    UI-free so the alignment is unit-tested without the ``[terminal]`` extra;
+    ``ConfigScreen`` just wraps each tuple in a Textual ``Option``.
+    """
+    if not rows:
+        return []
+
+    def shown_value(row: EditRow) -> str:
+        return f"{row.value} ▾" if row.kind == "enum" else row.value
+
+    label_w = max(len(r.label) for r in rows) + 2
+    value_w = max(len(shown_value(r)) for r in rows) + 2
+    return [
+        (r.key, f"{r.label:<{label_w}}{shown_value(r):<{value_w}}[dim]{r.doc}[/dim]")
+        for r in rows
+    ]
+
+
 def set_value(text: str, path: list[str], value: str) -> str | None:
     """Set the YAML scalar at ``path`` to ``value``, preserving formatting.
 

--- a/argus/viewers/terminal/console.py
+++ b/argus/viewers/terminal/console.py
@@ -189,9 +189,13 @@ class SettingsScreen(Screen):
         self.query_one("#settings-list", OptionList).focus()
 
     def _restore_cursor(self) -> None:  # pragma: no cover — UI
+        # Re-focus the rebuilt list after a recompose so the keyboard keeps
+        # working without a mouse click (the list is composed fresh on every
+        # change).
         option_list = self.query_one("#settings-list", OptionList)
         if option_list.option_count:
             option_list.highlighted = min(self._highlight, option_list.option_count - 1)
+        option_list.focus()
 
     def on_option_list_option_selected(  # pragma: no cover — UI
         self, event: OptionList.OptionSelected,
@@ -209,6 +213,68 @@ class SettingsScreen(Screen):
     def action_close(self) -> None:  # pragma: no cover — UI
         self.app.persist_settings()
         self.dismiss()
+
+
+class _ChoiceScreen(ModalScreen[str | None]):
+    """A dropdown-style picker for a bounded-choice (enum) config value.
+
+    Lists the allowed options and dismisses with the chosen value (or
+    ``None`` on cancel), so ``ConfigScreen`` can set an enum setting in one
+    step instead of cycling through it with repeated Enter presses. A plain
+    modal that never changes the theme or mutates its list while mounted —
+    safe under the Textual 8.x modal constraints the Console works around.
+    """
+
+    CSS = """
+    _ChoiceScreen { align: center middle; }
+    #choice-body {
+        background: $surface; border: thick $accent;
+        width: auto; min-width: 32; max-width: 64; height: auto; padding: 1 2;
+    }
+    #choice-title { text-style: bold; padding: 0 0 1 0; }
+    #choice-list { height: auto; max-height: 14; border: none; background: transparent; }
+    #choice-hint { color: $text-muted; padding: 1 0 0 0; }
+    """
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel", show=True),
+        Binding("q", "cancel", show=False),
+    ]
+
+    def __init__(self, title: str, options: list[str], current: str) -> None:
+        super().__init__()
+        self._title = title
+        self._options = options
+        self._current = current
+
+    def compose(self) -> ComposeResult:  # pragma: no cover — UI
+        with Vertical(id="choice-body"):
+            yield Static(f"Choose · {self._title}", id="choice-title")
+            yield OptionList(
+                *(
+                    Option(
+                        f"{'● ' if opt == self._current else '  '}{opt}", id=opt,
+                    )
+                    for opt in self._options
+                ),
+                id="choice-list",
+            )
+            yield Static(
+                "↑↓ move   ·   enter select   ·   esc cancel", id="choice-hint",
+            )
+
+    def on_mount(self) -> None:  # pragma: no cover — UI
+        option_list = self.query_one("#choice-list", OptionList)
+        if self._current in self._options:
+            option_list.highlighted = self._options.index(self._current)
+        option_list.focus()
+
+    def on_option_list_option_selected(  # pragma: no cover — UI
+        self, event: OptionList.OptionSelected,
+    ) -> None:
+        self.dismiss(event.option.id)
+
+    def action_cancel(self) -> None:  # pragma: no cover — UI
+        self.dismiss(None)
 
 
 class ConfigScreen(Screen):
@@ -253,8 +319,8 @@ class ConfigScreen(Screen):
         with Vertical(id="config-body"):
             yield Static(f"⚙  Configure · {self._path.name}{dirty}", id="config-title")
             opts = [
-                Option(f"{r.label:<26}{r.value:<14}[dim]{r.doc}[/dim]", id=r.key)
-                for r in rows
+                Option(text, id=key)
+                for key, text in config_editor.row_display(rows)
             ]
             yield OptionList(*opts, id="config-list")
             yield Static(
@@ -264,12 +330,15 @@ class ConfigScreen(Screen):
 
     def on_mount(self) -> None:  # pragma: no cover — UI
         self._restore_cursor()
-        self.query_one("#config-list", OptionList).focus()
 
     def _restore_cursor(self) -> None:  # pragma: no cover — UI
+        # Re-focus after a recompose: the OptionList is rebuilt on every
+        # change, so without re-focusing the new widget the arrow keys and
+        # Enter silently stop working until the user clicks back in.
         option_list = self.query_one("#config-list", OptionList)
         if option_list.option_count:
             option_list.highlighted = min(self._highlight, option_list.option_count - 1)
+        option_list.focus()
 
     def on_option_list_option_selected(  # pragma: no cover — UI
         self, event: OptionList.OptionSelected,
@@ -280,11 +349,30 @@ class ConfigScreen(Screen):
         if row is None:
             return
         self._highlight = event.option_index
+        # Enum settings (bounded choices) open a chooser so the user picks
+        # directly instead of pressing Enter to cycle through every option.
+        # Toggles (on/off) just flip in place.
+        if row.kind == "enum" and row.options:
+            self._pick_enum(row)
+            return
         result = config_editor.apply_row(self._text, row)
         if result is not None:
             self._text, _ = result
         self.refresh(recompose=True)
         self.call_after_refresh(self._restore_cursor)
+
+    def _pick_enum(self, row: "config_editor.EditRow") -> None:  # pragma: no cover — UI
+        def _chosen(value: str | None) -> None:
+            if value is not None and value != row.value:
+                new_text = config_editor.set_value(self._text, row.path, value)
+                if new_text is not None:
+                    self._text = new_text
+            self.refresh(recompose=True)
+            self.call_after_refresh(self._restore_cursor)
+
+        self.app.push_screen(
+            _ChoiceScreen(row.label, list(row.options), row.value), _chosen,
+        )
 
     def action_save(self) -> None:  # pragma: no cover — UI
         if self._text == self._original:
@@ -382,9 +470,12 @@ class InitScreen(Screen):
         self.query_one("#init-list", OptionList).focus()
 
     def _restore_cursor(self) -> None:  # pragma: no cover — UI
+        # Re-focus the rebuilt list after a recompose so the keyboard keeps
+        # working without a mouse click.
         option_list = self.query_one("#init-list", OptionList)
         if option_list.option_count:
             option_list.highlighted = min(self._highlight, option_list.option_count - 1)
+        option_list.focus()
 
     def on_option_list_option_selected(  # pragma: no cover — UI
         self, event: OptionList.OptionSelected,


### PR DESCRIPTION
## Description
Fixes three issues found while test-driving the **Console's Configure screen** (`argus` → Configure):

1. **Column overlap** — a long key (`reporting · severity_threshold`, 30 chars) overflowed the fixed `:<26` label column and rendered as `severity_thresholdcritical`, with the value jammed against the key.
2. **Cycle-by-Enter for bounded choices** — enum settings (severity threshold, execution backend, pull policy, …) advanced one value per Enter press; you had to hit Enter repeatedly to reach the option you wanted.
3. **Keyboard focus lost after a change** — after changing a value, arrow keys and Enter silently stopped working and you had to reach for the mouse.

## Changes Made
- [x] Fixed bug
- [x] Modified existing scanner/workflow (Console TUI)
- [ ] Other

### Details
- **Column overlap** → new UI-free `config_editor.row_display(rows)` sizes the label and value columns to the *widest* entry instead of a fixed width, so nothing collides regardless of key length. `ConfigScreen.compose` renders its tuples.

  ```
  scanner · gitleaks              on                Run this scanner on each scan.
  reporting · severity_threshold  critical ▾        Fail the scan at or above this severity.
  execution · pull_policy         if-not-present ▾  When to pull scanner container images.
  ```

- **Dropdown picker** → enum rows now open a `_ChoiceScreen` modal listing the allowed values (the current one marked `●`); pick one and it's applied via `config_editor.set_value` — no more cycling. Enum rows carry a `▾` affordance; on/off **toggles still flip in place** on Enter (a 2-value dropdown would be overkill).

- **Focus loss** → the OptionList is rebuilt via `recompose` on every change, but `_restore_cursor` only re-set the highlight — it never re-`.focus()`ed the new widget, so the keyboard died until a mouse click. Now it re-focuses. The **Settings and Init screens shared the exact same latent bug** and are fixed too.

No scanner/schema changes. The comment-preserving editor itself was already correct.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed (rendered `row_display` against the reported config — columns align, no overlap)

### Test Results
New `TestRowDisplay` (4 tests): the long-label no-overlap regression, value-column alignment across rows, the `▾` enum affordance, and the empty case. Full suite **4218 passed** (the 3 failures are the known pre-existing local-only fastapi/starlette skew, green in CI); 302 terminal-viewer tests green.

> The interactive bits (the modal picker, focus retention) are UI glue that can't run in the headless test env (no TTY) — they follow the screen's existing modal/recompose patterns and the underlying logic (`row_display`, `set_value`) is unit-tested. Worth a quick `argus` → Configure spin to confirm the picker + focus feel right.

## Security Considerations
- [x] No security impact — terminal-only Configure surface; edits still go through the comment-preserving, schema-validated `config_editor` and aren't written until `s` save.

## AI Context Updates (.ai/)
- [ ] N/A — bug fix to existing Console behavior; no new components or structure.

## Checklist
- [x] Code follows project style guidelines
- [x] All tests pass (3 failures are pre-existing + local-env)
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Console Configure screen (Phase 2, #264). Merges into `feat/tui-explorer-and-scan-runner`.
