### PR TITLE
chore(deps): skip Python pre-release base images in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,6 +60,16 @@ updates:
         patterns:
           - "*"
 
+    # Skip Python pre-release base images. Dependabot's docker manager sorts
+    # e.g. python:3.15.0b2-alpine ahead of the stable 3.14.x line and proposes
+    # it (see #290); Dependabot owns the Dockerfile FROM lines (Renovate, which
+    # has ignoreUnstable, only handles the ARG tool versions + source-pinned
+    # tags). Track stable Python only — the final X.Y.0 release is still picked
+    # up; only aN / bN / rcN pre-releases are ignored.
+    ignore:
+      - dependency-name: "python"
+        versions: ["*0a*", "*0b*", "*0rc*"]
+
     commit-message:
       prefix: "chore(deps)"
 


### PR DESCRIPTION
## Description
Stop Dependabot proposing **Python pre-release base images** (e.g. `python:3.15.0b2-alpine`, as in #290). Adds an `ignore` rule for the `python` docker dependency covering alpha/beta/rc tags.

## Changes Made
- [x] Modified existing scanner/workflow
- [x] Other (please specify): Dependabot config

### Details
- Dependabot owns the Dockerfile `FROM` base images; its docker manager sorts `python:3.15.0b2-alpine` ahead of the stable `3.14.x` line and proposed it across five scanner images (#290).
- Adds `ignore` on the docker ecosystem for `dependency-name: "python"`, `versions: ["*0a*", "*0b*", "*0rc*"]` — matches Python's pre-release tag forms (`X.Y.0aN` / `0bN` / `0rcN`) while leaving the final `X.Y.0` stable release (and `-alpine`/`-slim` stable tags) eligible.
- Renovate (which has `ignoreUnstable`) already skips these but only manages the ARG tool versions + source-pinned tags, not the `FROM` lines — so the fix belongs in Dependabot.

## Testing
- [x] Manual testing performed

### Test Results
`.github/dependabot.yml` parses and the `ignore` rule resolves to the expected structure. No stable update is affected by the patterns.

## Security Considerations
- [x] Security enhancement

### Security Details
Keeps production scanner images off Python pre-releases; aligns with the repo's supply-chain policy (stable, vetted versions only).

## AI Context Updates (.ai/)
- [x] N/A - No .ai/ updates needed

## Checklist
- [x] Code follows project style guidelines
- [x] All tests pass
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Addresses the root cause behind #290 (Dependabot proposing `python:3.15.0b2`).
