### PR TITLE
fix(container): private-registry (ECR) scanning in CI — docker-login auth + --no-timestamp

### DIFF
--- a/.ai/errors.yaml
+++ b/.ai/errors.yaml
@@ -217,6 +217,36 @@ scn_detector_errors:
       \ mount, not registry pull.\n"
   reference: "argus/container/scanner.py::_registry_auth_env and docs/troubleshooting/docker.md\
     \ \u2192 'target image fails to authenticate inside the sub-scanner container'"
+- pattern: "401 Unauthorized|Not Authorized|unexpected status code 401"
+  category: container-scanning
+  context: "A container scan of a private-registry image (e.g. AWS ECR) fails with\n\
+    401 even though the CI job ran ``docker login`` successfully and a host\n``docker\
+    \ pull`` of the same ref works. Happens on the Docker-fallback\npath \u2014 trivy/grype\
+    \ run inside their own container because no scanner\nbinary is installed on the\
+    \ runner.\n"
+  root_cause: "The consumer authenticated with ``docker login`` (the common\n``aws\
+    \ ecr get-login-password | docker login`` pattern) rather than\npassing ``registry_username``\
+    \ / ``registry_auth`` to Argus. Those\n``docker login`` credentials live in the\
+    \ host ``~/.docker/config.json``,\nwhich the sub-scanner container cannot see \u2014\
+    \ so it falls back to an\nanonymous pull and the private registry rejects it.\n"
+  solution:
+    steps:
+    - "Upgrade to a build that includes _docker_login_mount_args (argus/container/scanner.py):\
+      \ Argus now stages a sanitized copy of the host Docker config and mounts it\
+      \ into the scanner container with DOCKER_CONFIG set, so docker-login creds reach\
+      \ trivy/grype/syft on the Docker-fallback path."
+    - "Alternative (no SDK change needed): install trivy + grype as local binaries\
+      \ on the runner before the scan \u2014 local binaries read ~/.docker/config.json\
+      \ directly, bypassing the fallback container."
+    - "Alternative: pass containers.registry_username_env / registry_password_env\
+      \ (or the registry_auth map) in argus.yml so creds are forwarded as -e env vars\
+      \ regardless of docker login."
+    note: "Only inline ``auths`` entries (what ``docker login`` writes on a CI\nrunner)\
+      \ are bridged. ``credsStore`` / ``credHelpers`` are dropped from the\nmounted\
+      \ copy because the helper binary they name doesn't exist inside\nthe scanner\
+      \ image. Local-image scans (built from a Dockerfile) are\nunaffected \u2014 they\
+      \ read the daemon over the mounted socket.\n"
+  reference: "argus/container/scanner.py::_docker_login_mount_args"
 errors:
   RESOURCE_NOT_ACCESSIBLE_BY_INTEGRATION:
     category: permissions

--- a/argus/cli.py
+++ b/argus/cli.py
@@ -304,6 +304,25 @@ def _make_run_dir(base_dir: str) -> str:
     return str(run_dir)
 
 
