### PR TITLE
feat(console): live-preview theme dropdown in Settings

### DIFF
--- a/.ai/architecture.yaml
+++ b/.ai/architecture.yaml
@@ -165,7 +165,8 @@ components:
         background-computed system-readiness chip (argus.core.system_status — Docker daemon / local-tool
         availability / cached-image-digest match vs published releases; ``d`` opens SystemStatusScreen with the
         per-check detail + remediation), a
-        live-themed Settings screen backed by argus.core.console_config, a Configure form editor (ConfigScreen)
+        live-themed Settings screen backed by argus.core.console_config (theme via a live-preview
+        ThemePickerScreen dropdown — arrow previews, enter chooses, esc reverts; ConsoleSettings.with_value), a Configure form editor (ConfigScreen)
         for argus.yml backed by config_editor.py (UI-free, comment-preserving targeted line edits + schema validation),
         and an Init wizard (InitScreen) backed by init_wizard.py (UI-free frontend over argus.init detect_project +
         generate_config — detect, toggle proposed scanners, write argus.yml, optionally hand off to the scan runner),
@@ -840,7 +841,8 @@ docsite:
         background-computed system-readiness chip (argus.core.system_status — Docker daemon / local-tool
         availability / cached-image-digest match vs published releases; ``d`` opens SystemStatusScreen with the
         per-check detail + remediation), a
-        live-themed Settings screen backed by argus.core.console_config, a Configure form editor (ConfigScreen)
+        live-themed Settings screen backed by argus.core.console_config (theme via a live-preview
+        ThemePickerScreen dropdown — arrow previews, enter chooses, esc reverts; ConsoleSettings.with_value), a Configure form editor (ConfigScreen)
         for argus.yml backed by config_editor.py (UI-free, comment-preserving targeted line edits + schema validation),
         and an Init wizard (InitScreen) backed by init_wizard.py (UI-free frontend over argus.init detect_project +
         generate_config — detect, toggle proposed scanners, write argus.yml, optionally hand off to the scan runner),

--- a/argus/core/console_config.py
+++ b/argus/core/console_config.py
@@ -143,6 +143,19 @@ class ConsoleSettings:
             data[key] = not data[key]
         return ConsoleSettings.from_dict(data)
 
