### PR TITLE
feat(cli): Console provider seam for bare `argus`

### DIFF
--- a/.ai/architecture.yaml
+++ b/.ai/architecture.yaml
@@ -173,7 +173,9 @@ components:
         and a Ctrl+P command palette (ArgusConsoleCommands) for fuzzy jump-to-action parity with the findings viewer;
         bare ``argus`` opens it in an interactive
         TTY (cli._run_bare_argus), falling back to --help when non-interactive, and ``argus view`` deep-links to
-        the findings viewer.'
+        the findings viewer. An installed Console provider (the ``argus.console_providers`` entry-point group — e.g.
+        Argus Enterprise) takes precedence over the built-in console via cli._discover_console_provider; OSS ships
+        none, so this is the open-core seam for the bare-``argus`` experience (mirrors reporters / browser plugins).'
       viewers/browser/: '`argus view --interface=browser` — FastAPI + Jinja2 web UI, 127.0.0.1 only ([browser]
         extra). Routes include ``/diff?a=<path>&b=<path>`` powered by argus.core.findings_view.diff_scans,
         sharing the bucketing logic with the TUI''s ``D`` keybind. ``/report`` renders the formal vulnerability
@@ -852,7 +854,9 @@ docsite:
         and a Ctrl+P command palette (ArgusConsoleCommands) for fuzzy jump-to-action parity with the findings viewer;
         bare ``argus`` opens it in an interactive
         TTY (cli._run_bare_argus), falling back to --help when non-interactive, and ``argus view`` deep-links to
-        the findings viewer.'
+        the findings viewer. An installed Console provider (the ``argus.console_providers`` entry-point group — e.g.
+        Argus Enterprise) takes precedence over the built-in console via cli._discover_console_provider; OSS ships
+        none, so this is the open-core seam for the bare-``argus`` experience (mirrors reporters / browser plugins).'
       viewers/browser/: '`argus view --interface=browser` — FastAPI + Jinja2 web UI, 127.0.0.1 only ([browser]
         extra). Routes include ``/diff?a=<path>&b=<path>`` powered by argus.core.findings_view.diff_scans,
         sharing the bucketing logic with the TUI''s ``D`` keybind. ``/report`` renders the formal vulnerability

