### PR TITLE
feat(view): directory picker — open a scan from anywhere (O) + no-scan fallback

### DIFF
--- a/.ai/architecture.yaml
+++ b/.ai/architecture.yaml
@@ -148,6 +148,9 @@ components:
       viewers/terminal/: '`argus view --interface=terminal` — Textual TUI ([terminal] extra). Includes
         DiffPickerScreen + DiffScreen for scan-over-scan diff (``D`` keybind), reusing argus.core.findings_view.diff_scans.
         A runs sidebar (``b``) lists discovered runs via argus.core.run_discovery and switches between them in place;
+        ``O`` opens a filesystem ResultsPickerScreen (results_picker.py formats rows over run_discovery.list_directory)
+        to load a scan from another directory — also shown automatically when no scan resolves in the launch dir
+        (so bare ``argus`` → View findings navigates to a scan instead of exiting), via a shared BrowseApp._try_load;
         ``R`` runs argus scan in-app (runs_sidebar.py formats rows, scan_runner.py builds the argv,
         RunScanPromptScreen + RunScanScreen stream it) and reloads results when it finishes. Right-click context
         menus anchor at the cursor via mouse_actions.clamp_menu_offset. console.py + console_model.py provide the
@@ -810,6 +813,9 @@ docsite:
       viewers/terminal/: '`argus view --interface=terminal` — Textual TUI ([terminal] extra). Includes
         DiffPickerScreen + DiffScreen for scan-over-scan diff (``D`` keybind), reusing argus.core.findings_view.diff_scans.
         A runs sidebar (``b``) lists discovered runs via argus.core.run_discovery and switches between them in place;
+        ``O`` opens a filesystem ResultsPickerScreen (results_picker.py formats rows over run_discovery.list_directory)
+        to load a scan from another directory — also shown automatically when no scan resolves in the launch dir
+        (so bare ``argus`` → View findings navigates to a scan instead of exiting), via a shared BrowseApp._try_load;
         ``R`` runs argus scan in-app (runs_sidebar.py formats rows, scan_runner.py builds the argv,
         RunScanPromptScreen + RunScanScreen stream it) and reloads results when it finishes. Right-click context
         menus anchor at the cursor via mouse_actions.clamp_menu_offset. console.py + console_model.py provide the