+    def with_value(self, key: str, value: object) -> "ConsoleSettings":
+        """Return a copy with setting ``key`` set to ``value`` (normalized).
+
+        Unlike ``advance`` (which steps a cycle), this sets a *specific*
+        value — used by the theme picker, where the user chooses a theme
+        directly. An unknown key returns an unchanged copy; an out-of-range
+        value snaps back to the field default via ``normalized``.
+        """
+        data = self.to_dict()
+        if key in data:
+            data[key] = value
+        return ConsoleSettings.from_dict(data)
+
     def display_rows(self) -> list[tuple[str, str, str]]:
         """Return ``[(key, label, value_text), ...]`` for the Settings screen.
 

--- a/argus/tests/core/test_console_config.py
+++ b/argus/tests/core/test_console_config.py
@@ -124,6 +124,24 @@ class TestAdvanceAndRows:
         assert s.animations is True  # original untouched (immutable update)
         assert advanced is not s
 
+    def test_with_value_sets_specific_theme(self):
+        s = ConsoleSettings(theme=DEFAULT_THEME)
+        assert s.with_value("theme", "nord").theme == "nord"
+
+    def test_with_value_invalid_snaps_to_default(self):
+        s = ConsoleSettings()
+        assert s.with_value("theme", "not-a-theme").theme == DEFAULT_THEME
+
+    def test_with_value_unknown_key_is_noop(self):
+        s = ConsoleSettings()
+        assert s.with_value("not-a-setting", "x") == s
+
+    def test_with_value_returns_new_instance(self):
+        s = ConsoleSettings(theme=DEFAULT_THEME)
+        out = s.with_value("theme", "dracula")
+        assert s.theme == DEFAULT_THEME  # original untouched
+        assert out is not s and out.theme == "dracula"
+
     def test_display_rows_cover_all_settings(self):
         rows = ConsoleSettings(theme="nord", animations=False).display_rows()
         by_key = {key: (label, text) for key, label, text in rows}

--- a/argus/tests/viewers/terminal/test_console.py
+++ b/argus/tests/viewers/terminal/test_console.py
@@ -187,6 +187,55 @@ class TestChoiceScreen:
         assert screen._current == "high"
 
 
+class TestThemePicker:
+    def _picker(self, module, current="argus-dark"):
+        screen = module.ThemePickerScreen(current)
+
+        class _FakeApp:
+            def __init__(self) -> None:
+                self.settings = ConsoleSettings(theme=current)
+                self.applied: list = []
+
+            def apply_theme(self) -> None:
+                self.applied.append(self.settings.theme)
+
+        # Under the stubbed module, Screen has no read-only ``app`` property,
+        # so we can attach a fake app + record dismissal.
+        screen.app = _FakeApp()
+        screen._dismissed = []
+        screen.dismiss = lambda v=None: screen._dismissed.append(v)
+        return screen
+
+    def test_construction_remembers_original(self, console):
+        module, _app, _calls = console
+        screen = module.ThemePickerScreen("nord")
+        assert screen._original == "nord"
+
+    def test_preview_applies_theme_live(self, console):
+        module, _app, _calls = console
+        screen = self._picker(module)
+        screen._preview("dracula")
+        assert screen.app.settings.theme == "dracula"
+        assert screen.app.applied == ["dracula"]
+
+    def test_select_keeps_previewed_theme(self, console):
+        module, _app, _calls = console
+        screen = self._picker(module)
+        ev = types.SimpleNamespace(option=types.SimpleNamespace(id="gruvbox"))
+        screen.on_option_list_option_selected(ev)
+        assert screen.app.settings.theme == "gruvbox"
+        assert screen._dismissed == [True]
+
+    def test_cancel_reverts_to_original(self, console):
+        module, _app, _calls = console
+        screen = self._picker(module, current="argus-dark")
+        screen._preview("monokai")          # user arrowed around…
+        assert screen.app.settings.theme == "monokai"
+        screen.action_cancel()              # …then bailed
+        assert screen.app.settings.theme == "argus-dark"
+        assert screen._dismissed == [False]
+
+
 class TestSystemStatusScreen:
     def test_construction_stores_status(self, console):
         module, _app, _calls = console

--- a/argus/viewers/terminal/console.py
+++ b/argus/viewers/terminal/console.py
@@ -133,10 +133,83 @@ class DocsScreen(ModalScreen):
         self.query_one("#docs-body", VerticalScroll).focus()
 
 
+class ThemePickerScreen(Screen):
+    """Live-preview theme dropdown: arrow to preview, Enter to choose, Esc to revert.
+
+    Highlighting a theme applies it immediately so the user sees it before
+    committing; Enter keeps the previewed theme, Esc restores whatever was
+    active when the picker opened. A full Screen (not a ModalScreen) for the
+    same reason ``SettingsScreen`` is — applying a theme while a ModalScreen is
+    mounted hits a Textual 8.x render bug (NoneType visual).
+    """
+
+    CSS = """
+    ThemePickerScreen { align: center middle; }
+    #theme-body {
+        background: $surface; border: thick $accent;
+        width: 60%; max-width: 56; height: auto; max-height: 80%; padding: 1 2;
+    }
+    #theme-title { text-style: bold; padding: 0 0 1 0; }
+    #theme-list { height: auto; max-height: 18; border: none; background: transparent; }
+    #theme-hint { color: $text-muted; padding: 1 0 0 0; }
+    """
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel", show=True),
+        Binding("q", "cancel", show=False),
+    ]
+
+    def __init__(self, current: str) -> None:
+        super().__init__()
+        self._original = current
+
+    def compose(self) -> ComposeResult:  # pragma: no cover — UI
+        with Vertical(id="theme-body"):
+            yield Static("🎨  Theme — ↑↓ to preview", id="theme-title")
+            yield OptionList(
+                *(
+                    Option(f"{'● ' if name == self._original else '  '}{name}", id=name)
+                    for name in console_config.THEMES
+                ),
+                id="theme-list",
+            )
+            yield Static(
+                "↑↓ preview   ·   enter choose   ·   esc cancel", id="theme-hint",
+            )
+
+    def on_mount(self) -> None:  # pragma: no cover — UI
+        option_list = self.query_one("#theme-list", OptionList)
+        if self._original in console_config.THEMES:
+            option_list.highlighted = console_config.THEMES.index(self._original)
+        option_list.focus()
+
+    def _preview(self, name: str) -> None:  # pragma: no cover — UI
+        self.app.settings = self.app.settings.with_value("theme", name)
+        self.app.apply_theme()
+
+    def on_option_list_option_highlighted(  # pragma: no cover — UI
+        self, event: OptionList.OptionHighlighted,
+    ) -> None:
+        if event.option and event.option.id:
+            self._preview(event.option.id)
+
+    def on_option_list_option_selected(  # pragma: no cover — UI
+        self, event: OptionList.OptionSelected,
+    ) -> None:
+        if event.option and event.option.id:
+            self._preview(event.option.id)
+        self.dismiss(True)   # keep the previewed theme
+
+    def action_cancel(self) -> None:  # pragma: no cover — UI
+        # Restore whatever theme was active when the picker opened.
+        self.app.settings = self.app.settings.with_value("theme", self._original)
+        self.app.apply_theme()
+        self.dismiss(False)
+
+
 class SettingsScreen(Screen):
     """herdr-style settings: an arrow-navigable list where Enter changes the