--- a/argus/cli.py
+++ b/argus/cli.py
@@ -628,10 +628,49 @@ def _launch_view(
     return EXIT_ERROR
 
 
+#: Entry-point group through which an external package (e.g. Argus Enterprise)
+#: can supply the bare-``argus`` Console. The open-core seam pattern mirrors
+#: reporters (ADR-023) and the browser-viewer plugin group: OSS ships no
+#: provider, so discovery is a no-op here; an installed provider transparently
+#: takes over the bare-``argus`` experience.
+_CONSOLE_PROVIDER_GROUP = "argus.console_providers"
+
+
+def _discover_console_provider():
+    """Return an installed Console provider callable, or ``None``.
+
+    A provider is a zero-argument callable returning an ``int`` exit code,
+    registered under the :data:`_CONSOLE_PROVIDER_GROUP` entry-point group. The
+    first one found wins and takes precedence over the built-in console. OSS
+    ships none, so this returns ``None`` and the built-in console (or
+    ``--help``) is used. Discovery and load failures are swallowed (logged) so
+    a broken third-party provider can never break bare ``argus``.
+    """
+    import logging
+    from importlib.metadata import entry_points
+
+    log = logging.getLogger(__name__)
+    try:
+        eps = list(entry_points(group=_CONSOLE_PROVIDER_GROUP))
+    except Exception as exc:  # pragma: no cover - defensive
+        log.warning("console provider discovery failed: %s", exc)
+        return None
+    for ep in eps:
+        try:
+            return ep.load()
+        except Exception as exc:
+            log.warning("console provider '%s' failed to load: %s", ep.name, exc)
+    return None
+
+
 def _run_bare_argus(parser: argparse.ArgumentParser) -> int:
     """Handle bare ``argus`` (no subcommand).
 
-    In an interactive terminal, launch the Argus Console (the home TUI).
+    In an interactive terminal, launch the Argus Console (the home TUI). An
+    installed Console provider (e.g. Argus Enterprise, via the
+    ``argus.console_providers`` entry-point group) takes precedence over the
+    built-in console; OSS ships none.
+
     Non-interactive contexts (piped, redirected, CI — no TTY on stdout or
     stdin) keep the previous behaviour and print ``--help`` so scripts and
     pipelines that invoke a bare ``argus`` are unaffected. When the
@@ -640,6 +679,15 @@ def _run_bare_argus(parser: argparse.ArgumentParser) -> int:
     """
     interactive = sys.stdout.isatty() and sys.stdin.isatty()
     if interactive:
+        provider = _discover_console_provider()
+        if provider is not None:
+            try:
+                return provider()
+            except Exception as exc:  # broken provider — fall back to built-in
+                import logging
+                logging.getLogger(__name__).warning(
+                    "console provider failed, falling back to built-in: %s", exc,
+                )
         try:
             from argus.viewers.terminal import ViewerUnavailable, launch_console
             return launch_console()

--- a/argus/tests/test_cli_console.py
+++ b/argus/tests/test_cli_console.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import sys
 
-from argus.cli import _run_bare_argus, EXIT_SUCCESS
+from argus.cli import _discover_console_provider, _run_bare_argus, EXIT_SUCCESS
 from argus.viewers.terminal import ViewerUnavailable
 
 
@@ -74,3 +74,87 @@ def test_missing_terminal_extra_falls_back_to_help(monkeypatch, capsys):
     assert parser.help_calls == 1
     err = capsys.readouterr().err
     assert "terminal" in err.lower()  # install hint surfaced
+
+
+class TestConsoleProviderSeam:
+    """The open-core seam: an installed provider takes over bare ``argus``.
+
+    Mirrors the reporters / browser-plugin entry-point pattern. OSS ships no
+    provider; an external package (Argus Enterprise) supplies one.
+    """
+
+    def test_provider_takes_precedence_over_builtin(self, monkeypatch):
+        _force_tty(monkeypatch, True)
+        parser = _FakeParser()
+        monkeypatch.setattr("argus.cli._discover_console_provider", lambda: (lambda: 7))
+        # The built-in console must NOT run when a provider is present.
+        monkeypatch.setattr(
+            "argus.viewers.terminal.launch_console",
+            lambda *a, **k: (_ for _ in ()).throw(AssertionError("built-in must not run")),
+            raising=False,
+        )
+        assert _run_bare_argus(parser) == 7
+        assert parser.help_calls == 0
+
+    def test_no_provider_falls_back_to_builtin(self, monkeypatch):
+        _force_tty(monkeypatch, True)
+        parser = _FakeParser()
+        monkeypatch.setattr("argus.cli._discover_console_provider", lambda: None)
+        monkeypatch.setattr("argus.viewers.terminal.launch_console", lambda *a, **k: 0, raising=False)
+        assert _run_bare_argus(parser) == 0
+
+    def test_broken_provider_falls_back_to_builtin(self, monkeypatch):
+        _force_tty(monkeypatch, True)
+        parser = _FakeParser()
+
+        def boom():
+            raise RuntimeError("provider exploded")
+
+        monkeypatch.setattr("argus.cli._discover_console_provider", lambda: boom)
+        launched = {"n": 0}
+
+        def fake_launch(results_dir=None):
+            launched["n"] += 1
+            return 0
+
+        monkeypatch.setattr("argus.viewers.terminal.launch_console", fake_launch, raising=False)
+        # A provider that raises must not break bare argus — fall through to built-in.
+        assert _run_bare_argus(parser) == 0
+        assert launched["n"] == 1
+
+    def test_non_interactive_never_consults_provider(self, monkeypatch):
+        _force_tty(monkeypatch, False)
+        parser = _FakeParser()
+        monkeypatch.setattr(
+            "argus.cli._discover_console_provider",
+            lambda: (_ for _ in ()).throw(AssertionError("must not discover without a TTY")),
+        )
+        assert _run_bare_argus(parser) == EXIT_SUCCESS
+        assert parser.help_calls == 1
+
+    def test_discover_returns_none_when_no_providers_registered(self):
+        # OSS registers no provider, so real discovery must yield None.
+        assert _discover_console_provider() is None
+
+    def test_discover_loads_registered_provider(self, monkeypatch):
+        class _FakeEP:
+            name = "console"
+
+            def load(self):
+                return lambda: 0
+
+        monkeypatch.setattr("importlib.metadata.entry_points", lambda group: [_FakeEP()])
+        provider = _discover_console_provider()
+        assert callable(provider)
+        assert provider() == 0
+
+    def test_discover_skips_provider_that_fails_to_load(self, monkeypatch):
+        class _BadEP:
+            name = "broken"
+
+            def load(self):
+                raise ImportError("missing dep")
+
+        monkeypatch.setattr("importlib.metadata.entry_points", lambda group: [_BadEP()])
+        # A provider whose load() raises is skipped, not propagated.
+        assert _discover_console_provider() is None


### PR DESCRIPTION
## Description
Adds an open-core extension seam so an installed package (e.g. **Argus Enterprise**) can supply the bare-`argus` Console without the OSS core depending on it. OSS ships no provider, so behaviour is unchanged.

## Changes Made
- [x] Modified existing scanner/workflow
- [x] Updated documentation
- [x] Other (please specify): CLI open-core plugin seam

### Details
- **`cli._discover_console_provider()`** — discovers a Console provider via the new `argus.console_providers` entry-point group. A provider is a zero-arg callable returning an `int` exit code. Discovery and `ep.load()` failures are swallowed (logged), so a broken third-party provider can never break bare `argus`.
- **`_run_bare_argus()`** — in an interactive TTY, an installed provider takes precedence over the built-in console; if the provider raises, it falls back to the built-in console rather than erroring. Non-interactive (no TTY) behaviour is unchanged: still prints `--help`.
- Mirrors the existing open-core seams: the `argus.reporters` group (ADR-023) and the `argus.viewers.browser_plugins` browser-plugin group (#292).
- **No breaking changes.** OSS registers no provider, so the built-in console still runs exactly as before.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed

### Test Results
`pytest argus/tests/test_cli_console.py argus/tests/test_cli.py` → **139 passed**. 7 new tests cover: provider precedence over built-in, fallback when no provider, fallback when the provider raises, no-TTY never consults a provider, real discovery returns `None` (OSS), discovery loads a registered EP, discovery skips an EP that fails to load. Architecture-sync gate (`scripts/ci/check_architecture_sync.py`) passes.

## Security Considerations
- [x] No security impact

### Security Details
Discovery is opt-in via installed entry points; OSS ships none. A malicious/broken provider is contained — load and run failures fall back to the built-in console. No new network or filesystem surface.

## AI Context Updates (.ai/)
- [x] `.ai/architecture.yaml` updated (documented the seam on both terminal-viewer mirror blocks)
- [ ] `.ai/workflows.yaml` updated (if commands/tasks changed)
- [ ] `.ai/decisions.yaml` updated (if design decision made)
- [ ] `.ai/errors.yaml` updated (if common error addressed)

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
N/A — open-core enablement work.
