### PR TITLE
feat(console): system-readiness chip on the home screen (Docker / tools / image digests)

### DIFF
--- a/.ai/architecture.yaml
+++ b/.ai/architecture.yaml
@@ -143,6 +143,13 @@ components:
         argus-results.json) + executive summary (reuses findings_view.compute_summary so counts match every other
         view) + severity-grouped findings. Pure data — no Jinja/FastAPI/WeasyPrint — so it''s tested without any
         viewer extra. Drives the /report HTML view + the /report.pdf server-side render. See ADR-031.
+      core/system_status.py: UI-free Console-home readiness checks. compute_status(scanner_names, backend, *probes)
+        → SystemStatus (verdict ok/warn/down + glyph + summary) over StatusCheck rows — Docker daemon state
+        (probe_docker), local-tool availability per scanner (probe_local_tools over is_available), and cached
+        Argus image-digest match vs toolchain._published_argus_digests (probe_cached_image_digests; skipped when
+        Docker is off). Docker is only *blocking* when the effective execution.backend needs it with no local
+        fallback. All probes injectable for tests; effective_backend() reads execution.backend best-effort. Drives
+        the home chip (computed in a background worker) + SystemStatusScreen.
       viewers/: '`argus view` interfaces (optional extras)'
       viewers/__init__.py: ViewerUnavailable shared exception
       viewers/terminal/: '`argus view --interface=terminal` — Textual TUI ([terminal] extra). Includes
@@ -155,6 +162,9 @@ components:
         RunScanPromptScreen + RunScanScreen stream it) and reloads results when it finishes. Right-click context
         menus anchor at the cursor via mouse_actions.clamp_menu_offset. console.py + console_model.py provide the
         Argus Console — the home launcher (scan / findings / configure / init / settings / docs) with a
+        background-computed system-readiness chip (argus.core.system_status — Docker daemon / local-tool
+        availability / cached-image-digest match vs published releases; ``d`` opens SystemStatusScreen with the
+        per-check detail + remediation), a
         live-themed Settings screen backed by argus.core.console_config, a Configure form editor (ConfigScreen)
         for argus.yml backed by config_editor.py (UI-free, comment-preserving targeted line edits + schema validation),
         and an Init wizard (InitScreen) backed by init_wizard.py (UI-free frontend over argus.init detect_project +
@@ -808,6 +818,13 @@ docsite:
         argus-results.json) + executive summary (reuses findings_view.compute_summary so counts match every other
         view) + severity-grouped findings. Pure data — no Jinja/FastAPI/WeasyPrint — so it''s tested without any
         viewer extra. Drives the /report HTML view + the /report.pdf server-side render. See ADR-031.
+      core/system_status.py: UI-free Console-home readiness checks. compute_status(scanner_names, backend, *probes)
+        → SystemStatus (verdict ok/warn/down + glyph + summary) over StatusCheck rows — Docker daemon state
+        (probe_docker), local-tool availability per scanner (probe_local_tools over is_available), and cached
+        Argus image-digest match vs toolchain._published_argus_digests (probe_cached_image_digests; skipped when
+        Docker is off). Docker is only *blocking* when the effective execution.backend needs it with no local
+        fallback. All probes injectable for tests; effective_backend() reads execution.backend best-effort. Drives
+        the home chip (computed in a background worker) + SystemStatusScreen.
       viewers/: '`argus view` interfaces (optional extras)'
       viewers/__init__.py: ViewerUnavailable shared exception
       viewers/terminal/: '`argus view --interface=terminal` — Textual TUI ([terminal] extra). Includes
@@ -820,6 +837,9 @@ docsite:
         RunScanPromptScreen + RunScanScreen stream it) and reloads results when it finishes. Right-click context
         menus anchor at the cursor via mouse_actions.clamp_menu_offset. console.py + console_model.py provide the
         Argus Console — the home launcher (scan / findings / configure / init / settings / docs) with a