--- a/argus/tests/viewers/terminal/test_results_picker.py
+++ b/argus/tests/viewers/terminal/test_results_picker.py
@@ -1,0 +1,97 @@
+"""Unit tests for argus.viewers.terminal.results_picker (UI-free row formatting).
+
+No Textual: the picker screen lives in app.py; this pins the pure
+row-building + id-encoding the screen renders and decodes.
+"""
+
+from __future__ import annotations
+
+from argus.viewers.terminal.results_picker import UP_ID, decode_id, picker_rows
+
+
+def _entry(name, path, *, is_dir=False, is_results_file=False,
+           has_results=False, finding_count=None):
+    return {
+        "name": name, "path": path, "is_dir": is_dir,
+        "is_results_file": is_results_file, "has_results": has_results,
+        "finding_count": finding_count,
+    }
+
+
+class TestPickerRows:
+    def test_parent_row_added_when_included(self):
+        rows = picker_rows([], include_parent=True)
+        assert rows[0][0] == UP_ID
+
+    def test_no_parent_row_at_root(self):
+        rows = picker_rows([], include_parent=False)
+        assert all(opt_id != UP_ID for opt_id, _ in rows)
+
+    def test_results_file_is_a_load_row(self):
+        rows = picker_rows(
+            [_entry("argus-results.json", "/p/argus-results.json", is_results_file=True)],
+            include_parent=False,
+        )
+        assert rows[0][0] == "load::/p/argus-results.json"
+
+    def test_scan_dir_is_load_row_with_count(self):
+        rows = picker_rows(
+            [_entry("run-1", "/p/run-1", is_dir=True, has_results=True, finding_count=7)],
+            include_parent=False,
+        )
+        opt_id, display = rows[0]
+        assert opt_id == "load::/p/run-1"
+        assert "7 findings" in display
+
+    def test_scan_dir_without_count_says_scan(self):
+        rows = picker_rows(
+            [_entry("run", "/p/run", is_dir=True, has_results=True, finding_count=None)],
+            include_parent=False,
+        )
+        assert "scan" in rows[0][1]
+
+    def test_plain_dir_is_navigable(self):
+        rows = picker_rows(
+            [_entry("src", "/p/src", is_dir=True)], include_parent=False,
+        )
+        assert rows[0][0] == "dir::/p/src"
+
+    def test_other_files_are_skipped(self):
+        rows = picker_rows(
+            [_entry("README.md", "/p/README.md")], include_parent=False,
+        )
+        assert rows == []
+
+    def test_order_preserved_with_parent_first(self):
+        entries = [
+            _entry("src", "/p/src", is_dir=True),
+            _entry("argus-results.json", "/p/argus-results.json", is_results_file=True),
+        ]
+        rows = picker_rows(entries, include_parent=True)
+        assert [r[0] for r in rows] == [
+            UP_ID, "dir::/p/src", "load::/p/argus-results.json",
+        ]
+
+
+class TestDecodeId:
+    def test_up(self):
+        assert decode_id(UP_ID) == ("up", None)
+
+    def test_dir(self):
+        assert decode_id("dir::/x/y") == ("dir", "/x/y")
+
+    def test_load(self):
+        assert decode_id("load::/x/y") == ("load", "/x/y")
+
+    def test_none_for_empty(self):
+        assert decode_id(None) == ("none", None)
+        assert decode_id("") == ("none", None)
+
+    def test_none_for_unrecognised(self):
+        assert decode_id("__noop__") == ("none", None)
+
+    def test_path_with_embedded_separator(self):
+        # A path containing "::" still decodes (split on the first only).
+        assert decode_id("load::/a::b/argus-results.json") == (
+            "load", "/a::b/argus-results.json",
+        )

--- a/argus/tests/viewers/terminal/test_runs_navigation.py
+++ b/argus/tests/viewers/terminal/test_runs_navigation.py
@@ -201,6 +201,112 @@ class TestSwitchRun:
         )
 
 