+def _resolve_run_output_dir(base_dir: str, no_timestamp: bool) -> str:
+    """Pick the run's output directory: flat when ``no_timestamp``, else timestamped.
+
+    ``--no-timestamp`` (the CI / composite-action use case) writes reports
+    directly into ``base_dir`` so downstream tooling can read fixed paths
+    like ``<output_dir>/container-scan.json``. Without it, container scans
+    landed in ``<base_dir>/<timestamp>/`` (plus a ``latest`` symlink) and
+    the composite action — which reads from the output-dir root — found
+    nothing to parse or aggregate.
+
+    The default (timestamped subdirectory + ``latest`` symlink) is kept
+    for interactive local runs so prior results are never overwritten.
+    """
+    if no_timestamp:
+        Path(base_dir).mkdir(parents=True, exist_ok=True)
+        return base_dir
+    return _make_run_dir(base_dir)
+
+
 def _build_common_parent() -> argparse.ArgumentParser:
     """Flags shared across every subcommand.
 
@@ -1721,11 +1740,9 @@ def _cmd_source_scan(args: argparse.Namespace) -> int:
 
     # Initialize output directory — timestamped subdirectory by default,
     # flat directory when --no-timestamp is set (CI/action use case).
-    if getattr(args, "no_timestamp", False):
-        output_dir = config.reporting.output_dir
-        Path(output_dir).mkdir(parents=True, exist_ok=True)
-    else:
-        output_dir = _make_run_dir(config.reporting.output_dir)
+    output_dir = _resolve_run_output_dir(
+        config.reporting.output_dir, getattr(args, "no_timestamp", False),
+    )
     config.reporting.output_dir = output_dir
     log = get_logger(
         "argus",
@@ -2326,7 +2343,13 @@ def _cmd_container_scan(
 
     config = container_config
     base_dir = args.output_dir or config.get("output_dir", "./argus-results")
-    output_dir = _make_run_dir(base_dir)
+    # Honor --no-timestamp so the composite action can read container-scan.
+    # {json,md} from the output-dir root. Previously this path always nested
+    # under <output_dir>/<timestamp>/, so the action found nothing to parse
+    # or aggregate. See _resolve_run_output_dir / the generic scan path.
+    output_dir = _resolve_run_output_dir(
+        base_dir, getattr(args, "no_timestamp", False),
+    )
     formats = args.formats or ["terminal", "markdown"]
 
     # Now that we know the output dir, re-attach the logger's file

--- a/argus/container/scanner.py
+++ b/argus/container/scanner.py
@@ -801,6 +801,92 @@ def _container_vol_args(
     return args
 
 
+# Where the host's Docker config is mounted inside a container-mode
+# sub-scanner. Trivy and Grype (via stereoscope) both honor DOCKER_CONFIG,
+# so pointing it at the mount makes a prior `docker login` reach the
+# scanner regardless of the scanner image's home directory.
+_CONTAINER_DOCKER_CONFIG = "/tmp/.docker"
+
+
+def _docker_login_mount_args(tmp_path: Path, local: bool) -> list[str]:
+    """Mount host ``docker login`` credentials into a container-mode sub-scanner.
+
+    The Docker-fallback path runs trivy/grype/syft inside their *own*
+    container, which by default sees neither the host's
+    ``~/.docker/config.json`` nor any host env vars. When a consumer
+    authenticates with the common ``aws ecr get-login-password | docker
+    login`` pattern (rather than passing ``registry_username`` /
+    ``registry_auth`` to Argus), those credentials never reach the
+    scanner and a private-registry pull fails with ``401 Unauthorized``
+    even though the host is fully authenticated — the most common
+    real-world failure for CI consumers of the composite action.
+
+    This bridges that gap: it materializes a *sanitized* copy of the host
+    Docker config under ``tmp_path`` containing only the ``auths`` entries
+    that carry inline credentials, then mounts it read-only and points
+    ``DOCKER_CONFIG`` at it. Explicit ``registry_auth`` creds (forwarded
+    as ``-e`` env vars) still take precedence when both are present.
+
+    The sanitization is deliberate: ``credsStore`` / ``credHelpers`` and
+    helper-backed ``auths`` entries are dropped, because the credential
+    helper binary they name (``docker-credential-ecr-login``,
+    ``docker-credential-desktop``, …) does not exist inside the scanner
+    image — mounting them verbatim would make the scanner try to exec a
+    missing helper and fail. Inline ``auth`` / ``identitytoken`` entries
+    (what ``docker login`` writes on a CI runner) are kept.
+
+    Returns ``[]`` — i.e. no behavior change — for local-image scans
+    (those read the docker daemon over the mounted socket, not the
+    registry), when no usable host config exists (anonymous public scans),
+    or when the config can't be read/parsed.
+    """
+    if local:
+        return []
+
+    config_dir = os.environ.get("DOCKER_CONFIG") or os.path.join(
+        os.path.expanduser("~"), ".docker",
+    )
+    src = os.path.join(config_dir, "config.json")
+    if not os.path.isfile(src):
+        return []
+
+    try:
+        with open(src, encoding="utf-8") as fh:
+            cfg = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.debug("skipping docker-login mount: cannot read %s (%s)", src, exc)
+        return []
+
+    auths = cfg.get("auths")
+    if not isinstance(auths, dict):
+        return []
+
+    usable = {
+        registry: entry
+        for registry, entry in auths.items()
+        if isinstance(entry, dict) and (entry.get("auth") or entry.get("identitytoken"))
+    }
+    if not usable:
+        # Only helper-backed entries (credsStore/credHelpers) — nothing the
+        # scanner container could use without the (absent) helper binary.
+        return []
+
+    dest_dir = tmp_path / ".docker"
+    try:
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        (dest_dir / "config.json").write_text(
+            json.dumps({"auths": usable}), encoding="utf-8",
+        )
+    except OSError as exc:
+        logger.debug("skipping docker-login mount: cannot stage config (%s)", exc)
+        return []
+
+    return [
+        "-v", f"{dest_dir}:{_CONTAINER_DOCKER_CONFIG}:ro",
+        "-e", f"DOCKER_CONFIG={_CONTAINER_DOCKER_CONFIG}",
+    ]
+
+
 def _validate_scanner_output(
     scanner_name: str,
     output_file: Path,
@@ -928,12 +1014,18 @@ def _run_trivy(
         # Run actual scan with --skip-db-update (DB already warm). Cred
         # flags go on the scan step only; DB download pulls from public
         # ghcr.io and doesn't need (or use) registry auth.
-        cmd = [rt, "run", "--rm"] + _docker_env_flags(auth_env) + vol_args + [
-            image,
-            "image", "--format", "json",
-            "--output", "/output/trivy-results.json",
-            "--skip-db-update",
-        ]
+        cmd = (
+            [rt, "run", "--rm"]
+            + _docker_env_flags(auth_env)
+            + _docker_login_mount_args(tmp_path, local)
+            + vol_args
+            + [
+                image,
+                "image", "--format", "json",
+                "--output", "/output/trivy-results.json",
+                "--skip-db-update",
+            ]
+        )
         if not local:
             cmd.extend(["--image-src", "remote"])
         cmd.append(image_ref)
@@ -1059,11 +1151,17 @@ def _run_grype(
 
         # Cred flags on the scan step only — the DB update pulls from
         # public sources and ignores registry auth.
-        cmd = [rt, "run", "--rm"] + _docker_env_flags(auth_env) + vol_args + [
-            image, grype_target,
-            "-o", "json",
-            "--file", "/output/grype-results.json",
-        ]
+        cmd = (
+            [rt, "run", "--rm"]
+            + _docker_env_flags(auth_env)
+            + _docker_login_mount_args(tmp_path, local)
+            + vol_args
+            + [
+                image, grype_target,
+                "-o", "json",
+                "--file", "/output/grype-results.json",
+            ]
+        )
     else:
         cmd = [
             "grype", grype_target,
@@ -1139,12 +1237,18 @@ def _run_syft(
         rt = container_runtime.runtime_cmd()
         # Syft needs docker.sock to read local images
         vol_args = _container_vol_args(tmp_path, "syft", mount_docker_sock=True)
-        cmd = [rt, "run", "--rm"] + _docker_env_flags(auth_env) + vol_args + [
-            image,
-            image_ref,
-            "-o", "cyclonedx-json",
-            "--file", "/output/syft-sbom.json",
-        ]
+        cmd = (
+            [rt, "run", "--rm"]
+            + _docker_env_flags(auth_env)
+            + _docker_login_mount_args(tmp_path, local)
+            + vol_args
+            + [
+                image,
+                image_ref,
+                "-o", "cyclonedx-json",
+                "--file", "/output/syft-sbom.json",
+            ]
+        )
     else:
         cmd = [
             "syft", image_ref,

--- a/argus/tests/test_cli_container.py
+++ b/argus/tests/test_cli_container.py
@@ -2,6 +2,7 @@
 
 import argparse
 import json
+from pathlib import Path
 
 import pytest
 
@@ -11,6 +12,7 @@ from argus.cli import (
     _load_container_config,
     _print_container_terminal,
     _print_dast_terminal,
+    _resolve_run_output_dir,
     _write_container_json,
     _write_dast_json,
     _write_dast_markdown,
@@ -198,6 +200,34 @@ class TestIsDastLifecycle:
     def test_returns_false_without_lifecycle_flags(self):
         args = _base_scan_namespace()
         assert _is_dast_lifecycle(args) is False
+
+
+class TestResolveRunOutputDir:
+    """``_resolve_run_output_dir`` — flat vs timestamped output layout.
+
+    The flat layout is what lets the composite action find
+    ``<output_dir>/container-scan.{json,md}`` and aggregate container
+    results; the timestamped layout is the interactive-local default.
+    """
+
+    def test_no_timestamp_writes_flat(self, tmp_path):
+        base = tmp_path / "reports"
+        out = _resolve_run_output_dir(str(base), no_timestamp=True)
+        # Output dir IS the base dir — no timestamped subdir, no symlink.
+        assert out == str(base)
+        assert base.is_dir()
+        assert not (base / "latest").exists()
+        assert list(base.iterdir()) == []
+
+    def test_timestamped_by_default(self, tmp_path):
+        base = tmp_path / "reports"
+        out = _resolve_run_output_dir(str(base), no_timestamp=False)
+        # Output dir is a timestamped subdirectory under base, and a
+        # 'latest' pointer is created alongside it.
+        assert out != str(base)
+        assert Path(out).is_dir()
+        assert Path(out).parent == base
+        assert (base / "latest").exists()
 
 
 # =====================================================================

--- a/argus/tests/test_container_scanner_runners.py
+++ b/argus/tests/test_container_scanner_runners.py
@@ -1115,6 +1115,13 @@ class TestRunTrivyForwardsCredsInContainer:
 
     def test_no_creds_no_e_flags(self, tmp_path, monkeypatch):
         _force_container_path(monkeypatch, "trivy")
+        # Isolate from any host `docker login` so this exercises the genuine
+        # "no auth anywhere" case. Point DOCKER_CONFIG at an empty dir (no
+        # config.json) so _docker_login_mount_args is inert — otherwise the
+        # runner's ambient ~/.docker/config.json would (correctly) inject a
+        # docker-config mount + `-e DOCKER_CONFIG`, which is what
+        # test_no_config_creds_but_host_login_mounts_config covers.
+        monkeypatch.setenv("DOCKER_CONFIG", str(tmp_path / "empty-docker"))
         intercepted: list[list[str]] = []
 
         def fake_run(cmd, **_kwargs):
@@ -1134,6 +1141,39 @@ class TestRunTrivyForwardsCredsInContainer:
         # constrained CI might reject.
         scan_cmd = intercepted[-1]
         assert "-e" not in scan_cmd
+
+    def test_no_config_creds_but_host_login_mounts_config(self, tmp_path, monkeypatch):
+        # The ECR scenario: the user passes no registry_username/registry_auth
+        # to Argus and instead authenticates the host with `docker login`.
+        # Those credentials must still reach trivy inside the fallback
+        # container — via a read-only mount of the (sanitized) host config
+        # with DOCKER_CONFIG pointed at it.
+        _force_container_path(monkeypatch, "trivy")
+        host_docker = tmp_path / "hostdocker"
+        host_docker.mkdir()
+        (host_docker / "config.json").write_text(
+            json.dumps({"auths": {"123.dkr.ecr.us-east-1.amazonaws.com": {"auth": "QVdTOnRvaw=="}}}),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("DOCKER_CONFIG", str(host_docker))
+        intercepted: list[list[str]] = []
+
+        def fake_run(cmd, **_kwargs):
+            intercepted.append(list(cmd))
+            (tmp_path / "trivy-results.json").write_text('{"Results": []}')
+            return _completed(returncode=0)
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+
+        _run_trivy(
+            "123.dkr.ecr.us-east-1.amazonaws.com/app:latest",
+            tmp_path, local=False, config=None,
+        )
+
+        scan_cmd = intercepted[-1]
+        joined = " ".join(scan_cmd)
+        assert f"DOCKER_CONFIG={_CONTAINER_DOCKER_CONFIG}" in scan_cmd
+        assert f":{_CONTAINER_DOCKER_CONFIG}:ro" in joined
 
     def test_local_built_image_skips_creds_even_if_configured(self, tmp_path, monkeypatch):
         # A locally-built image doesn't pull from any registry; the

--- a/argus/tests/test_container_scanner_runners.py
+++ b/argus/tests/test_container_scanner_runners.py
@@ -1228,6 +1228,39 @@ class TestRunGrypeForwardsCredsInContainer:
         assert "-e GRYPE_REGISTRY_AUTH_USERNAME=alice" in joined
         assert "-e GRYPE_REGISTRY_AUTH_PASSWORD=s3cret" in joined
 
+    def test_no_config_creds_but_host_login_mounts_config(self, tmp_path, monkeypatch):
+        # Same ECR scenario as the trivy case: no registry_* in argus.yml,
+        # the host authenticated with `docker login`. Grype (via
+        # stereoscope) honors DOCKER_CONFIG, so the sanitized host config
+        # must be mounted read-only into the fallback container.
+        _force_container_path(monkeypatch, "grype")
+        host_docker = tmp_path / "hostdocker"
+        host_docker.mkdir()
+        (host_docker / "config.json").write_text(
+            json.dumps({"auths": {"123.dkr.ecr.us-east-1.amazonaws.com": {"auth": "QVdTOnRvaw=="}}}),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("DOCKER_CONFIG", str(host_docker))
+        intercepted: list[list[str]] = []
+
+        def fake_run(cmd, **_kwargs):
+            intercepted.append(list(cmd))
+            (tmp_path / "grype-results.json").write_text('{"matches": []}')
+            return _completed(returncode=0)
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+
+        _run_grype(
+            "123.dkr.ecr.us-east-1.amazonaws.com/app:latest",
+            tmp_path, local=False, config=None,
+        )
+
+        # DB update runs first (no creds); the mount goes on the scan step.
+        scan_cmd = intercepted[-1]
+        joined = " ".join(scan_cmd)
+        assert f"DOCKER_CONFIG={_CONTAINER_DOCKER_CONFIG}" in scan_cmd
+        assert f":{_CONTAINER_DOCKER_CONFIG}:ro" in joined
+
 
 class TestRunSyftForwardsCredsInContainer:
     """Syft uses its own env-var names."""
@@ -1255,6 +1288,36 @@ class TestRunSyftForwardsCredsInContainer:
         joined = " ".join(intercepted[0])
         assert "-e SYFT_REGISTRY_AUTH_USERNAME=alice" in joined
         assert "-e SYFT_REGISTRY_AUTH_PASSWORD=s3cret" in joined
+
+    def test_no_config_creds_but_host_login_mounts_config(self, tmp_path, monkeypatch):
+        # SBOM generation over a private registry: a host `docker login`
+        # (no registry_* in argus.yml) must reach syft inside the fallback
+        # container via the mounted, sanitized DOCKER_CONFIG.
+        _force_container_path(monkeypatch, "syft")
+        host_docker = tmp_path / "hostdocker"
+        host_docker.mkdir()
+        (host_docker / "config.json").write_text(
+            json.dumps({"auths": {"123.dkr.ecr.us-east-1.amazonaws.com": {"auth": "QVdTOnRvaw=="}}}),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("DOCKER_CONFIG", str(host_docker))
+        intercepted: list[list[str]] = []
+
+        def fake_run(cmd, **_kwargs):
+            intercepted.append(list(cmd))
+            return _completed(returncode=0)
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+
+        _run_syft(
+            "123.dkr.ecr.us-east-1.amazonaws.com/app:latest",
+            tmp_path, local=False, config=None,
+        )
+
+        scan_cmd = intercepted[-1]
+        joined = " ".join(scan_cmd)
+        assert f"DOCKER_CONFIG={_CONTAINER_DOCKER_CONFIG}" in scan_cmd
+        assert f":{_CONTAINER_DOCKER_CONFIG}:ro" in joined
 
 
 class TestLocalBinaryPathReceivesCredsViaEnv:

--- a/argus/tests/test_container_scanner_runners.py
+++ b/argus/tests/test_container_scanner_runners.py
@@ -18,8 +18,10 @@ from unittest.mock import patch
 import pytest
 
 from argus.container.scanner import (
+    _CONTAINER_DOCKER_CONFIG,
     RegistryAuthError,
     _docker_env_flags,
+    _docker_login_mount_args,
     _is_path_component_prefix,
     _normalize_image_ref,
     _redact_cmd_for_log,
@@ -931,6 +933,77 @@ class TestSubprocessEnv:
         assert env is not None
         assert env["TRIVY_USERNAME"] == "alice"
         assert env["PATH"] == "/usr/bin"  # host env preserved
+
+
+class TestDockerLoginMountArgs:
+    """``_docker_login_mount_args`` bridges host ``docker login`` creds into
+    the Docker-fallback scanner container (the private-ECR fix)."""
+
+    def _write_host_config(self, monkeypatch, tmp_path, payload):
+        """Point DOCKER_CONFIG at a fresh dir holding the given config.json."""
+        host_dir = tmp_path / "hostdocker"
+        host_dir.mkdir()
+        (host_dir / "config.json").write_text(json.dumps(payload), encoding="utf-8")
+        monkeypatch.setenv("DOCKER_CONFIG", str(host_dir))
+        return host_dir
+
+    def test_local_scan_never_mounts(self, monkeypatch, tmp_path):
+        # Local-image scans read the docker daemon over the socket, not
+        # the registry — no credentials to bridge.
+        self._write_host_config(
+            monkeypatch, tmp_path,
+            {"auths": {"123.dkr.ecr.us-east-1.amazonaws.com": {"auth": "QVdTOnRvaw=="}}},
+        )
+        assert _docker_login_mount_args(tmp_path, local=True) == []
+
+    def test_no_host_config_yields_no_mount(self, monkeypatch, tmp_path):
+        # Anonymous public scans (the default) must be completely
+        # unaffected — no host login, no mount, no behavior change.
+        monkeypatch.setenv("DOCKER_CONFIG", str(tmp_path / "does-not-exist"))
+        assert _docker_login_mount_args(tmp_path, local=False) == []
+
+    def test_inline_auth_is_mounted_and_sanitized(self, monkeypatch, tmp_path):
+        # The ECR case: `aws ecr get-login-password | docker login` writes
+        # an inline base64 auth. It must reach the scanner, with the
+        # unusable credsStore stripped out.
+        self._write_host_config(monkeypatch, tmp_path, {
+            "auths": {"123.dkr.ecr.us-east-1.amazonaws.com": {"auth": "QVdTOnRvaw=="}},
+            "credsStore": "ecr-login",
+        })
+        args = _docker_login_mount_args(tmp_path, local=False)
+
+        # Mount + DOCKER_CONFIG env pointed at the in-container path.
+        assert "-v" in args and "-e" in args
+        assert f"DOCKER_CONFIG={_CONTAINER_DOCKER_CONFIG}" in args
+        mount = args[args.index("-v") + 1]
+        host_side, container_side, mode = mount.rsplit(":", 2)
+        assert container_side == _CONTAINER_DOCKER_CONFIG
+        assert mode == "ro"
+
+        # Staged config keeps the inline auth and drops the helper directive.
+        staged = json.loads(
+            (tmp_path / ".docker" / "config.json").read_text(encoding="utf-8")
+        )
+        assert staged == {
+            "auths": {"123.dkr.ecr.us-east-1.amazonaws.com": {"auth": "QVdTOnRvaw=="}}
+        }
+        assert "credsStore" not in staged
+
+    def test_helper_only_config_yields_no_mount(self, monkeypatch, tmp_path):
+        # If every entry is helper-backed (no inline auth), there's nothing
+        # the scanner container could use without the absent helper binary.
+        self._write_host_config(monkeypatch, tmp_path, {
+            "auths": {"123.dkr.ecr.us-east-1.amazonaws.com": {}},
+            "credsStore": "ecr-login",
+        })
+        assert _docker_login_mount_args(tmp_path, local=False) == []
+
+    def test_malformed_config_is_skipped(self, monkeypatch, tmp_path):
+        host_dir = tmp_path / "hostdocker"
+        host_dir.mkdir()
+        (host_dir / "config.json").write_text("{not json", encoding="utf-8")
+        monkeypatch.setenv("DOCKER_CONFIG", str(host_dir))
+        assert _docker_login_mount_args(tmp_path, local=False) == []
 
 
 class TestRedactCmdForLog:

--- a/docs/troubleshooting/docker.md
+++ b/docs/troubleshooting/docker.md
@@ -259,6 +259,29 @@ back to a broader entry's creds (no silent privilege broadening). Run
 with `--verbose` to see the redacted `docker run` invocation argus
 constructs — confirms which env vars were forwarded.
 
+**Fix — private image 401s when you authenticated with `docker login`
+(e.g. AWS ECR).** If you don't pass `registry_username` / `registry_auth`
+to Argus but instead authenticate the host the usual CI way:
+
+```bash
+aws ecr get-login-password --region us-east-1 \
+  | docker login --username AWS --password-stdin <acct>.dkr.ecr.us-east-1.amazonaws.com
+```
+
+…those credentials live in the host `~/.docker/config.json`, which a
+sub-scanner running on the Docker-fallback path (no trivy/grype binary on
+the runner) cannot see — so the pull falls back to anonymous and the
+registry returns `401 Unauthorized`. Argus bridges this automatically:
+it stages a sanitized copy of the host Docker config (inline `auths`
+only — `credsStore` / `credHelpers` are dropped because the helper
+binary they name isn't present inside the scanner image) and mounts it
+read-only into the sub-scanner container with `DOCKER_CONFIG` pointed at
+the mount. No argus.yml change is required; a prior `docker login` is
+enough. Two equivalent alternatives: install trivy + grype as local
+binaries on the runner (local binaries read `~/.docker/config.json`
+directly), or configure `registry_auth` so creds are forwarded as `-e`
+env vars regardless of `docker login`.
+
 Bisect before blaming argus: `docker pull <ref>` outside argus with the
 same creds proves whether your account has access. If `docker pull`
 fails too, the issue is creds or registry permissions, not the scan


### PR DESCRIPTION
## Description
Fix two bugs that broke `argus scan container` against **private registries (e.g. AWS ECR) in CI**, where consumers authenticate the host with `docker login` rather than passing credentials to Argus.

## Changes Made
- [x] Modified existing scanner/workflow
- [x] Updated documentation
- [x] Fixed bug

### Details
**1. Authenticate to private registries via host `docker login` (`argus/container/scanner.py`)**

The container engine only forwarded *explicit* `registry_username` / `registry_auth` config into the trivy/grype/syft sub-scanner containers (as `-e` env vars). On the Docker-fallback path (no scanner binary on the runner, so each tool runs inside its own container), the very common CI pattern —

```bash
aws ecr get-login-password | docker login <acct>.dkr.ecr.<region>.amazonaws.com
```

— left credentials in the host `~/.docker/config.json`, which the sub-scanner container cannot see. The pull fell back to anonymous and the registry returned **401 Unauthorized**, even though the host was fully authenticated.

New `_docker_login_mount_args()` bridges the gap: it stages a **sanitized** copy of the host Docker config (inline `auths` only — `credsStore` / `credHelpers` are dropped because the helper binary they name, e.g. `docker-credential-ecr-login`, doesn't exist inside the scanner image) and mounts it read-only into the trivy/grype/syft containers with `DOCKER_CONFIG` pointed at the mount. Explicit `registry_auth` env vars still take precedence; local-image scans (read over `docker.sock`) and anonymous public scans are unaffected.

**2. Honor `--no-timestamp` for container scans (`argus/cli.py`)**

`_cmd_container_scan` always wrote reports to a timestamped subdirectory (`<output_dir>/<ts>/` + a `latest` symlink), ignoring `--no-timestamp`. The `scanner-container` composite action passes `--no-timestamp` and then reads `container-scan.{json,md}` from the output-dir **root** — so it found nothing, reported zero counts, uploaded no summary artifact, and the aggregated `security-summary` silently omitted every container scan. Extracted the flat-vs-timestamped decision into `_resolve_run_output_dir()` and shared it with the generic scan path (which already honored the flag) so the two can't drift again.

**Breaking changes:** none. Both changes are additive / behavior-preserving for existing flows.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed

### Test Results
New coverage:
- `TestDockerLoginMountArgs` — local-scan skip, no-config skip, inline-auth sanitization (drops `credsStore`), helper-only skip, malformed-config skip.
- `TestResolveRunOutputDir` — flat output under `--no-timestamp`, timestamped + `latest` symlink by default.
- `test_no_config_creds_but_host_login_mounts_config` — end-to-end check that a host `docker login` (no explicit creds in `argus.yml`) is bridged into the fallback container. Added for all three sub-scanners: `_run_trivy`, `_run_grype`, and `_run_syft`.
- `test_no_creds_no_e_flags` now pins `DOCKER_CONFIG` to an empty dir so it deterministically exercises the genuine "no auth anywhere" case. It previously relied on the runner having no ambient `~/.docker/config.json`; the new `_docker_login_mount_args` (correctly) injects a config mount whenever a host login exists, so the test broke on CI runners that ship a `config.json`. Fixed in `e22239f`.

```
argus/tests/test_cli_container.py + test_container_scanner_runners.py: 124 passed
```

CI is green on all four Python versions (3.11–3.14) and `codecov/patch`. The only remaining repo failures are pre-existing and environmental (missing optional deps `mcp` / `slugify` in `test_mcp_architecture_resource.py`, plus unrelated `preflight`/`tool_config` fixtures) — confirmed identical on `main`.

> Note: end-to-end validation against a live private ECR registry is best confirmed by a consumer CI run (the unit tests cover the mount-arg construction and output-dir layout, not a real registry pull).

## Security Considerations
- [x] Security enhancement

### Security Details
- Credentials are passed into the container via a read-only bind mount of a **sanitized** config (helper-backed entries stripped), not via argv — keeping secrets out of the host process list.
- The staged config is written under the per-run temp dir, which is ephemeral and not part of the uploaded report artifacts.
- No broadening of the auth surface: when no host login or usable inline `auth` exists, the helper returns `[]` and behavior is unchanged (anonymous pull).

## AI Context Updates (.ai/)
- [x] `.ai/errors.yaml` updated (new `401 Unauthorized` container-scanning entry with root cause + three remediations)
- [x] N/A for architecture/workflows/decisions — no structural or command changes

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (`docs/troubleshooting/docker.md`)
- [ ] Changelog updated (release-it managed — left to the release process)
- [x] All tests pass (excluding pre-existing environmental failures noted above)
- [ ] Reviewed by at least one maintainer

## Related Issues
N/A