+        background-computed system-readiness chip (argus.core.system_status — Docker daemon / local-tool
+        availability / cached-image-digest match vs published releases; ``d`` opens SystemStatusScreen with the
+        per-check detail + remediation), a
         live-themed Settings screen backed by argus.core.console_config, a Configure form editor (ConfigScreen)
         for argus.yml backed by config_editor.py (UI-free, comment-preserving targeted line edits + schema validation),
         and an Init wizard (InitScreen) backed by init_wizard.py (UI-free frontend over argus.init detect_project +

--- a/argus/core/system_status.py
+++ b/argus/core/system_status.py
@@ -1,0 +1,267 @@
+"""UI-free system readiness checks for the Console home (go/no-go chip).
+
+Answers "can I actually run a scan right now, and with what?" before the user
+hits a wall like "Docker isn't running". Pure logic over injectable probes so
+it's unit-testable without a real Docker daemon or installed tools; the Console
+renders the result as a one-line chip (computed in a background worker so the
+home stays instant) with an Enter-to-expand modal.
+
+Three checks:
+
+* **Docker** — daemon running / installed-but-stopped / not installed. Only
+  *blocking* when the effective execution backend needs it and there's no
+  local fallback.
+* **Local tools** — how many of the configured scanners are runnable as local
+  binaries (each scanner's ``is_available()``).
+* **Scanner images** — best-effort: how many cached Argus container images
+  match a published release digest (genuine, unmodified tooling). Skipped when
+  Docker isn't running.
+
+The overall verdict is the worst actionable state: ``ok`` (●), ``warn`` (▲),
+or ``down`` (✖).
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from typing import Callable, Optional
+
+# A representative set of common local-binary security scanners for the
+# readiness "tools" check — kept small so the check stays fast (one
+# ``--version`` subprocess each) and relevant. Not exhaustive; the chip is a
+# readiness signal, not a full inventory.
+COMMON_SCANNERS = ["bandit", "gitleaks", "osv", "checkov", "trivy-iac"]
+
+# Verdict ranking — higher is worse, so the overall verdict is the max.
+_OK = "ok"
+_WARN = "warn"
+_DOWN = "down"
+_RANK = {_OK: 0, _WARN: 1, _DOWN: 2}
+
+
+@dataclass(frozen=True)
+class StatusCheck:
+    """One readiness check.
+
+    ``ok`` is tri-state: True (good), False (a problem), None (not applicable
+    / unknown — e.g. the image check when Docker is off). ``blocking`` marks a
+    failure that stops scanning outright (drives the ``down`` verdict).
+    """
+
+    key: str
+    label: str
+    ok: Optional[bool]
+    detail: str
+    remediation: str = ""
+    blocking: bool = False
+
+    @property
+    def verdict(self) -> str:
+        if self.ok is True or self.ok is None:
+            return _OK
+        return _DOWN if self.blocking else _WARN
+
+
+@dataclass(frozen=True)
+class SystemStatus:
+    """Aggregate readiness — a verdict plus the per-check breakdown."""
+
+    checks: list[StatusCheck] = field(default_factory=list)
+
+    @property
+    def verdict(self) -> str:
+        return max(
+            (c.verdict for c in self.checks), key=lambda v: _RANK[v], default=_OK,
+        )
+
+    @property
+    def glyph(self) -> str:
+        return {"ok": "●", "warn": "▲", "down": "✖"}[self.verdict]
+
+    @property
+    def summary(self) -> str:
+        """A short chip message — the headline problem, or "ready"."""
+        if self.verdict == _OK:
+            return "System ready"
+        # Lead with the worst (blocking first, then warnings).
+        ranked = sorted(
+            (c for c in self.checks if c.verdict != _OK),
+            key=lambda c: _RANK[c.verdict], reverse=True,
+        )
+        return ranked[0].detail if ranked else "System ready"
+
+
+# --------------------------------------------------------------------------
+# Probes — real implementations, each injectable for tests.
+# --------------------------------------------------------------------------
+
+def probe_docker() -> str:  # pragma: no cover - subprocess edge
+    """Return ``"running"`` / ``"stopped"`` / ``"absent"`` for the Docker daemon.
+
+    ``absent`` when the ``docker`` CLI isn't on PATH; otherwise ``docker info``
+    decides running vs. installed-but-not-started. Best-effort and bounded —
+    any error / timeout reads as ``stopped`` rather than raising.
+    """
+    if shutil.which("docker") is None:
+        return "absent"
+    try:
+        result = subprocess.run(
+            ["docker", "info", "--format", "{{.ServerVersion}}"],
+            capture_output=True, text=True, timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return "stopped"
+    return "running" if result.returncode == 0 else "stopped"
+
+
+def probe_local_tools(scanner_names: list[str]) -> dict[str, bool]:  # pragma: no cover - subprocess edge
+    """Map each scanner name to whether its tool is available as a local binary.
+
+    Best-effort: a scanner that can't be instantiated or whose availability
+    check raises is treated as unavailable rather than crashing the status.
+    """
+    from argus.scanners import get_scanner
+
+    out: dict[str, bool] = {}
+    for name in scanner_names:
+        try:
+            out[name] = bool(get_scanner(name)().is_available())
+        except Exception:
+            out[name] = False
+    return out
+
+
+def probe_cached_image_digests() -> set[str]:  # pragma: no cover - subprocess edge
+    """Return ``sha256:...`` digests of Argus images cached locally.
+
+    ``docker images --digests`` parsed best-effort; empty set on any error or
+    when Docker isn't running (the caller skips the image check then).
+    """
+    try:
+        result = subprocess.run(
+            ["docker", "images", "--digests", "--format", "{{.Digest}}"],
+            capture_output=True, text=True, timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return set()
+    if result.returncode != 0:
+        return set()
+    return {
+        line.strip() for line in result.stdout.splitlines()
+        if line.strip().startswith("sha256:")
+    }
+
+
+# --------------------------------------------------------------------------
+# Assembly
+# --------------------------------------------------------------------------
+
+def _docker_check(state: str, *, backend: str, local_tool_count: int) -> StatusCheck:
+    if state == "running":
+        return StatusCheck(
+            "docker", "Docker", True, "Docker daemon is running",
+        )
+    needs_docker = backend == "docker" or (backend == "auto" and local_tool_count == 0)
+    if state == "absent":
+        return StatusCheck(
+            "docker", "Docker", None if not needs_docker else False,
+            "Docker not installed",
+            remediation="Install Docker, or run with local tools "
+                        "(execution.backend: local).",
+            blocking=needs_docker,
+        )
+    # stopped
+    return StatusCheck(
+        "docker", "Docker", False, "Docker is installed but not running",
+        remediation="Start Docker Desktop / the daemon, or set "
+                    "execution.backend: local to use local tools.",
+        blocking=needs_docker,
+    )
+
+
+def _tools_check(availability: dict[str, bool]) -> StatusCheck:
+    total = len(availability)
+    have = sum(1 for ok in availability.values() if ok)
+    if total == 0:
+        return StatusCheck("tools", "Local tools", None, "No scanners configured")
+    if have == total:
+        return StatusCheck(
+            "tools", "Local tools", True, f"All {total} scanners available locally",
+        )
+    missing = sorted(n for n, ok in availability.items() if not ok)
+    return StatusCheck(
+        "tools", "Local tools", False,
+        f"{have}/{total} scanners available locally",
+        remediation="Missing: " + ", ".join(missing)
+                    + " — install them, or run those scanners via Docker.",
+    )
+
+
+def _images_check(cached: set[str], published: set[str]) -> StatusCheck:
+    matched = cached & published
+    if not cached:
+        return StatusCheck(
+            "images", "Scanner images", None,
+            "No Argus images cached (pulled on first containerized scan)",
+        )
+    if matched:
+        return StatusCheck(
+            "images", "Scanner images", True,
+            f"{len(matched)} cached Argus image(s) match a published release",
+        )
+    return StatusCheck(
+        "images", "Scanner images", False,
+        "Cached Argus images don't match any published release digest",
+        remediation="Re-pull the official images, or verify the registry — "
+                    "a mismatch can mean a rebuilt / overridden image.",
+    )
+
+
+def effective_backend(config_path: object = None) -> str:
+    """Best-effort ``execution.backend`` (``auto`` / ``local`` / ``docker``).
+
+    Defaults to ``auto`` when there's no config or it can't be parsed, so the
+    chip works before ``argus init`` has run.
+    """
+    try:
+        from argus.core.config import ArgusConfig
+        cfg = ArgusConfig.load(config_path) if config_path else ArgusConfig.load()
+        return cfg.execution.backend or "auto"
+    except Exception:
+        return "auto"
+
+
+def compute_status(
+    *,
+    scanner_names: list[str],
+    backend: str = "auto",
+    docker_probe: Callable[[], str] = probe_docker,
+    tools_probe: Callable[[list[str]], dict[str, bool]] = probe_local_tools,
+    cached_digests_probe: Callable[[], set[str]] = probe_cached_image_digests,
+    published_digests: Optional[set[str]] = None,
+) -> SystemStatus:
+    """Assemble a :class:`SystemStatus` from the probes.
+
+    All probes are injectable so tests run without Docker or installed tools.
+    ``backend`` is the effective ``execution.backend`` (``auto`` / ``local`` /
+    ``docker``) — it decides whether a stopped/absent Docker is *blocking*.
+    The image check only runs when Docker is up.
+    """
+    availability = tools_probe(scanner_names)
+    local_count = sum(1 for ok in availability.values() if ok)
+
+    docker_state = docker_probe()
+    checks = [
+        _docker_check(docker_state, backend=backend, local_tool_count=local_count),
+        _tools_check(availability),
+    ]
+
+    if docker_state == "running":
+        if published_digests is None:
+            from argus.core.toolchain import _published_argus_digests
+            published_digests = _published_argus_digests()
+        checks.append(_images_check(cached_digests_probe(), published_digests))
+
+    return SystemStatus(checks=checks)

--- a/argus/tests/core/test_system_status.py
+++ b/argus/tests/core/test_system_status.py
@@ -1,0 +1,133 @@
+"""Unit tests for argus.core.system_status — readiness verdict logic.
+
+The subprocess probes (Docker, tool availability, cached image digests) are
+injected, so these run without a real Docker daemon or installed tools.
+"""
+
+from __future__ import annotations
+
+from argus.core.system_status import (
+    SystemStatus,
+    compute_status,
+    effective_backend,
+)
+
+
+def _status(**overrides):
+    base = dict(
+        scanner_names=["bandit", "gitleaks"],
+        backend="auto",
+        docker_probe=lambda: "running",
+        tools_probe=lambda names: {n: True for n in names},
+        cached_digests_probe=lambda: {"sha256:abc"},
+        published_digests={"sha256:abc"},
+    )
+    base.update(overrides)
+    return compute_status(**base)
+
+
+def _check(status: SystemStatus, key: str):
+    return next(c for c in status.checks if c.key == key)
+
+
+class TestVerdict:
+    def test_all_good_is_ok(self):
+        s = _status()
+        assert s.verdict == "ok"
+        assert s.glyph == "●"
+        assert "ready" in s.summary.lower()
+        assert {c.key for c in s.checks} == {"docker", "tools", "images"}
+
+    def test_docker_stopped_auto_with_local_tools_is_warn(self):
+        # Local fallback exists → a stopped Docker degrades, not blocks.
+        s = _status(docker_probe=lambda: "stopped")
+        assert s.verdict == "warn"
+        assert s.glyph == "▲"
+        docker = _check(s, "docker")
+        assert docker.ok is False and docker.blocking is False
+
+    def test_docker_stopped_backend_docker_is_down(self):
+        s = _status(backend="docker", docker_probe=lambda: "stopped")
+        assert s.verdict == "down"
+        assert s.glyph == "✖"
+        assert _check(s, "docker").blocking is True
+        assert "not running" in s.summary.lower()
+
+    def test_docker_stopped_auto_no_local_tools_is_down(self):
+        s = _status(
+            docker_probe=lambda: "stopped",
+            tools_probe=lambda names: {n: False for n in names},
+        )
+        # Nothing can run: no Docker, no local tools.
+        assert s.verdict == "down"
+        assert _check(s, "docker").blocking is True
+
+
+class TestChecks:
+    def test_partial_tools_is_warn(self):
+        s = _status(
+            scanner_names=["bandit", "gitleaks", "osv"],
+            backend="local",
+            docker_probe=lambda: "absent",
+            tools_probe=lambda names: {"bandit": True, "gitleaks": False, "osv": True},
+        )
+        tools = _check(s, "tools")
+        assert tools.ok is False
+        assert "2/3" in tools.detail
+        assert "gitleaks" in tools.remediation
+        # backend=local → Docker absent is N/A (not blocking).
+        assert _check(s, "docker").ok is None
+        assert s.verdict == "warn"
+
+    def test_images_skipped_when_docker_off(self):
+        s = _status(backend="local", docker_probe=lambda: "stopped")
+        assert all(c.key != "images" for c in s.checks)
+
+    def test_image_digest_mismatch_is_warn(self):
+        s = _status(
+            cached_digests_probe=lambda: {"sha256:rogue"},
+            published_digests={"sha256:official"},
+        )
+        assert _check(s, "images").ok is False
+        assert s.verdict == "warn"
+
+    def test_no_images_cached_is_not_applicable(self):
+        s = _status(
+            cached_digests_probe=lambda: set(),
+            published_digests={"sha256:official"},
+        )
+        assert _check(s, "images").ok is None
+        assert s.verdict == "ok"
+
+    def test_no_scanners_configured(self):
+        s = _status(scanner_names=[], tools_probe=lambda names: {})
+        assert _check(s, "tools").ok is None
+
+    def test_published_digests_resolved_from_toolchain_when_omitted(self):
+        # Exercises the default branch that imports the published-digest set.
+        s = compute_status(
+            scanner_names=["bandit"],
+            backend="local",
+            docker_probe=lambda: "running",
+            tools_probe=lambda names: {n: True for n in names},
+            cached_digests_probe=lambda: set(),
+        )
+        # No cached images → N/A, but the import branch ran without error.
+        assert _check(s, "images").ok is None
+
+
+class TestSummaryAndEmpty:
+    def test_empty_status_defaults_ok(self):
+        assert SystemStatus().verdict == "ok"
+        assert SystemStatus().summary == "System ready"
+
+
+class TestEffectiveBackend:
+    def test_defaults_to_auto_without_config(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        assert effective_backend(None) in {"auto", "local", "docker"}
+
+    def test_reads_backend_from_config(self, tmp_path, monkeypatch):
+        (tmp_path / "argus.yml").write_text("execution:\n  backend: local\n")
+        monkeypatch.chdir(tmp_path)
+        assert effective_backend(str(tmp_path / "argus.yml")) == "local"

--- a/argus/tests/viewers/terminal/test_console.py
+++ b/argus/tests/viewers/terminal/test_console.py
@@ -187,6 +187,27 @@ class TestChoiceScreen:
         assert screen._current == "high"
 
 
+class TestSystemStatusScreen:
+    def test_construction_stores_status(self, console):
+        module, _app, _calls = console
+        from argus.core.system_status import StatusCheck, SystemStatus
+        status = SystemStatus(checks=[
+            StatusCheck("docker", "Docker", True, "Docker daemon is running"),
+        ])
+        screen = module.SystemStatusScreen(status)
+        assert screen._status is status
+
+    def test_home_apply_system_status_stores(self, console):
+        module, _app, _calls = console
+        from argus.core.system_status import SystemStatus
+        home = module.HomeScreen()
+        status = SystemStatus(checks=[])
+        # query_one fails under the stub (no real widget) but the status is
+        # stored first, so the `d` action can still open the modal.
+        home._apply_system_status(status)
+        assert home._system_status is status
+
+
 class TestCommandPalette:
     def test_provider_registered_on_app(self, console):
         module, _app, _calls = console

--- a/argus/viewers/terminal/console.py
+++ b/argus/viewers/terminal/console.py
@@ -522,6 +522,54 @@ class InitScreen(Screen):
         self.dismiss()
 
 
+class SystemStatusScreen(ModalScreen):
+    """Detailed system-readiness breakdown, opened from the home chip (``d``).
+
+    One row per check — glyph, label, detail, and a remediation hint when
+    something needs attention (Docker stopped, a tool missing, an image-digest
+    mismatch). Read-only; ESC closes. The status itself is computed UI-free in
+    ``argus.core.system_status``; this is the thin renderer.
+    """
+
+    _ROW_GLYPH = {"ok": "✔", "warn": "▲", "down": "✖"}
+
+    CSS = """
+    SystemStatusScreen { align: center middle; }
+    #sysstatus-body {
+        background: $surface; border: thick $accent;
+        width: 80%; max-width: 88; height: auto; max-height: 90%; padding: 1 2;
+    }
+    #sysstatus-title { text-style: bold; padding: 0 0 1 0; }
+    #sysstatus-hint { color: $text-muted; padding: 1 0 0 0; }
+    """
+    BINDINGS = [
+        Binding("escape", "close", "Close", show=True),
+        Binding("q", "close", show=False),
+    ]
+
+    def __init__(self, status) -> None:
+        super().__init__()
+        self._status = status
+
+    def compose(self) -> ComposeResult:  # pragma: no cover — UI
+        with Vertical(id="sysstatus-body"):
+            yield Static(
+                f"{self._status.glyph}  System status", id="sysstatus-title",
+            )
+            for check in self._status.checks:
+                glyph = self._ROW_GLYPH.get(check.verdict, "•")
+                yield Static(f"{glyph}  [b]{check.label}[/b] — {check.detail}")
+                if check.remediation and check.verdict != "ok":
+                    yield Static(f"      [dim]{check.remediation}[/dim]")
+            yield Static("esc to close", id="sysstatus-hint")
+
+    def on_mount(self) -> None:  # pragma: no cover — UI
+        self.focus()
+
+    def action_close(self) -> None:  # pragma: no cover — UI
+        self.dismiss()
+
+
 class HomeScreen(Screen):
     """The launcher: wordmark banner, project status, and the menu."""
 
@@ -537,11 +585,16 @@ class HomeScreen(Screen):
     #tagline { width: 100%; text-align: center; color: $text-muted; padding: 0 0 1 0; }
     #status { width: 100%; text-align: center; color: $text-muted; padding: 0 0 1 0;
               border-top: dashed $panel; border-bottom: dashed $panel; }
+    #system-status { width: 100%; text-align: center; color: $text-muted; padding: 0 0 1 0; }
     #menu { height: auto; width: 72; border: round $accent; padding: 0 1; }
     """
     BINDINGS = [
         Binding("q", "app.quit", "Quit"),
         Binding("s", "menu('settings')", "Settings"),
+        # System readiness (Docker / local tools / image digests). Computed in
+        # the background so the home renders instantly; ``d`` expands the chip
+        # into the detailed breakdown.
+        Binding("d", "system_status", "System"),
         Binding("question_mark", "menu('docs')", "Help", key_display="?"),
     ]
 