+class TestSwitchRunUpdateRoot:
+    def test_update_root_reroots_to_opened_scan(self, app):
+        _module, a, _widgets, _notify, tmp_path = app
+        # A scan in a *different* tree than the launch root.
+        run = tmp_path / "other-project" / "argus-results" / "run-1"
+        _write_run(run, severities=[Severity.HIGH])
+        a._switch_run(str(run), update_root=True)
+        # Launch root follows the opened scan so the sidebar shows its siblings.
+        assert a._launch_root == run.resolve()
+
+    def test_default_keeps_launch_root(self, app):
+        _module, a, _widgets, _notify, tmp_path = app
+        original_root = a._launch_root
+        run = tmp_path / "run-1"
+        _write_run(run, severities=[Severity.LOW])
+        a._switch_run(str(run))  # update_root defaults False
+        assert a._launch_root == original_root
+
+
+class TestTryLoad:
+    def test_returns_true_and_populates(self, app):
+        _module, a, _widgets, _notify, tmp_path = app
+        run = tmp_path / "run-1"
+        _write_run(run, severities=[Severity.HIGH, Severity.LOW])
+        assert a._try_load(str(run)) is True
+        assert len(a.all_findings) == 2
+        assert a._current_results_path is not None
+
+    def test_returns_false_on_missing(self, app):
+        _module, a, _widgets, _notify, tmp_path = app
+        assert a._try_load(str(tmp_path / "nope")) is False
+
+
+class TestOpenResults:
+    def test_action_open_results_pushes_picker(self, app):
+        module, a, _widgets, _notify, _tmp = app
+        pushed: list = []
+        a.push_screen = lambda screen, cb=None: pushed.append((screen, cb))  # type: ignore[method-assign]
+        a.action_open_results()
+        assert pushed
+        assert isinstance(pushed[0][0], module.ResultsPickerScreen)
+
+
+def _stub_picker(module, start):
+    """A ResultsPickerScreen with its Textual-provided methods stubbed."""
+    screen = module.ResultsPickerScreen(start)
+    screen._events = {"dismissed": [], "refreshed": 0}
+    screen.query_one = lambda *a, **k: types.SimpleNamespace(focus=lambda: None)  # type: ignore[method-assign]
+    screen.refresh = lambda *a, **k: screen._events.__setitem__("refreshed", screen._events["refreshed"] + 1)  # type: ignore[method-assign]
+    screen.call_after_refresh = lambda *a, **k: None  # type: ignore[method-assign]
+    screen.dismiss = lambda v=None: screen._events["dismissed"].append(v)  # type: ignore[method-assign]
+    return screen
+
+
+class TestResultsPickerScreen:
+    def test_build_options_lists_dirs_and_scans_only(self, tmp_path):
+        module = _load_app_module()
+        _write_run(tmp_path / "run-1", severities=[Severity.HIGH])
+        (tmp_path / "src").mkdir()
+        (tmp_path / "README.md").write_text("x")  # non-scan file → skipped
+        screen = module.ResultsPickerScreen(tmp_path)
+        opts = screen._build_options()
+        # run-1 (load) + src (dir) = 2; README.md dropped. No parent row at the
+        # picker's own start (tmp_path has a parent, so +1 for "..").
+        assert len(opts) == 3
+
+    def test_load_selection_dismisses_with_path(self, tmp_path):
+        module = _load_app_module()
+        screen = _stub_picker(module, tmp_path)
+        event = types.SimpleNamespace(option=types.SimpleNamespace(id="load::/p/run"))
+        screen.on_option_list_option_selected(event)
+        assert screen._events["dismissed"] == ["/p/run"]
+
+    def test_dir_selection_navigates(self, tmp_path):
+        module = _load_app_module()
+        sub = tmp_path / "child"
+        sub.mkdir()
+        screen = _stub_picker(module, tmp_path)
+        event = types.SimpleNamespace(option=types.SimpleNamespace(id=f"dir::{sub}"))
+        screen.on_option_list_option_selected(event)
+        assert screen._cwd == sub
+        assert screen._events["refreshed"] == 1
+        assert screen._events["dismissed"] == []  # navigated, not selected
+
+    def test_up_navigates_to_parent(self, tmp_path):
+        module = _load_app_module()
+        sub = tmp_path / "child"
+        sub.mkdir()
+        screen = _stub_picker(module, sub)
+        screen.action_go_up()
+        assert screen._cwd == tmp_path.resolve()
+
+    def test_none_selection_is_noop(self, tmp_path):
+        module = _load_app_module()
+        screen = _stub_picker(module, tmp_path)
+        event = types.SimpleNamespace(option=types.SimpleNamespace(id="__noop__"))
+        screen.on_option_list_option_selected(event)
+        assert screen._events["dismissed"] == []
+
+    def test_cancel_dismisses_none(self, tmp_path):
+        module = _load_app_module()
+        screen = _stub_picker(module, tmp_path)
+        screen.action_dismiss()
+        assert screen._events["dismissed"] == [None]
+
+
 class TestEventAnchor:
     def test_returns_screen_coords(self):
         module = _load_app_module()

--- a/argus/viewers/terminal/app.py
+++ b/argus/viewers/terminal/app.py
@@ -36,10 +36,15 @@ from textual.screen import ModalScreen
 from textual.widgets import DataTable, Footer, Header, Input, OptionList, Static
 from textual.widgets.option_list import Option
 
-from argus.viewers.terminal import mouse_actions, runs_sidebar, scan_runner
+from argus.viewers.terminal import (
+    mouse_actions,
+    results_picker,
+    runs_sidebar,
+    scan_runner,
+)
 from argus.viewers.terminal.loader import flatten_findings, load_summary
 from argus.core.config import ArgusConfig, ViewConfig
