### PR TITLE
feat(browser): plugin seam for registering extra routes (extension point)

### DIFF
--- a/.ai/architecture.yaml
+++ b/.ai/architecture.yaml
@@ -186,7 +186,10 @@ components:
         source scan). A persistent sticky scan-context bar (project / commit / scan time / finding count, built by
         _context_bar + threaded through _base_context) sits under the header on the dashboard / findings / log
         views; omitted on the picker / diff where no single scan is in scope (B0 IA — top-nav + context bar chosen
-        over a left sidebar). See ADR-031.'
+        over a left sidebar). Plugin seam: create_app discovers the
+        ``argus.viewers.browser_plugins`` entry-point group and lets each registered ``register(app)`` callable add
+        routes/capabilities (mirrors argus.reporters; OSS ships none, a bad plugin is logged + skipped); it exposes
+        app.state.load_scan + render_report_html as the helper surface plugins build on. See ADR-031.'
       scanners/: 'Scanner modules implementing Scanner protocol (SCANNER_REGISTRY includes linters via
         auto-merge). The container scanner orchestrates five sub-scanners on every run: trivy (CVE scan),
         grype (CVE scan, deduplicated against trivy), syft (SBOM), exposure (declared-port surface from
@@ -862,7 +865,10 @@ docsite:
         source scan). A persistent sticky scan-context bar (project / commit / scan time / finding count, built by
         _context_bar + threaded through _base_context) sits under the header on the dashboard / findings / log
         views; omitted on the picker / diff where no single scan is in scope (B0 IA — top-nav + context bar chosen
-        over a left sidebar). See ADR-031.'
+        over a left sidebar). Plugin seam: create_app discovers the
+        ``argus.viewers.browser_plugins`` entry-point group and lets each registered ``register(app)`` callable add
+        routes/capabilities (mirrors argus.reporters; OSS ships none, a bad plugin is logged + skipped); it exposes
+        app.state.load_scan + render_report_html as the helper surface plugins build on. See ADR-031.'
       scanners/: 'Scanner modules implementing Scanner protocol (SCANNER_REGISTRY includes linters via
         auto-merge). The container scanner orchestrates five sub-scanners on every run: trivy (CVE scan),
         grype (CVE scan, deduplicated against trivy), syft (SBOM), exposure (declared-port surface from

--- a/argus/tests/viewers/browser/test_plugin_seam.py
+++ b/argus/tests/viewers/browser/test_plugin_seam.py
@@ -1,0 +1,87 @@
+"""Browser viewer plugin seam — the open-core extension point.
+
+Lets installed packages (e.g. Argus Enterprise's server-side PDF report)
+register extra routes via the ``argus.viewers.browser_plugins`` entry-point
+group, without the OSS core depending on them. Tests inject plugins directly
+(``browser_plugins=``) to avoid needing a real installed package.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient   # noqa: E402
+
+from argus.viewers.browser.app import create_app   # noqa: E402
+
+
+def _sca_payload():
+    return {
+        "results": [{
+            "scanner": "osv",
+            "findings": [{
+                "id": "CVE-2021-44228", "severity": "high", "title": "Log4Shell",
+                "cve": "CVE-2021-44228", "scanner": "osv", "metadata": {},
+            }],
+            "raw_report": None, "sarif_report": None, "metadata": {},
+            "critical_count": 0, "high_count": 1, "medium_count": 0,
+            "low_count": 0, "total_count": 1,
+        }],
+    }
+
+
+class TestPluginSeam:
+    def test_no_plugins_by_default_but_helpers_exposed(self, tmp_path):
+        # OSS ships no plugins; the app still builds and exposes the helper
+        # surface that plugins (the PDF report) build on.
+        app = create_app(root=str(tmp_path))
+        assert callable(app.state.load_scan)
+        assert callable(app.state.render_report_html)
+
+    def test_injected_plugin_registers_a_route(self, tmp_path):
+        def register(app):
+            @app.get("/__plugin_probe")
+            def probe():
+                return {"ok": True, "root": str(app.state.root)}
+
+        app = create_app(root=str(tmp_path), browser_plugins=[register])
+        resp = TestClient(app).get("/__plugin_probe")
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+
+    def test_broken_plugin_is_skipped_and_others_still_load(self, tmp_path):
+        def bad(app):
+            raise RuntimeError("boom")
+
+        def good(app):
+            @app.get("/__ok")
+            def ok():
+                return {"ok": True}
+
+        # A raising plugin must not crash app creation, and later plugins still
+        # register — one bad plugin can't take down the viewer.
+        app = create_app(root=str(tmp_path), browser_plugins=[bad, good])
+        assert TestClient(app).get("/__ok").status_code == 200
+
+    def test_plugin_can_build_a_report_via_exposed_helpers(self, tmp_path):
+        # Proves the server-side PDF plugin's pattern works end-to-end: resolve
+        # the scan with app.state.load_scan, render with render_report_html.
+        (tmp_path / "argus-results.json").write_text(json.dumps(_sca_payload()))
+
+        def register(app):
+            @app.get("/__report_len")
+            def report_len(scan: str | None = None):
+                summary, resolved, error = app.state.load_scan(scan)
+                if summary is None:
+                    return {"len": 0, "error": error}
+                html = app.state.render_report_html(summary, resolved, pdf=True)
+                return {"len": len(html)}
+
+        app = create_app(root=str(tmp_path), browser_plugins=[register])
+        resp = TestClient(app).get("/__report_len")
+        assert resp.status_code == 200
+        assert resp.json()["len"] > 0

--- a/argus/viewers/browser/app.py
+++ b/argus/viewers/browser/app.py
@@ -237,11 +237,60 @@ def _context_bar(scan_summary, resolved: Path | None) -> dict | None:
     }
 
 
+# Plugin seam (open-core extension point). Third-party / enterprise packages
+# register a ``register(app)`` callable under this entry-point group to add
+# routes or capabilities to the browser viewer (e.g. a server-side PDF report).
+# Mirrors the ``argus.reporters`` entry-point pattern. The OSS viewer ships no
+# plugins, so this is a no-op by default.
+_BROWSER_PLUGIN_GROUP = "argus.viewers.browser_plugins"
+
+
+def _discover_browser_plugins() -> list:
+    """Load ``register(app)`` callables from the browser-plugin entry-point group.
+
+    A broken or missing entry point is logged and skipped — discovery never
+    raises, so a bad plugin can't stop the viewer from starting.
+    """
+    from importlib.metadata import entry_points
+
+    plugins: list = []
+    try:
+        eps = entry_points(group=_BROWSER_PLUGIN_GROUP)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("browser plugin discovery failed: %s", exc)
+        return plugins
+    for ep in eps:
+        try:
+            plugins.append(ep.load())
+        except Exception as exc:
+            logger.warning("browser plugin '%s' failed to load: %s", ep.name, exc)
+    return plugins
+
+
+def _mount_browser_plugins(app: FastAPI, plugins: list | None) -> None:
+    """Let installed plugins register extra routes/capabilities on ``app``.
+
+    ``plugins`` is a list of ``register(app)`` callables; ``None`` discovers
+    them via the ``argus.viewers.browser_plugins`` entry-point group. A plugin
+    that raises is logged and skipped so one bad plugin can't take down the
+    viewer. Plugins read ``app.state`` (notably ``root``, ``load_scan``,
+    ``render_report_html``) and add routes via the FastAPI ``app``.
+    """
+    if plugins is None:
+        plugins = _discover_browser_plugins()
+    for register in plugins:
+        try:
+            register(app)
+        except Exception as exc:
+            logger.warning("browser plugin failed to register: %s", exc)
+
+
 def create_app(
     root: str | None = None,
     *,
     enrich: bool | None = None,
     enrichment_service: object | None = None,
+    browser_plugins: list | None = None,
 ) -> FastAPI:
     """Build the FastAPI app, wire templates / static, register routes.
 
@@ -250,6 +299,11 @@ def create_app(
     no-egress posture: only when enabled does the server reach the EPSS/KEV
     APIs or scan local source. ``None`` reads ``ARGUS_VIEW_ENRICH`` from the
     environment. ``enrichment_service`` is injectable for tests.
+
+    ``browser_plugins`` is the extension seam: a list of ``register(app)``
+    callables (``None`` discovers them via the ``argus.viewers.browser_plugins``
+    entry-point group). OSS ships none; enterprise / third-party packages use it
+    to add routes (e.g. the server-side PDF report). Injectable for tests.
     """
     app = FastAPI(
         title="Argus",
@@ -1016,6 +1070,14 @@ def create_app(
                 "scan_label": None,
             },
         )
+
+    # Plugin seam: expose the scan-resolution + report-render helpers that
+    # extension packages (e.g. the Argus Enterprise server-side PDF report)
+    # build on, then let installed plugins register their routes. OSS ships no
+    # plugins, so this is a no-op by default.
+    app.state.load_scan = _load_scan
+    app.state.render_report_html = _render_report_html
+    _mount_browser_plugins(app, browser_plugins)
 
     return app
 


### PR DESCRIPTION
## Description
Adds an **additive plugin seam** to the browser viewer so installed packages can register extra routes/capabilities without the OSS core depending on them — mirroring the established `argus.reporters` entry-point pattern (ADR-023). This is the open-core extension point that a future out-of-tree **server-side PDF report** plugs into; the OSS viewer keeps the HTML `/report` view and browser print-to-PDF.

## Changes Made
- [x] Modified existing scanner/workflow (browser viewer)
- [x] Other (new extension entry-point group)

### Details
- **`create_app`** discovers the `argus.viewers.browser_plugins` entry-point group; each plugin is a `register(app)` callable that adds routes. New `browser_plugins=` kwarg injects them for tests.
- A plugin that fails to **load** or **raises** during registration is logged and skipped — one bad plugin can never take down the viewer (`_discover_browser_plugins` / `_mount_browser_plugins`).
- Exposes **`app.state.load_scan`** + **`app.state.render_report_html`** as the documented helper surface plugins build on (resolve a scan → render the report HTML → hand to a PDF engine).
- **OSS ships no plugins**, so this is a no-op by default and every existing route is unchanged.

## Testing
- [x] Unit tests added/updated
### Test Results
New `test_plugin_seam.py` (4): no-op default + helpers exposed, injected plugin registers a route, a broken plugin is skipped while others still load, and an end-to-end report build through the exposed helpers (the PDF plugin's exact pattern). Full browser suite **197 passed** (the 3 failures are the known pre-existing local-only fastapi/starlette skew, green in CI).

## Security Considerations
- [x] No security impact — read-only / localhost posture unchanged; discovery is defensive (never fatal). OSS ships no plugins.

## AI Context Updates (.ai/)
- [x] `.ai/architecture.yaml` updated (the `argus.viewers.browser_plugins` seam + exposed helpers), both mirror blocks.

## Checklist
- [x] Code follows project style guidelines
- [x] All tests pass
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Generalizes the `argus.reporters` extension pattern to the browser viewer. Foundation for out-of-tree route plugins. Merges into `feat/tui-explorer-and-scan-runner`.