@@ -555,6 +608,9 @@ class HomeScreen(Screen):
                     yield Static(console_model.ARGUS_BANNER, id="banner")
                 yield Static(console_model.TAGLINE, id="tagline")
                 yield Static("", id="status")
+                yield Static(
+                    "[dim]checking system…[/dim]", id="system-status",
+                )
                 yield OptionList(
                     *(
                         Option(f"{item.icon}  {item.label}   [dim]{item.hint}[/dim]", id=item.key)
@@ -565,8 +621,12 @@ class HomeScreen(Screen):
         yield Footer()
 
     def on_mount(self) -> None:  # pragma: no cover — UI
+        self._system_status = None
         self.refresh_status()
         self.query_one("#menu", OptionList).focus()
+        # Probe system readiness off the UI thread (Docker info + tool version
+        # checks shell out and can stall) so the home paints instantly.
+        self.run_worker(self._compute_system_status, thread=True)
         if self.app.settings.motion_enabled:
             banner = self.query_one("#banner", Static)
             banner.styles.opacity = 0.0
@@ -577,6 +637,28 @@ class HomeScreen(Screen):
             self.app.launch_root, config_path=self.app.config_path,
         )
         self.query_one("#status", Static).update(console_model.status_line(status))
+
+    def _compute_system_status(self) -> None:  # pragma: no cover — UI (thread)
+        from argus.core import system_status
+        backend = system_status.effective_backend(self.app.config_path)
+        status = system_status.compute_status(
+            scanner_names=system_status.COMMON_SCANNERS, backend=backend,
+        )
+        self.app.call_from_thread(self._apply_system_status, status)
+
+    def _apply_system_status(self, status) -> None:  # pragma: no cover — UI
+        self._system_status = status
+        try:
+            chip = self.query_one("#system-status", Static)
+        except Exception:
+            return
+        chip.update(f"{status.glyph}  {status.summary}   [dim](d for details)[/dim]")
+
+    def action_system_status(self) -> None:  # pragma: no cover — UI
+        if self._system_status is None:
+            self.app.notify("Still checking system status…", timeout=2)
+            return
+        self.app.push_screen(SystemStatusScreen(self._system_status))
 
     def action_menu(self, key: str) -> None:  # pragma: no cover — UI
         self.app.dispatch_menu(key)

--- a/docs/console.md
+++ b/docs/console.md
@@ -26,6 +26,13 @@ argus scan ...   # every subcommand is unchanged
 - **Status line** — at a glance: whether an `argus.yml` exists, and the
   latest run's label, finding count, and worst severity (from the same
   run-discovery logic the viewers use).