-from argus.core.run_discovery import discover_runs
+from argus.core.run_discovery import discover_runs, list_directory
 from argus.core import remediation
 from argus.core.findings_view import (
     SEVERITY_GLYPH,
@@ -523,6 +528,83 @@ class DiffPickerScreen(_BackgroundDismissMixin, ModalScreen[str | None]):
                 self.dismiss(None)
                 return
             self.dismiss(value)
+
+    def action_dismiss(self) -> None:
+        self.dismiss(None)
+
+
+class ResultsPickerScreen(_BackgroundDismissMixin, ModalScreen[str | None]):
+    """Filesystem browser for an ``argus-results.json`` (or a results dir).
+
+    Navigates one level at a time (like the browser ``/picker``): directories
+    holding a scan are flagged with a finding-count peek; descend into plain
+    directories, go up with ``backspace``, and select a scan to dismiss with
+    its path for the caller to load. Opened when "View findings" can't resolve
+    a scan in the launch directory, and on demand (``o``) to open results from
+    another project. Dismisses with the chosen path, or ``None`` on cancel.
+    """
+
+    BINDINGS = [
+        Binding("escape", "dismiss", show=False),
+        Binding("q", "dismiss", show=False),
+        Binding("backspace", "go_up", show=False),
+    ]
+
+    CSS = _PICKER_CSS
+
+    def __init__(self, start: Path):
+        super().__init__()
+        self._cwd = start.resolve()
+
+    def compose(self) -> ComposeResult:  # pragma: no cover — UI
+        with Container(id="picker-body"):
+            yield Static(
+                f"[b]Open scan[/b] · [dim]{self._cwd}[/dim]\n"
+                "enter to open / descend · backspace up · ESC cancel"
+            )
+            yield OptionList(*self._build_options(), id="picker-list")
+
+    def _build_options(self) -> list[Option]:
+        entries, error = list_directory(self._cwd, show_hidden=False)
+        rows = results_picker.picker_rows(
+            entries, include_parent=self._cwd.parent != self._cwd,
+        )
+        options = [Option(text, id=opt_id) for opt_id, text in rows]
+        if error:
+            options.append(Option(f"[red]{error}[/red]", id="__noop__"))
+        elif not entries:
+            options.append(Option("[dim](no sub-directories or scans here)[/dim]", id="__noop__"))
+        return options
+
+    def on_mount(self) -> None:
+        self.query_one("#picker-list", OptionList).focus()
+
+    def action_go_up(self) -> None:
+        parent = self._cwd.parent
+        if parent != self._cwd:
+            self._cwd = parent
+            self.refresh(recompose=True)
+            self.call_after_refresh(
+                lambda: self.query_one("#picker-list", OptionList).focus()
+            )
+
+    def on_option_list_option_selected(
+        self, event: OptionList.OptionSelected,
+    ) -> None:
+        action, path = results_picker.decode_id(
+            str(event.option.id) if event.option.id else None,
+        )
+        if action == "up":
+            self.action_go_up()
+        elif action == "dir" and path:
+            self._cwd = Path(path)
+            self.refresh(recompose=True)
+            self.call_after_refresh(
+                lambda: self.query_one("#picker-list", OptionList).focus()
+            )
+        elif action == "load" and path:
+            self.dismiss(path)
+        # "none" (placeholder rows) — ignore
 
     def action_dismiss(self) -> None:
         self.dismiss(None)
@@ -1312,6 +1394,7 @@ class ArgusBrowseCommands(Provider):
             ("Diff: Compare against another scan", "Pick another argus-results.json and bucket changes (new / fixed / severity-changed / still-open)", app.action_diff_against),
             ("Runs: Toggle the runs sidebar", "Show / hide the list of discovered scan runs and switch between them (b)", app.action_toggle_runs),
             ("Scan: Run argus scan", "Launch argus scan from the TUI, stream output, and reload results when done (shift+r)", app.action_run_scan),
+            ("Open: Load results from another directory", "Filesystem picker to open a scan from another project / archived results (shift+o)", app.action_open_results),
             ("Fix: Apply a Tier-1 dependency bump", "Propose + preview + apply a deterministic fix for the focused finding or selection (shift+f)", app.action_fix),
             ("Intel: Enrich with EPSS + CISA KEV", "Fetch exploit-probability + known-exploited intelligence for the CVEs in view (i)", app.action_enrich),
             ("Triage: Suppress / accept-risk (VEX)", "Record a triage decision to OpenVEX + .trivyignore/.gitleaksignore for the focused finding or selection (shift+s)", app.action_suppress),
@@ -1553,6 +1636,11 @@ class BrowseApp(App):
         # it finishes. Lowercase ``r`` stays the reveal-export action.
         Binding("b", "toggle_runs", "Runs", show=True),
         Binding("R", "run_scan", "Run scan", show=True),
+        # Open a scan from another directory (filesystem picker) — traverse
+        # to another project / archived results without relaunching. Capital
+        # ``O`` (lowercase ``o`` is "open last export"); matches the
+        # capital-for-major-action convention (R / F / S / D).
+        Binding("O", "open_results", "Open scan", show=True),
         # Deterministic Tier-1 fix (dependency bump) for the focused finding
         # — or every fixable row in the multi-select set. Diff-first: shows
         # the proposed change before touching anything.
@@ -1708,23 +1796,6 @@ class BrowseApp(App):
 
     def on_mount(self) -> None:
         self.title = "argus view (terminal)"
-        try:
-            summary, resolved = load_summary(self._results_dir)
-        except (FileNotFoundError, ValueError) as exc:
-            self.exit(message=f"\n{exc}\n", return_code=1)
-            return
-        self.sub_title = str(resolved)
-        self._current_results_path = resolved
-        self.all_findings = flatten_findings(summary)
-        # Read scan-time context (cwd / repo_root / commit_sha) off the
-        # loaded summary. Older argus-results.json files predate the
-        # field — leave self._scan_context as None and the click
-        # handlers fall back to their previous best-effort behavior.
-        self._scan_context = getattr(summary, "scan_context", None)
-        if self._scan_context is not None and self._scan_context.commit_sha:
-            # Pin the remote-URL ref to the commit the scan actually
-            # saw rather than the contributor's local HEAD.
-            self._scan_ref = self._scan_context.commit_sha
         table = self.query_one(DataTable)
         # Initial tooltip is the generic blurb; ``on_mouse_move`` swaps
         # it for a per-row summary (severity / id / package / first
@@ -1744,15 +1815,70 @@ class BrowseApp(App):
         self._col_keys = table.add_columns(
             " ", "Sev", "ID", "Package@Version", "Scanner", "Location",
         )
-        self._refresh_list()
-        self._update_sort_indicator()
-        # Discover sibling runs and fill the (initially hidden) sidebar.
+        loaded = self._try_load(self._results_dir)
+        # Discover sibling runs and fill the (initially hidden) sidebar —
+        # done even with no scan loaded so the user can see runs exist.
         self._populate_runs()
-        # Open into the findings list, not the search box. The search
-        # input is the first focusable child by yield order, so without
-        # this users land in the search field and find that ↑/↓ edit
-        # the query rather than navigating findings.
-        table.focus()
+        if loaded:
+            self._refresh_list()
+            self._update_sort_indicator()
+            # Open into the findings list, not the search box. The search
+            # input is the first focusable child by yield order, so without
+            # this users land in the search field and find that ↑/↓ edit
+            # the query rather than navigating findings.
+            table.focus()
+        else:
+            # No scan in the launch directory — open the picker so the user
+            # can navigate to one rather than dropping out to the shell with
+            # an error (which read as a "flicker back to home" from the
+            # Console hand-off).
+            self._prompt_for_results()
+
+    def _try_load(self, path: str | Path | None) -> bool:
+        """Load the scan at ``path`` into app state; ``False`` if unresolvable.
+
+        Pure state load (findings, current path, scan context) — the caller
+        refreshes the table / runs sidebar. Shared by on_mount, the runs
+        sidebar, the scan runner, and the results picker so every entry point
+        loads a scan the same way. Reads scan-time context (cwd / repo_root /
+        commit_sha) off the summary; older results predate it and leave
+        ``self._scan_context`` None, so click handlers fall back to their
+        best-effort behaviour.
+        """
+        try:
+            summary, resolved = load_summary(path)
+        except (FileNotFoundError, ValueError, OSError):
+            return False
+        self.all_findings = flatten_findings(summary)
+        self._current_results_path = resolved
+        self.sub_title = str(resolved)
+        self._scan_context = getattr(summary, "scan_context", None)
+        if self._scan_context is not None and self._scan_context.commit_sha:
+            # Pin the remote-URL ref to the commit the scan actually saw
+            # rather than the contributor's local HEAD.
+            self._scan_ref = self._scan_context.commit_sha
+        return True
+
+    def _prompt_for_results(self) -> None:  # pragma: no cover — UI event
+        """Open the results picker when no scan is loaded.
+
+        Cancelling with nothing loaded exits cleanly (there's nothing to
+        show) instead of leaving a blank screen.
+        """
+        start = self._launch_root if self._launch_root.exists() else Path.cwd()
+
+        def _chosen(path: str | None) -> None:
+            if path:
+                self._switch_run(path, update_root=True)
+                self.query_one(DataTable).focus()
+            elif self._current_results_path is None:
+                self.exit(
+                    message="\nNo scan selected. Run `argus scan` first, or "
+                            "point `argus view` at a results directory.\n",
+                    return_code=0,
+                )
+
+        self.push_screen(ResultsPickerScreen(start), _chosen)
 
     # ------------------------------------------------------------------
     # Runs sidebar + run switching
@@ -1836,32 +1962,50 @@ class BrowseApp(App):
         if path:
             self._switch_run(path)
 
-    def _switch_run(self, path: str) -> None:
+    def _switch_run(self, path: str, *, update_root: bool = False) -> None:
         """Load the run at ``path`` in place, keeping filters/sort.
 
         Resets the multi-select set (it keyed off the previous run's
         finding objects) but preserves the active severity/product/
         scanner/search filters — switching runs to compare the same
-        slice across scans is the common motivation. Surfaces load
-        failures as a toast rather than crashing the session.
+        slice across scans is the common motivation. ``update_root``
+        re-roots run discovery at the loaded scan's directory: set it when
+        opening a scan from *elsewhere* (the results picker) so the sidebar
+        shows that project's sibling runs; left off for in-root switches
+        (the sidebar, the scan runner). Surfaces load failures as a toast
+        rather than crashing the session.
         """
-        try:
-            summary, resolved = load_summary(path)
-        except (FileNotFoundError, ValueError, OSError) as exc:
+        if not self._try_load(path):
             self.notify(
-                f"Couldn't load run: {exc}", severity="error", timeout=6,
+                f"Couldn't load a scan at: {path}", severity="error", timeout=6,
             )
             return
-        self.all_findings = flatten_findings(summary)
-        self._current_results_path = resolved
-        self.sub_title = str(resolved)
-        self._scan_context = getattr(summary, "scan_context", None)
-        if self._scan_context is not None and self._scan_context.commit_sha:
-            self._scan_ref = self._scan_context.commit_sha
+        if update_root and self._current_results_path is not None:
+            self._launch_root = Path(self._current_results_path).parent
         # New run → the old selection's object identities are stale.
         self._selected.clear()
         self._refresh_list()
         self._populate_runs()
+
+    def action_open_results(self) -> None:  # pragma: no cover — UI event
+        """Open a scan from another directory (``o``).
+
+        A filesystem picker to load results from anywhere — another project,
+        an archived results folder — without relaunching. Complements the
+        runs sidebar (``b``), which switches between runs of the *current*
+        launch root; this re-roots there so the sidebar follows.
+        """
+        start = (
+            Path(self._current_results_path).parent
+            if self._current_results_path else self._launch_root
+        )
+
+        def _chosen(path: str | None) -> None:
+            if path:
+                self._switch_run(path, update_root=True)
+                self.query_one(DataTable).focus()
+
+        self.push_screen(ResultsPickerScreen(start), _chosen)
 
     def action_run_scan(self) -> None:  # pragma: no cover — UI event
         """Launch ``argus scan`` from inside the TUI (``R``).

--- a/argus/viewers/terminal/results_picker.py
+++ b/argus/viewers/terminal/results_picker.py
@@ -1,0 +1,70 @@
+"""Pure row formatting for the terminal viewer's results picker.
+
+The picker is a filesystem browser the findings viewer opens when it can't
+resolve a scan in the launch directory, and on demand (the ``o`` key) to load
+results from another project. The Textual ``OptionList`` that renders it lives
+in ``app.py``; everything here is pure string/id work over the entries
+``argus.core.run_discovery.list_directory`` produces, so it's unit-testable
+without Textual.
+
+Each row's option id encodes what selecting it *does*, so the screen doesn't
+need to re-stat the filesystem to decide:
+
+    ``__up__``        → go to the parent directory
+    ``dir::<path>``   → descend into a plain directory
+    ``load::<path>``  → load this scan (a results-bearing dir or the file)
+
+Only directories and ``argus-results.json`` files are shown — other files are
+noise for a "find me a scan" picker.
+"""
+
+from __future__ import annotations
+
+UP_ID = "__up__"
+_DIR_PREFIX = "dir::"
+_LOAD_PREFIX = "load::"
+
+
+def picker_rows(entries: list[dict], *, include_parent: bool) -> list[tuple[str, str]]:
+    """Return ``[(option_id, display)]`` for one directory level.
+
+    ``entries`` is a ``list_directory`` result. ``include_parent`` adds a
+    ``..`` row (omitted at a filesystem root). Directories that directly
+    contain a scan — and ``argus-results.json`` files — become ``load::``
+    rows (with a finding-count peek); plain directories become ``dir::``
+    rows the screen descends into. Everything else is dropped.
+    """
+    rows: list[tuple[str, str]] = []
+    if include_parent:
+        rows.append((UP_ID, "📁  .."))
+    for entry in entries:
+        path = entry.get("path", "")
+        name = entry.get("name", "")
+        if entry.get("is_results_file"):
+            rows.append((f"{_LOAD_PREFIX}{path}", f"📄  {name}   [dim]· scan results[/dim]"))
+        elif entry.get("is_dir"):
+            if entry.get("has_results"):
+                count = entry.get("finding_count")
+                tag = f"{count} findings" if count is not None else "scan"
+                rows.append((f"{_LOAD_PREFIX}{path}", f"📁  {name}/   [green]● {tag}[/green]"))
+            else:
+                rows.append((f"{_DIR_PREFIX}{path}", f"📁  {name}/"))
+        # non-dir, non-results files are intentionally skipped
+    return rows
+
+
+def decode_id(option_id: str | None) -> tuple[str, str | None]:
+    """Decode a picker option id into ``(action, path)``.
+
+    ``action`` is ``"up"``, ``"dir"``, ``"load"``, or ``"none"`` (for an
+    unrecognised / placeholder id). ``path`` is ``None`` for ``up`` / ``none``.
+    """
+    if not option_id:
+        return "none", None
+    if option_id == UP_ID:
+        return "up", None
+    if option_id.startswith(_DIR_PREFIX):
+        return "dir", option_id[len(_DIR_PREFIX):]
+    if option_id.startswith(_LOAD_PREFIX):
+        return "load", option_id[len(_LOAD_PREFIX):]
+    return "none", None

--- a/docs/view-terminal.md
+++ b/docs/view-terminal.md
@@ -70,6 +70,7 @@ Press `?` inside the TUI for the same reference, grouped by purpose.
 | `r` | reveal last export in file manager |
 | **Runs & scanning** | |
 | `b` | toggle the runs sidebar — switch between scan runs without relaunching |
+| `O` (shift+o) | open a scan from another directory — filesystem picker to load results from another project / archived folder |
 | `R` (shift+r) | run `argus scan` in-app, stream output, and reload results when done |
 | `F` (shift+f) | fix — propose a dependency bump for the finding (or selection), preview the diff, apply |
 | `i` | enrich — fetch EPSS + CISA KEV intelligence for the CVEs in view (see below) |
@@ -103,6 +104,17 @@ agree on what counts as a run (including collapsing the `latest/` symlink
 into the timestamped run it points at).
 
 ![Runs sidebar revealed on the left — two runs newest-first, the current run marked, alongside the findings list and detail pane](images/view-terminal/11-runs-sidebar.svg)
+
+**Open a scan from elsewhere (`O`).** Where the sidebar switches between
+runs of the *current* root, `O` (shift+o) opens a filesystem picker to load
+results from anywhere — another project, an archived results folder — without
+relaunching. Navigate one directory level at a time (`backspace` goes up);
+directories that contain a scan are flagged with a finding-count peek, and
+selecting one — or an `argus-results.json` file — loads it and re-roots the
+runs sidebar there. The same picker appears automatically when you open the
+viewer (or pick **View findings** in the Console) somewhere with no scan in
+the launch directory, so you can navigate to one instead of dropping back to
+the shell.
 
 **Run a scan (`R`).** Press `R` (shift+r) to launch `argus scan` without
 leaving the TUI. A prompt collects an optional scanner (blank runs all


### PR DESCRIPTION
## Description
The directory picker you asked for — completes the "View findings" flow.

When the findings viewer can't resolve a scan in the launch directory it now **opens a filesystem picker instead of exiting** (the behaviour behind the "View findings flickers back to the Console home" report — even with the loader fix in #282, a directory with *no* scan still dropped out). The same picker is available **on demand via `O`** to traverse to another project's results or an archived folder without relaunching.

## Changes Made
- [x] Modified existing scanner/workflow (terminal findings viewer)
- [x] Updated documentation
- [x] Other (new UI-free `results_picker` module + `ResultsPickerScreen`)

### Details
- **`results_picker.py`** (UI-free, fully tested) — formats one directory level from `run_discovery.list_directory` into picker rows (directories + `argus-results.json` files only; scan-bearing dirs flagged with a finding-count peek) and encodes/decodes each row's action in its option id (`__up__` / `dir::` / `load::`).
- **`ResultsPickerScreen`** — navigates one level at a time (`backspace` = up, `ESC` = cancel); selecting a scan-bearing directory or a results file dismisses with its path.
- **`BrowseApp`** — extracted **`_try_load`**, one loader shared by `on_mount`, the runs sidebar, the scan runner, and the picker. `on_mount` routes the no-scan case to `_prompt_for_results` (picker; cancelling with nothing loaded exits cleanly). `_switch_run(..., update_root=True)` re-roots run discovery at a scan opened from elsewhere so the sidebar follows. New **`O`** keybind (+ command-palette entry + help).

`O` is capital because lowercase `o` is already "open last export"; it matches the capital-for-major-action convention (`R` / `F` / `S` / `D`).

## Testing
- [x] Unit tests added/updated
### Test Results
New `test_results_picker.py` (UI-free rows + id decode, incl. embedded-`::` paths) and `test_runs_navigation.py` additions (`_try_load` true/false, `update_root` re-root, `action_open_results` pushes the picker, and `ResultsPickerScreen` build-options / load-select / dir-navigate / up / cancel). Full terminal suite: **332 passed**. (`compose` is the one method that can't run headless — the `with Container` context manager — so it's `# pragma: no cover — UI`; everything else is exercised.)

## Security Considerations
- [x] No security impact — read-only filesystem browsing (`list_directory` is non-recursive, hides dotfiles/build dirs); loading a scan is the same read the viewer already does.

## AI Context Updates (.ai/)
- [x] `.ai/architecture.yaml` updated (`results_picker`, `ResultsPickerScreen`, the `O` keybind + no-scan picker behaviour, `_try_load`), both mirror blocks.

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (`docs/view-terminal.md` — `O` keybind + "Open a scan from elsewhere")
- [x] All tests pass
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Follow-on to #282 (View-findings resolution). The companion **home system-status chip** is the next change. Merges into `feat/tui-explorer-and-scan-runner`.
