### PR TITLE
feat(view): loading feedback for init, scan startup, and run switching

### DIFF
--- a/argus/tests/viewers/terminal/test_console.py
+++ b/argus/tests/viewers/terminal/test_console.py
@@ -71,6 +71,10 @@ def console(monkeypatch, tmp_path):
     app.exit = lambda result=None: calls["exit"].append(result)  # type: ignore[method-assign]
     app._open_scan = lambda: calls.__setitem__("scan", calls["scan"] + 1)  # type: ignore[method-assign]
     app._edit_config = lambda: calls.__setitem__("edit", calls["edit"] + 1)  # type: ignore[method-assign]
+    # Run workers synchronously so deferred work (e.g. init detection) lands
+    # within the test (production runs it in a thread to keep the UI live).
+    app.run_worker = lambda work, *a, **k: (work() if callable(work) else None)  # type: ignore[method-assign]
+    app.call_from_thread = lambda fn, *a, **k: fn(*a, **k)  # type: ignore[method-assign]
     return module, app, calls
 
 
@@ -124,6 +128,7 @@ class TestDispatch:
     def test_init_opens_wizard(self, console, tmp_path, monkeypatch):
         _module, app, calls = console
         monkeypatch.chdir(tmp_path)  # detect against an empty dir, fast + deterministic
+        app.notify = lambda *a, **k: None  # "Detecting…" toast; stub avoids super().notify
         app.dispatch_menu("init")
         assert "InitScreen" in calls["push"]
         assert calls["exit"] == []  # no hand-off any more

--- a/argus/tests/viewers/terminal/test_runs_navigation.py
+++ b/argus/tests/viewers/terminal/test_runs_navigation.py
@@ -125,6 +125,10 @@ def app(tmp_path):
     app.query_one = fake_query_one  # type: ignore[method-assign]
     app.notify = lambda *a, **k: notify_calls.append({"a": a, **k})  # type: ignore[method-assign]
     app._refresh_list = lambda: None  # type: ignore[method-assign]
+    # Run the load worker synchronously so tests can assert state right after
+    # _switch_run (production runs it in a thread to animate the spinner).
+    app.run_worker = lambda work, *a, **k: (work() if callable(work) else None)  # type: ignore[method-assign]
+    app.call_from_thread = lambda fn, *a, **k: fn(*a, **k)  # type: ignore[method-assign]
     return module, app, widgets, notify_calls, tmp_path
 
 

--- a/argus/viewers/terminal/app.py
+++ b/argus/viewers/terminal/app.py
@@ -1228,6 +1228,10 @@ class RunScanScreen(ModalScreen[str | None]):
 
     async def _stream(self) -> None:  # pragma: no cover — subprocess streaming
         import asyncio
+        # Immediate feedback before the subprocess produces its first line —
+        # otherwise the pane sits empty during the spawn + scanner startup and
+        # reads as a hang.
+        self._append("⏳  Starting argus scan…")
         try:
             self._proc = await asyncio.create_subprocess_exec(
                 *self._argv,
@@ -1975,7 +1979,29 @@ class BrowseApp(App):
         (the sidebar, the scan runner). Surfaces load failures as a toast
         rather than crashing the session.
         """
-        if not self._try_load(path):
+        # Show the table's built-in spinner while the new scan loads + the
+        # rows rebuild (a noticeable beat for a large results file) so the
+        # switch never reads as a frozen pause. The load runs in a worker so
+        # the spinner actually animates; the rebuild happens back on the UI
+        # thread in _finish_switch.
+        try:
+            self.query_one(DataTable).loading = True
+        except Exception:
+            pass
+
+        def _work() -> None:
+            ok = self._try_load(path)
+            self.call_from_thread(self._finish_switch, ok, path, update_root)
+
+        self.run_worker(_work, thread=True)
+
+    def _finish_switch(self, ok: bool, path: str, update_root: bool) -> None:
+        """Apply a loaded run on the UI thread (called from the load worker)."""
+        try:
+            self.query_one(DataTable).loading = False
+        except Exception:
+            pass
+        if not ok:
             self.notify(
                 f"Couldn't load a scan at: {path}", severity="error", timeout=6,
             )

--- a/argus/viewers/terminal/console.py
+++ b/argus/viewers/terminal/console.py
@@ -889,12 +889,25 @@ class ConsoleApp(App):
     def _open_init(self) -> None:  # pragma: no cover — UI
         """Open the init wizard over the project at the current directory.
 
-        Detects the project, lets the user review/toggle the proposed
-        scanners, and writes argus.yml in-app. On "write & scan" it hands
-        straight to the scan runner; either way it refreshes home status.
+        Detection (``build_plan`` — a filesystem walk) runs in a worker with
+        an immediate "Detecting…" toast so the home isn't frozen blank while
+        it works; the wizard opens when detection completes.
         """
-        plan = init_wizard.build_plan(Path("."))
+        self.notify("Detecting project…", timeout=2)
 
+        def _work() -> None:
+            plan = init_wizard.build_plan(Path("."))
+            self.call_from_thread(self._show_init, plan)
+
+        self.run_worker(_work, thread=True)
+
+    def _show_init(self, plan: "init_wizard.InitPlan") -> None:  # pragma: no cover — UI
+        """Push the init wizard once detection has produced a plan.
+
+        Lets the user review/toggle the proposed scanners and writes argus.yml
+        in-app. On "write & scan" it hands to the scan runner; either way it
+        refreshes home status.
+        """
         def _after(result: object) -> None:
             self.config_path = self._detect_config_path()
             screen = self.screen


### PR DESCRIPTION
## Description
Three TUI spots left you "in the dark" during brief synchronous work — they now give immediate feedback instead of a frozen screen.

## Changes Made
- [x] Fixed bug / UX (no functional change to scanning)

### Details
- **Initialize** — `build_plan` (a filesystem walk for project detection) ran on the UI thread before the wizard opened, freezing the home. It now runs in a worker behind an immediate **"Detecting project…"** toast; the wizard opens when detection finishes (`_open_init` → worker → `_show_init`).
- **Run switching** — selecting a run (sidebar / picker / post-scan reload) loaded the results + rebuilt the table synchronously, reading as a pause. It now shows the DataTable's **built-in spinner** (`loading = True`) while the load runs in a worker, applying the rows back on the UI thread (`_switch_run` → `_finish_switch`) so the spinner actually animates.
- **Scan** — `RunScanScreen` now prints **"⏳ Starting argus scan…"** immediately, before the subprocess produces its first line, so the output pane isn't blank during spawn + scanner startup.

## Testing
- [x] Unit tests added/updated
### Test Results
Existing `TestSwitchRun` now exercises the worker path (the fixtures run `run_worker` / `call_from_thread` synchronously, so state assertions still hold; production runs them threaded). `test_init_opens_wizard` covers the deferred `_open_init` → `_show_init` path. Full suite **4279 passed** (the 3 failures are the known pre-existing local-only fastapi/starlette skew, green in CI).

## Security Considerations
- [x] No security impact — UI feedback only; the scan/detection work is unchanged, just moved off the UI thread.

## AI Context Updates (.ai/)
- [x] N/A — behavioral polish; no new components/commands.

## Checklist
- [x] Code follows project style guidelines
- [x] All tests pass
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Test-drive UX feedback (Initialize / scanner / run-switch felt frozen). Merges into `feat/tui-explorer-and-scan-runner`.