-    focused setting and the result previews live (theme / accent apply
-    immediately; toggles flip). Persisted on close.
+    focused setting and the result previews live (theme opens a live-preview
+    dropdown; accent applies immediately; toggles flip). Persisted on close.
 
     A full Screen (not a ModalScreen) on purpose: live theme application
     while a ModalScreen is mounted hits a Textual render bug
@@ -204,8 +277,21 @@ class SettingsScreen(Screen):
         if not key:
             return
         self._highlight = event.option_index
+        if key == "theme":
+            # Theme opens a live-preview dropdown (arrow to preview, enter to
+            # choose, esc to revert) rather than cycling one step per Enter.
+            def _after_pick(_chosen: object) -> None:
+                # settings.theme is already set by the picker (preview/confirm
+                # or revert); just rebuild the list to show the new value.
+                self.refresh(recompose=True)
+                self.call_after_refresh(self._restore_cursor)
+
+            self.app.push_screen(
+                ThemePickerScreen(self.app.settings.theme), _after_pick,
+            )
+            return
         self.app.settings = self.app.settings.advance(key)
-        self.app.apply_theme()       # live preview for theme / accent
+        self.app.apply_theme()       # live preview for accent
         # Rebuild the list cleanly with the new values, then restore cursor.
         self.refresh(recompose=True)
         self.call_after_refresh(self._restore_cursor)

--- a/docs/console.md
+++ b/docs/console.md
@@ -85,15 +85,17 @@ functions behind `argus init`; the wizard is just a frontend over them.
 ## Settings
 
 A keyboard- and mouse-friendly settings page. Move with the arrows, press
-Enter to change the focused setting; theme and accent **preview live**,
-and everything persists to `~/.config/argus/console.yml`
-(XDG-aware — honours `$XDG_CONFIG_HOME`).
+Enter to change the focused setting; accent **previews live**, and everything
+persists to `~/.config/argus/console.yml` (XDG-aware — honours
+`$XDG_CONFIG_HOME`). **Theme** opens a live-preview dropdown: arrow up/down to
+see each theme applied instantly, Enter to keep it, Esc to revert to the one
+you started on.
 
 ![Argus Console settings — theme, accent, animations, reduced motion, notifications](images/console/console-settings.png)
 
 | Setting | Effect |
 |---|---|
-| Theme | Any of the built-in Textual themes plus the bespoke `argus-dark`. |
+| Theme | Any of the built-in Textual themes plus the bespoke `argus-dark` — chosen from a live-preview dropdown (↑↓ preview · Enter choose · Esc revert). |
 | Accent colour | Tints the `argus-dark` theme; previews instantly. |
 | Animations | Master switch for motion (e.g. the home fade-in). |
 | Reduced motion | Overrides Animations — turns all motion off (accessibility). |


### PR DESCRIPTION
## Description
Settings → **Theme** is now a live-preview dropdown instead of cycle-on-Enter: arrow up/down to see each theme applied **instantly**, Enter to keep it, Esc to revert to the one you started on.

## Changes Made
- [x] Modified existing scanner/workflow (Console Settings)
- [x] Updated documentation
- [x] Other (new `ThemePickerScreen`)

### Details
- **`ThemePickerScreen`** — lists all themes; highlighting one applies it live via `app.apply_theme()` (the preview), Enter dismisses keeping it, Esc restores the theme that was active when the picker opened. It's a **full Screen, not a ModalScreen** — applying a theme under a ModalScreen hits the Textual 8.x NoneType-visual bug (the same reason `SettingsScreen` itself is a full screen).
- **`ConsoleSettings.with_value(key, value)`** — UI-free setter for a *specific* value (vs `advance()`'s cycle), normalized so an out-of-range theme snaps to the default.
- **`SettingsScreen`** routes the Theme row to the picker; accent + toggles keep their cycle-on-Enter behaviour.

## Testing
- [x] Unit tests added/updated
### Test Results
`with_value` (set / invalid-snaps-to-default / unknown-key-noop / immutability) + `ThemePickerScreen` (preview applies live, Enter keeps the previewed theme, Esc reverts to original). Full suite **4279 passed** (the 3 failures are the known pre-existing local-only fastapi/starlette skew, green in CI).

## Security Considerations
- [x] No security impact — UI preference only.

## AI Context Updates (.ai/)
- [x] `.ai/architecture.yaml` updated (ThemePickerScreen + `with_value`), both mirror blocks.

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (`docs/console.md` — Settings / Theme)
- [x] All tests pass
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Console Settings UX (Phase 4). Merges into `feat/tui-explorer-and-scan-runner`.