+- **System-readiness chip** — a single go/no-go line (`●` ready / `▲` warning
+  / `✖` blocked) answering "can I scan right now, and with what?" *before* you
+  hit a wall like "Docker isn't running". It checks the Docker daemon, how many
+  common scanners are installed as local binaries, and whether cached Argus
+  images match a published release digest. Computed in the background so the
+  home paints instantly; press **`d`** to expand it into the full breakdown
+  with remediation for anything that needs attention.
 - **Launcher menu** — arrow keys + Enter, or click:
 
   | Item | What it does |


### PR DESCRIPTION
## Description
The home-screen **system-readiness chip** you asked for — so "Docker isn't running" (and friends) show up *before* you try to scan and hit a wall.

The Console home gets a single go/no-go line — **`●` ready / `▲` warning / `✖` blocked** — with a short headline. Press **`d`** to expand it into the full breakdown with remediation. Computed in a background worker so the home still paints instantly (it doesn't dominate — one line).

## Changes Made
- [x] Modified existing scanner/workflow (Console home)
- [x] Updated documentation
- [x] Other (new UI-free `core/system_status.py` + `SystemStatusScreen`)

### Details
- **`argus/core/system_status.py`** (UI-free) — `compute_status(...)` → `SystemStatus` (verdict + glyph + summary) over `StatusCheck` rows:
  - **Docker** — running / installed-but-stopped / absent. Only **blocking** when the effective `execution.backend` needs it with no local fallback (a stopped Docker on an all-local setup is a *warning*; `backend: docker` with Docker down is *blocked*). This is exactly the case that bit during test-driving.
  - **Local tools** — how many common scanners are runnable as local binaries (`is_available()`).
  - **Scanner images** — best-effort: cached Argus image digests vs published release digests (genuine vs rebuilt/overridden), skipped when Docker is off.
  - All three probes are **injectable**, so the verdict logic is fully unit-tested without Docker or installed tools. `effective_backend()` reads `execution.backend` best-effort.
- **Console home** — a `#system-status` chip (`checking system…` → result), computed in a `run_worker(thread=True)` and applied via `call_from_thread`; `d` opens **`SystemStatusScreen`** with the per-check detail + remediation.

Real-world check on a dev box (Docker up, no local scanners): `▲ 0/5 scanners available locally`, with the modal listing Docker ✔, tools ▲, images ▲ — accurate and actionable.

## Testing
- [x] Unit tests added/updated
### Test Results
New `test_system_status.py` — verdict matrix (ok / warn / down across Docker state × backend × local-tool availability), image match/mismatch/none, the toolchain-digest default branch, and `effective_backend`. Plus `SystemStatusScreen` + `HomeScreen._apply_system_status` construction tests. Full suite **4271 passed** (the 3 failures are the known pre-existing local-only fastapi/starlette skew, green in CI). The three subprocess probes are the only `# pragma: no cover` edges; all verdict logic is covered.

## Security Considerations
- [x] No security impact — read-only local probes (Docker info, `<tool> --version`, `docker images`), bounded timeouts, best-effort (any error degrades gracefully).

## AI Context Updates (.ai/)
- [x] `.ai/architecture.yaml` updated (`core/system_status.py` + the home chip / `SystemStatusScreen` / `d` keybind), both mirror blocks.

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (`docs/console.md` — system-readiness chip)
- [x] All tests pass
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
The second of the two Console features from test-driving (companion to the directory picker, #283). Merges into `feat/tui-explorer-and-scan-runner`.
