### PR TITLE
fix(viewers): resolve latest run for View findings + open report in new tab

### DIFF
--- a/argus/tests/viewers/terminal/test_loader.py
+++ b/argus/tests/viewers/terminal/test_loader.py
@@ -76,6 +76,58 @@ class TestLocateResults:
             locate_results(tmp_path / "nope")
 
 
+class TestRunLayoutResolution:
+    """``argus scan`` writes ``argus-results/<timestamp>/`` + a ``latest``
+    symlink. locate_results must find the run from the *parent* dir.
+
+    Regression: bare ``argus`` → "View findings" flickered straight back to
+    the home screen because the loader only checked the non-existent
+    ``argus-results/argus-results.json`` and raised, so the findings app
+    exited on mount.
+    """
+
+    def test_resolves_latest_symlink(self, tmp_path):
+        base = tmp_path / "argus-results"
+        run = base / "2026-06-13T23-33-33Z"
+        run.mkdir(parents=True)
+        (run / RESULTS_FILENAME).write_text(json.dumps(_sample_payload()))
+        (base / "latest").symlink_to(run)
+        resolved = locate_results(base)
+        assert resolved.resolve() == (run / RESULTS_FILENAME).resolve()
+
+    def test_none_resolves_latest_under_cwd(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        run = tmp_path / "argus-results" / "2026-06-13T23-33-33Z"
+        run.mkdir(parents=True)
+        (run / RESULTS_FILENAME).write_text(json.dumps(_sample_payload()))
+        (tmp_path / "argus-results" / "latest").symlink_to(run)
+        from pathlib import Path
+        assert Path(locate_results(None)).resolve() == (run / RESULTS_FILENAME).resolve()
+
+    def test_resolves_newest_run_without_symlink(self, tmp_path):
+        import os
+        base = tmp_path / "results"
+        old = base / "2026-01-01T00-00-00Z"
+        new = base / "2026-06-01T00-00-00Z"
+        old.mkdir(parents=True)
+        new.mkdir(parents=True)
+        (old / RESULTS_FILENAME).write_text(json.dumps(_sample_payload(("low",))))
+        (new / RESULTS_FILENAME).write_text(json.dumps(_sample_payload(("critical", "high"))))
+        os.utime(old / RESULTS_FILENAME, (1_000_000, 1_000_000))
+        os.utime(new / RESULTS_FILENAME, (2_000_000, 2_000_000))
+        assert locate_results(base) == new / RESULTS_FILENAME
+
+    def test_direct_drop_still_wins_over_latest(self, tmp_path):
+        base = tmp_path / "argus-results"
+        base.mkdir()
+        (base / RESULTS_FILENAME).write_text("{}")
+        run = base / "2026-01-01T00-00-00Z"
+        run.mkdir()
+        (run / RESULTS_FILENAME).write_text(json.dumps(_sample_payload()))
+        (base / "latest").symlink_to(run)
+        assert locate_results(base) == base / RESULTS_FILENAME
+
+
 class TestLoadSummary:
     def test_loads_valid_summary(self, tmp_path):
         f = tmp_path / RESULTS_FILENAME

--- a/argus/viewers/browser/templates/base.html.j2
+++ b/argus/viewers/browser/templates/base.html.j2
@@ -35,8 +35,11 @@
          {% if _active_nav == "/findings" %}aria-current="page"{% endif %}>Findings</a>
       <a href="/log{% if scan_param %}?scan={{ scan_param | urlencode }}{% endif %}"
          {% if _active_nav == "/log" %}aria-current="page"{% endif %}>Log</a>
+      {#- The report is a standalone print document (no app chrome), so open
+          it in a new tab: the user keeps their triage view instead of having
+          to hit Back to return. ``↗`` hints the new-tab behaviour. -#}
       <a href="/report{% if scan_param %}?scan={{ scan_param | urlencode }}{% endif %}"
-         {% if _active_nav == "/report" %}aria-current="page"{% endif %}>Report</a>
+         target="_blank" rel="noopener">Report&#8239;<span aria-hidden="true">↗</span></a>
 
       {#- Recent runs dropdown — only rendered when there are at
           least two scan-ready dirs under the launch root. Single-scan

--- a/argus/viewers/terminal/loader.py
+++ b/argus/viewers/terminal/loader.py
@@ -13,7 +13,7 @@ import json
 from pathlib import Path
 
 from argus.core.models import ScanSummary
-from argus.core.run_discovery import RESULTS_FILENAME
+from argus.core.run_discovery import RESULTS_FILENAME, discover_runs
 
 # Re-exported from argus.core.run_discovery (its canonical home) so existing
 # ``from argus.viewers.terminal.loader import RESULTS_FILENAME`` call sites
@@ -24,25 +24,58 @@ __all__ = ["RESULTS_FILENAME", "flatten_findings", "load_summary", "locate_resul
 def locate_results(path: str | Path | None) -> Path:
     """Resolve ``path`` to an ``argus-results.json`` file.
 
-    - ``None`` → ``./argus-results/argus-results.json``
-    - a directory → ``{dir}/argus-results.json``
-    - a file      → use as-is (must exist and parse as JSON)
+    Mirrors ``argus scan``'s actual output layout — and the browser viewer's
+    resolution — so the terminal viewer opens a scan from a *directory* the
+    same way, in order:
+
+    - a file → use as-is.
+    - ``{dir}/argus-results.json`` (a direct drop) → use it.
+    - ``{dir}/latest/argus-results.json`` → use it. ``argus scan`` writes to a
+      timestamped subdir (``argus-results/2026-…Z/``) and maintains a
+      ``latest`` symlink; this is the common shape, and the reason a bare
+      ``argus`` → "View findings" used to flicker straight back to the home
+      screen (the old code only looked for the non-existent
+      ``argus-results/argus-results.json``).
+    - the newest timestamped run under ``{dir}`` (via ``discover_runs``) →
+      use it, for layouts without a ``latest`` symlink.
+
+    ``None`` resolves against the conventional ``./argus-results`` home.
     """
-    if path is None:
-        candidate = Path("argus-results") / RESULTS_FILENAME
-    else:
+    if path is not None:
         p = Path(path)
-        candidate = p / RESULTS_FILENAME if p.is_dir() else p
-    if not candidate.is_file():
-        # Defer to the shared diagnoser so the message identifies the
-        # likely root cause (most often: ``reporting.formats`` in
-        # argus.yml omits ``json``) rather than just reporting the
-        # missing file. Both viewers raise this exception and surface
-        # the message verbatim, so users get the same actionable
-        # remediation regardless of which interface they invoked.
-        from argus.viewers.diagnose import diagnose_missing_results
-        raise FileNotFoundError(diagnose_missing_results(candidate))
-    return candidate
+        if p.is_file():
+            return p
+        if not p.is_dir():
+            # A specific path the user named that's neither file nor dir —
+            # diagnose against it directly rather than appending a filename.
+            from argus.viewers.diagnose import diagnose_missing_results
+            raise FileNotFoundError(diagnose_missing_results(p))
+        base = p
+    else:
+        base = Path("argus-results")
+
+    direct = base / RESULTS_FILENAME
+    if direct.is_file():
+        return direct
+
+    latest = base / "latest" / RESULTS_FILENAME
+    if latest.is_file():
+        return latest.resolve()
+
+    if base.is_dir():
+        runs = discover_runs(base.resolve())
+        if runs:
+            newest = Path(runs[0]["path"]) / RESULTS_FILENAME
+            if newest.is_file():
+                return newest
+
+    # Defer to the shared diagnoser so the message identifies the likely
+    # root cause (most often: ``reporting.formats`` in argus.yml omits
+    # ``json``) rather than just reporting the missing file. Both viewers
+    # raise this and surface it verbatim, so the remediation is identical
+    # regardless of which interface was invoked.
+    from argus.viewers.diagnose import diagnose_missing_results
+    raise FileNotFoundError(diagnose_missing_results(direct))
 
 
 def load_summary(path: str | Path | None) -> tuple[ScanSummary, Path]:


### PR DESCRIPTION
## Description
Two more issues from test-driving the viewers:

1. **"View findings" flickered back to the Console home.** Bare `argus` → View findings opened the findings app, which exited on mount because it couldn't find a scan. The terminal loader's `locate_results` only looked for `argus-results/argus-results.json`, but `argus scan` writes to a *timestamped* subdir (`argus-results/<ts>/`) and maintains a `latest` symlink — so the file was never found, `load_summary` raised `FileNotFoundError`, and `BrowseApp.on_mount` called `self.exit(...)` → flicker → home.

2. **The browser Report opened in place**, forcing a Back press to get back to the triage view.

## Changes Made
- [x] Fixed bug

### Details
- **`loader.locate_results`** now resolves a directory the same way the browser viewer's `_resolve_scan` does: a file path is used as-is; for a directory, a direct `argus-results.json` wins, else `latest/argus-results.json`, else the newest discovered run (via `discover_runs`). `None` resolves against the conventional `./argus-results` home. This brings the terminal viewer to parity with the browser and fixes `argus view` (no path) and `argus view argus-results/` too.

  Verified against the real repo layout: `locate_results(None)` now returns `argus-results/2026-06-13T23-33-33Z/argus-results.json` (the `latest` target) instead of raising.

- **Browser Report nav link** → `target="_blank" rel="noopener"` with a `↗` hint. The report is a standalone print document (no app chrome), so it belongs in its own tab — close it to return, no Back button.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed (real-layout resolution check)

### Test Results
New `TestRunLayoutResolution` (4 tests): latest-symlink, `None`-under-cwd, newest-run-without-symlink, and direct-drop-wins. The existing `locate_results` behaviors (file as-is, direct dir, missing → diagnoser hint) still pass. The 3 unrelated browser-template failures are the known pre-existing local-only fastapi/starlette skew (green in CI).

## Security Considerations
- [x] No security impact — read-only resolution; `rel="noopener"` on the new-tab link.

## AI Context Updates (.ai/)
- [ ] N/A — bug fix; no new components.

## Checklist
- [x] Code follows project style guidelines
- [x] All tests pass (3 failures pre-existing + local-env)
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Console "View findings" + browser report UX, from test-driving. Merges into `feat/tui-explorer-and-scan-runner`.

> Follow-ups the user asked for, **not** in this PR (tracked for a next change): a TUI **directory picker** shown when no results are found + available on-demand to traverse to another project's results; and a home-screen **system-status** indicator (Docker / local tools / image-digest match).
