### PR TITLE
feat(plugins): container sandbox prototype + threat model (ADR-031)

### DIFF
--- a/.ai/architecture.yaml
+++ b/.ai/architecture.yaml
@@ -85,6 +85,7 @@ components:
         by argus view terminal (TUI ``D`` keybind, DiffScreen) and argus view browser (web UI ``/diff``
         route).
       core/scopes.py: 'Finding scope taxonomy. scope_for_finding maps a finding to security / lint / supply-chain from each scanner''s category (linter->lint; sca/container/supply-chain->supply-chain; else security) via the live registry with a name-prefix fallback. Drives the scope-organized report output (reporters/scope_views.py).'
+      core/plugin_runtime.py: 'Container sandbox for untrusted third-party plugins (ADR-031, prototype). build_sandbox_argv emits a hardened docker run (no network, read-only rootfs, cap-drop ALL, no-new-privileges, non-root, resource limits, target ro at /scan, digest-pinned image, no host env/socket); validate_findings sanitizes untrusted argus.plugin.v1 output (schema / severity / length / control-chars / location-traversal); plugin_provenance + trust tiers (first-party / verified / unverified) record each plugin in the attestation. See docs/plugin-sandbox.md.'
       viewers/: '`argus view` interfaces (optional extras)'
       viewers/__init__.py: ViewerUnavailable shared exception
       viewers/terminal/: '`argus view --interface=terminal` — Textual TUI ([terminal] extra). Includes
@@ -666,6 +667,7 @@ docsite:
         by argus view terminal (TUI ``D`` keybind, DiffScreen) and argus view browser (web UI ``/diff``
         route).
       core/scopes.py: 'Finding scope taxonomy. scope_for_finding maps a finding to security / lint / supply-chain from each scanner''s category (linter->lint; sca/container/supply-chain->supply-chain; else security) via the live registry with a name-prefix fallback. Drives the scope-organized report output (reporters/scope_views.py).'
+      core/plugin_runtime.py: 'Container sandbox for untrusted third-party plugins (ADR-031, prototype). build_sandbox_argv emits a hardened docker run (no network, read-only rootfs, cap-drop ALL, no-new-privileges, non-root, resource limits, target ro at /scan, digest-pinned image, no host env/socket); validate_findings sanitizes untrusted argus.plugin.v1 output (schema / severity / length / control-chars / location-traversal); plugin_provenance + trust tiers (first-party / verified / unverified) record each plugin in the attestation. See docs/plugin-sandbox.md.'
       viewers/: '`argus view` interfaces (optional extras)'
       viewers/__init__.py: ViewerUnavailable shared exception
       viewers/terminal/: '`argus view --interface=terminal` — Textual TUI ([terminal] extra). Includes

--- a/.ai/decisions.yaml
+++ b/.ai/decisions.yaml
@@ -2454,3 +2454,49 @@ decisions:
         already covers the container case via its scanner-summary-* pattern.
 
         '
+  ADR-031:
+    title: Container sandbox for untrusted third-party plugins
+    date: '2026-06-17'
+    status: accepted
+    context: 'Argus should let third parties build plugins, but Argus is a security
+      tool that runs in sensitive environments with repo/credential access nearby.
+      Plugin code cannot be trusted by default — an in-process Python plugin runs
+      with full host trust and could exfiltrate or tamper. We need an isolation
+      model that also enables language-agnostic plugins, and an audit trail so
+      consumers know which (and how trusted) plugins produced a result.'
+    decision: 'Run third-party plugins as isolated containers implementing the
+      ``argus.plugin.v1`` contract (scan target read-only at /scan; findings JSON
+      on stdout). The host builds a hardened ``docker run`` invocation (no network
+      by default, read-only rootfs, --cap-drop ALL, no-new-privileges, non-root,
+      resource/pid limits, no host env/secrets, no docker socket, never
+      --privileged, digest-pinned image) and treats plugin output as untrusted:
+      schema-validated, severity-coerced, length-bounded, control-char-stripped,
+      and location-sanitized (absolute/.. rejected). Plugins carry a trust tier
+      (first-party / verified / unverified); unverified requires explicit opt-in,
+      gets no network, and is flagged in the attestation. Every plugin run is
+      recorded (name, version, image digest, trust tier, signature_verified) into
+      the scan results + the cosign attestation. Prototype: argus.core.plugin_runtime.'
+    alternatives_considered:
+    - name: In-process Python plugins only (entry points, full trust)
+      rejected_because: 'Python-only, and untrusted code runs in-process with full
+        host access — unacceptable default for a security tool. Kept as the trusted
+        first-party path; the sandbox is for third-party code.'
+    - name: Obfuscation / signing without isolation
+      rejected_because: 'Signing proves origin, not safety; a signed-but-malicious
+        or compromised plugin still needs containment. Isolation is the control.'
+    consequences:
+      positive:
+      - Untrusted, language-agnostic plugins with strong default isolation
+      - Reuses the existing Docker execution backend
+      - Auditable — plugins are called out by digest + trust tier in the attestation
+      - Graceful degradation — a hostile/broken plugin can't crash a scan
+      negative:
+      - Container escape via kernel 0-day is still possible (microVM is a future option)
+      - Per-plugin container overhead; network-allowed plugins can exfiltrate by design
+      - The stable entry-point contract + cosign image verification are still to come
+    implementation: 'argus/core/plugin_runtime.py (build_sandbox_argv,
+      validate_findings, plugin_provenance, run_plugin); threat model in
+      docs/plugin-sandbox.md; reference plugin in examples/plugins/hello-plugin/.'
+    related_adrs:
+    - ADR-018
+    - ADR-023

--- a/argus/core/plugin_runtime.py
+++ b/argus/core/plugin_runtime.py
@@ -1,0 +1,300 @@
+"""Container sandbox for untrusted third-party Argus plugins (prototype).
+
+A plugin runs as an **isolated container** implementing the ``argus.plugin.v1``
+contract: it receives the scan target read-only at ``/scan`` and writes a
+findings JSON document to **stdout**. Argus core treats a plugin as
+**untrusted** by default — the container is locked down (no network, read-only
+root filesystem, all capabilities dropped, non-root, no host env/secrets, no
+Docker socket) and the plugin's *output* is schema-validated and sanitized
+before any finding enters the pipeline.
+
+This is a prototype of the design in ``docs/plugin-sandbox.md`` (ADR-031). The
+stable entry-point contract (``argus.plugins.v1``) and cosign image-signature
+verification are tracked as follow-ups; ``PluginSpec.signature_verified`` is the
+hook the verifier will set.
+
+Security-critical: ``build_sandbox_argv`` and ``validate_findings`` are the trust
+boundary. Keep them conservative — a plugin is hostile until proven otherwise.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path, PurePosixPath
+
+from argus.core.models import Finding, ScanResult, Severity
+
+#: Output-contract identifier a conforming plugin must echo back.
+PLUGIN_SCHEMA = "argus.plugin.v1"
+
+_SCAN_MOUNT = "/scan"
+
+# Defensive caps on attacker-controlled output.
+_MAX_FINDINGS = 10_000
+_MAX_STR = 4_000
+
+# Sandbox resource defaults (DoS containment).
+_DEFAULT_TIMEOUT = 300
+_DEFAULT_MEMORY = "512m"
+_DEFAULT_CPUS = "1.0"
+_DEFAULT_PIDS = 256
+#: nobody:nogroup — run as an unprivileged uid that owns nothing on the host.
+_SANDBOX_USER = "65534:65534"
+
+
+class TrustTier(Enum):
+    """How much a plugin is trusted — drives sandbox strictness + attestation."""
+
+    FIRST_PARTY = "first-party"   # Huntridge-signed
+    VERIFIED = "verified"         # third-party, Huntridge-reviewed + signed
+    UNVERIFIED = "unverified"     # third-party, unreviewed — max sandbox, opt-in
+
+
+class PluginError(RuntimeError):
+    """Raised when a plugin spec, sandbox, or output violates the contract."""
+
+
+@dataclass(frozen=True)
+class PluginSpec:
+    """A plugin to run. ``image`` MUST be digest-pinned (``repo@sha256:...``)."""
+
+    name: str
+    image: str
+    version: str = ""
+    trust_tier: TrustTier = TrustTier.UNVERIFIED
+    allow_network: bool = False        # default-deny egress (anti-exfiltration)
+    timeout: int = _DEFAULT_TIMEOUT
+    signature_verified: bool = False   # set by the (future) cosign verifier
+
+
+def resolve_runtime() -> str:
+    """Return an available container runtime binary name, or raise."""
+    for runtime in ("docker", "podman"):
+        if shutil.which(runtime):
+            return runtime
+    raise PluginError("no container runtime (docker/podman) found on PATH")
+
+
+def _require_digest_pinned(image: str) -> None:
+    if "@sha256:" not in image:
+        raise PluginError(
+            f"plugin image must be digest-pinned (repo@sha256:...); got {image!r}"
+        )
+
+
+def build_sandbox_argv(
+    spec: PluginSpec, target_dir: str, *, runtime: str = "docker"
+) -> list[str]:
+    """Build the hardened ``docker run`` argv for an untrusted plugin.
+
+    Security invariants (see ``docs/plugin-sandbox.md``):
+
+    - **No network** unless explicitly allowed (anti-exfiltration).
+    - **Read-only root filesystem** + a small ``noexec,nosuid`` tmpfs for scratch.
+    - **All capabilities dropped** and **no-new-privileges**.
+    - **Non-root** (``nobody``).
+    - **Resource + PID limits** (DoS containment).
+    - Scan target mounted **read-only** at ``/scan``.
+    - **No host env/secrets** forwarded (no ``-e`` flags), **no Docker socket**,
+      **never** ``--privileged``.
+    - Image **digest-pinned**.
+    """
+    _require_digest_pinned(spec.image)
+    target = Path(target_dir).resolve()
+    if not target.is_dir():
+        raise PluginError(f"scan target is not a directory: {target}")
+
+    return [
+        runtime,
+        "run",
+        "--rm",
+        "--network",
+        ("bridge" if spec.allow_network else "none"),
+        "--read-only",
+        "--cap-drop",
+        "ALL",
+        "--security-opt",
+        "no-new-privileges",
+        "--user",
+        _SANDBOX_USER,
+        "--pids-limit",
+        str(_DEFAULT_PIDS),
+        "--memory",
+        _DEFAULT_MEMORY,
+        "--cpus",
+        _DEFAULT_CPUS,
+        "--tmpfs",
+        "/tmp:rw,noexec,nosuid,size=64m",
+        "--workdir",
+        _SCAN_MOUNT,
+        "--volume",
+        f"{target}:{_SCAN_MOUNT}:ro",
+        # Deliberately absent: -e host env, secrets, /var/run/docker.sock, --privileged.
+        spec.image,
+    ]
+
+
+def _clean_text(value: object) -> str:
+    """Bound length and strip control chars from attacker-controlled text.
+
+    Findings flow into HTML (browser viewer), SARIF, and Markdown; renderers
+    escape, but we strip C0/C1 control chars (except tab/newline) at the trust
+    boundary as defence-in-depth against terminal/markup injection.
+    """
+    text = str(value)[:_MAX_STR]
+    return "".join(c for c in text if c in "\t\n" or ord(c) >= 0x20)
+
+
+def _sanitize_location(value: object) -> str | None:
+    """Reject absolute paths and traversal in a plugin-reported location.
+
+    A plugin must not claim a host path or escape the scan root; such a value
+    is dropped rather than trusted.
+    """
+    if value is None:
+        return None
+    loc = _clean_text(value)
+    path = PurePosixPath(loc)
+    if path.is_absolute() or ".." in path.parts:
+        return None
+    return loc
+
+
+def validate_findings(raw: object, *, plugin_name: str) -> list[Finding]:
+    """Parse + validate untrusted plugin output into Findings.
+
+    Enforces the ``argus.plugin.v1`` envelope, caps count/size, coerces severity
+    to the known enum (unknown → ``UNKNOWN``, never trusted verbatim), and
+    sanitizes free-text + location fields. Raises :class:`PluginError` on a
+    structurally invalid document.
+    """
+    try:
+        doc = json.loads(raw) if isinstance(raw, (str, bytes, bytearray)) else raw
+    except (ValueError, TypeError) as exc:
+        raise PluginError(f"plugin {plugin_name!r} returned invalid JSON: {exc}") from exc
+
+    if not isinstance(doc, dict) or doc.get("schema") != PLUGIN_SCHEMA:
+        raise PluginError(
+            f"plugin {plugin_name!r}: missing/unknown schema (expected {PLUGIN_SCHEMA!r})"
+        )
+    raw_findings = doc.get("findings")
+    if not isinstance(raw_findings, list):
+        raise PluginError(f"plugin {plugin_name!r}: 'findings' must be a list")
+    if len(raw_findings) > _MAX_FINDINGS:
+        raise PluginError(
+            f"plugin {plugin_name!r}: too many findings ({len(raw_findings)} > {_MAX_FINDINGS})"
+        )
+
+    findings: list[Finding] = []
+    for index, item in enumerate(raw_findings):
+        if not isinstance(item, dict):
+            raise PluginError(f"plugin {plugin_name!r}: finding {index} is not an object")
+        findings.append(
+            Finding(
+                id=_clean_text(item.get("id") or f"{plugin_name}-{index}"),
+                severity=Severity.from_string(str(item.get("severity", "unknown"))),
+                title=_clean_text(item.get("title") or "(untitled)"),
+                description=_clean_text(item.get("description") or ""),
+                location=_sanitize_location(item.get("location")),
+                cwe=_clean_text(item["cwe"]) if item.get("cwe") else None,
+                cve=_clean_text(item["cve"]) if item.get("cve") else None,
+                scanner=f"plugin/{plugin_name}",
+                metadata={"untrusted": True, "plugin": plugin_name},
+            )
+        )
+    return findings
+
+
+def plugin_provenance(spec: PluginSpec) -> dict:
+    """Attestation/audit record for a plugin run (flows into ScanResult.metadata).
+
+    Lets the attestation layer call out exactly which plugin ran, by digest and
+    trust tier, so downstream consumers can weight the results.
+    """
+    _, _, digest = spec.image.partition("@")
+    return {
+        "plugin": {
+            "name": spec.name,
+            "version": spec.version,
+            "image": spec.image,
+            "digest": digest or None,
+            "trust_tier": spec.trust_tier.value,
+            "signature_verified": spec.signature_verified,
+            "sandboxed": True,
+            "network": "allowed" if spec.allow_network else "none",
+        }
+    }
+
+
+def assert_runnable(spec: PluginSpec, *, opted_in: bool = False) -> None:
+    """Policy gate before running a plugin.
+
+    An ``UNVERIFIED`` plugin must be explicitly opted into, and may not be
+    granted network egress without that opt-in — untrusted code does not get the
+    network for free.
+    """
+    if spec.trust_tier is TrustTier.UNVERIFIED and not opted_in:
+        raise PluginError(
+            f"plugin {spec.name!r} is unverified; pass opted_in=True to run it "
+            "(it runs sandboxed and is flagged 'unverified' in the attestation)"
+        )
+    if spec.allow_network and spec.trust_tier is TrustTier.UNVERIFIED and not opted_in:
+        raise PluginError(
+            f"plugin {spec.name!r} is unverified and requests network — denied"
+        )
+
+
+def run_plugin(
+    spec: PluginSpec,
+    target_dir: str,
+    *,
+    opted_in: bool = False,
+    runtime: str | None = None,
+    runner=subprocess.run,
+) -> ScanResult:
+    """Run a plugin in the sandbox and return a validated ScanResult.
+
+    ``runner`` is injectable (defaults to ``subprocess.run``) so the sandbox can
+    be exercised without a live container runtime. Failures (timeout, non-zero
+    exit, malformed output) degrade to a ``failed`` ScanResult rather than
+    raising into the engine — a hostile plugin cannot take down a scan.
+    """
+    assert_runnable(spec, opted_in=opted_in)
+    runtime = runtime or resolve_runtime()
+    argv = build_sandbox_argv(spec, target_dir, runtime=runtime)
+    meta = plugin_provenance(spec)
+
+    try:
+        proc = runner(argv, capture_output=True, text=True, timeout=spec.timeout)
+    except subprocess.TimeoutExpired:
+        return ScanResult(
+            scanner=f"plugin/{spec.name}",
+            findings=[],
+            metadata={**meta, "status": "failed", "error": "timeout"},
+        )
+
+    if getattr(proc, "returncode", 0) != 0:
+        return ScanResult(
+            scanner=f"plugin/{spec.name}",
+            findings=[],
+            metadata={**meta, "status": "failed", "error": f"exit {proc.returncode}"},
+        )
+
+    try:
+        findings = validate_findings(proc.stdout, plugin_name=spec.name)
+    except PluginError as exc:
+        return ScanResult(
+            scanner=f"plugin/{spec.name}",
+            findings=[],
+            metadata={**meta, "status": "failed", "error": str(exc)},
+        )
+
+    return ScanResult(
+        scanner=f"plugin/{spec.name}",
+        findings=findings,
+        metadata={**meta, "status": "ran"},
+    )

--- a/argus/tests/core/test_plugin_runtime.py
+++ b/argus/tests/core/test_plugin_runtime.py
@@ -1,0 +1,173 @@
+"""Security tests for the container plugin sandbox (argus.core.plugin_runtime).
+
+The trust boundary is ``build_sandbox_argv`` (the hardened invocation) and
+``validate_findings`` (untrusted-output handling). These run without Docker —
+the runtime is never invoked; the runner is injected.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+from argus.core.models import Severity
+from argus.core.plugin_runtime import (
+    PLUGIN_SCHEMA,
+    PluginError,
+    PluginSpec,
+    TrustTier,
+    assert_runnable,
+    build_sandbox_argv,
+    plugin_provenance,
+    run_plugin,
+    validate_findings,
+)
+
+PINNED = "ghcr.io/acme/plugin@sha256:" + "a" * 64
+
+
+def _spec(**kw):
+    return PluginSpec(name="acme", image=PINNED, **kw)
+
+
+def _envelope(findings):
+    return json.dumps({"schema": PLUGIN_SCHEMA, "findings": findings})
+
+
+class TestSandboxHardening:
+    def test_all_lockdown_flags_present(self, tmp_path):
+        argv = build_sandbox_argv(_spec(), str(tmp_path))
+        joined = " ".join(argv)
+        assert "--network none" in joined          # default-deny egress
+        assert "--read-only" in argv
+        assert ["--cap-drop", "ALL"] == argv[argv.index("--cap-drop"):argv.index("--cap-drop") + 2]
+        assert "--security-opt" in argv and "no-new-privileges" in argv
+        assert "--user" in argv and "65534:65534" in argv
+        assert "--pids-limit" in argv and "--memory" in argv and "--cpus" in argv
+        assert any(a.startswith("/tmp:rw,noexec,nosuid") for a in argv)
+        assert f"{tmp_path.resolve()}:/scan:ro" in argv  # target read-only
+
+    def test_no_escape_vectors(self, tmp_path):
+        argv = build_sandbox_argv(_spec(), str(tmp_path))
+        joined = " ".join(argv)
+        assert "--privileged" not in argv
+        assert "docker.sock" not in joined            # no socket mount → no host control
+        assert not any(a == "-e" or a == "--env" for a in argv)  # no host env/secrets
+
+    def test_digest_pin_required(self, tmp_path):
+        with pytest.raises(PluginError, match="digest-pinned"):
+            build_sandbox_argv(PluginSpec(name="x", image="ghcr.io/acme/plugin:latest"), str(tmp_path))
+
+    def test_network_opt_in_changes_only_network_flag(self, tmp_path):
+        argv = build_sandbox_argv(_spec(allow_network=True), str(tmp_path))
+        assert "--network" in argv and "bridge" in argv
+        assert "none" not in argv[argv.index("--network") + 1:argv.index("--network") + 2]
+
+    def test_target_must_be_a_directory(self, tmp_path):
+        f = tmp_path / "f"
+        f.write_text("x")
+        with pytest.raises(PluginError, match="not a directory"):
+            build_sandbox_argv(_spec(), str(f))
+
+
+class TestUntrustedOutput:
+    def test_rejects_invalid_json(self):
+        with pytest.raises(PluginError, match="invalid JSON"):
+            validate_findings("{not json", plugin_name="acme")
+
+    def test_rejects_wrong_schema(self):
+        with pytest.raises(PluginError, match="schema"):
+            validate_findings(json.dumps({"schema": "evil", "findings": []}), plugin_name="acme")
+
+    def test_rejects_non_list_findings(self):
+        with pytest.raises(PluginError, match="must be a list"):
+            validate_findings(json.dumps({"schema": PLUGIN_SCHEMA, "findings": {}}), plugin_name="acme")
+
+    def test_caps_finding_count(self):
+        huge = _envelope([{"id": str(i)} for i in range(10_001)])
+        with pytest.raises(PluginError, match="too many findings"):
+            validate_findings(huge, plugin_name="acme")
+
+    def test_unknown_severity_coerced_not_trusted(self):
+        out = validate_findings(_envelope([{"severity": "ULTRA-MEGA"}]), plugin_name="acme")
+        assert out[0].severity is Severity.UNKNOWN
+
+    def test_absolute_and_traversal_locations_dropped(self):
+        out = validate_findings(
+            _envelope([
+                {"location": "/etc/passwd"},
+                {"location": "../../host/secret"},
+                {"location": "src/app.py"},
+            ]),
+            plugin_name="acme",
+        )
+        assert out[0].location is None
+        assert out[1].location is None
+        assert out[2].location == "src/app.py"
+
+    def test_control_chars_stripped(self):
+        out = validate_findings(_envelope([{"title": "evil\x1b[2Jinjection\x00"}]), plugin_name="acme")
+        assert "\x1b" not in out[0].title and "\x00" not in out[0].title
+
+    def test_findings_tagged_untrusted(self):
+        out = validate_findings(_envelope([{"id": "F1", "severity": "high"}]), plugin_name="acme")
+        assert out[0].metadata["untrusted"] is True
+        assert out[0].scanner == "plugin/acme"
+        assert out[0].severity is Severity.HIGH
+
+
+class TestProvenanceAndPolicy:
+    def test_provenance_records_tier_and_digest(self):
+        prov = plugin_provenance(_spec(version="1.2.3", trust_tier=TrustTier.VERIFIED, signature_verified=True))
+        p = prov["plugin"]
+        assert p["trust_tier"] == "verified"
+        assert p["digest"] == "sha256:" + "a" * 64
+        assert p["signature_verified"] is True
+        assert p["network"] == "none"
+
+    def test_unverified_requires_opt_in(self):
+        with pytest.raises(PluginError, match="unverified"):
+            assert_runnable(_spec(trust_tier=TrustTier.UNVERIFIED))
+        assert_runnable(_spec(trust_tier=TrustTier.UNVERIFIED), opted_in=True)  # no raise
+
+    def test_verified_runs_without_opt_in(self):
+        assert_runnable(_spec(trust_tier=TrustTier.VERIFIED))  # no raise
+
+
+class TestRunPlugin:
+    def _runner(self, *, stdout="", returncode=0, raises=None):
+        def fake(argv, **kw):
+            if raises:
+                raise raises
+            return subprocess.CompletedProcess(argv, returncode, stdout=stdout, stderr="")
+        return fake
+
+    def test_happy_path_returns_validated_findings(self, tmp_path):
+        runner = self._runner(stdout=_envelope([{"id": "F1", "severity": "medium", "title": "x"}]))
+        res = run_plugin(_spec(trust_tier=TrustTier.VERIFIED), str(tmp_path), runtime="docker", runner=runner)
+        assert res.metadata["status"] == "ran"
+        assert res.metadata["plugin"]["trust_tier"] == "verified"
+        assert len(res.findings) == 1 and res.findings[0].severity is Severity.MEDIUM
+
+    def test_timeout_degrades_not_raises(self, tmp_path):
+        runner = self._runner(raises=subprocess.TimeoutExpired(cmd="docker", timeout=1))
+        res = run_plugin(_spec(trust_tier=TrustTier.VERIFIED), str(tmp_path), runtime="docker", runner=runner)
+        assert res.metadata["status"] == "failed" and res.metadata["error"] == "timeout"
+        assert res.findings == []
+
+    def test_nonzero_exit_degrades(self, tmp_path):
+        runner = self._runner(stdout="", returncode=2)
+        res = run_plugin(_spec(trust_tier=TrustTier.FIRST_PARTY), str(tmp_path), runtime="docker", runner=runner)
+        assert res.metadata["status"] == "failed" and "exit 2" in res.metadata["error"]
+
+    def test_malformed_output_degrades(self, tmp_path):
+        runner = self._runner(stdout="garbage")
+        res = run_plugin(_spec(trust_tier=TrustTier.FIRST_PARTY), str(tmp_path), runtime="docker", runner=runner)
+        assert res.metadata["status"] == "failed"
+
+    def test_unverified_blocked_without_opt_in(self, tmp_path):
+        runner = self._runner(stdout=_envelope([]))
+        with pytest.raises(PluginError):
+            run_plugin(_spec(), str(tmp_path), runtime="docker", runner=runner)  # default UNVERIFIED

--- a/docs/plugin-sandbox.md
+++ b/docs/plugin-sandbox.md
@@ -1,0 +1,126 @@
+# Plugin sandbox — threat model & design
+
+Argus can run **third-party plugins**. Because Argus is a security tool that
+runs inside sensitive environments (and often with repo/credential access
+nearby), a plugin is treated as **untrusted code** and executed in a locked-down
+container. This document is the threat model and the security contract.
+
+> Status: **prototype** — `argus.core.plugin_runtime` implements the sandbox and
+> output validation (see [ADR-031](../.ai/decisions.yaml)). The stable
+> entry-point contract (`argus.plugins.v1`) and cosign image-signature
+> verification are follow-ups.
+
+## Trust boundary
+
+```
+┌─────────────── Argus host (trusted) ───────────────┐
+│  engine → plugin_runtime                            │
+│     • builds hardened `docker run` argv             │
+│     • validates + sanitizes the plugin's output     │
+│     • records the plugin in the attestation         │
+└───────────────┬────────────────────────────────────┘
+                │  (only: scan target read-only @ /scan; findings JSON on stdout)
+        ┌───────▼────────┐
+        │ plugin container│  ← UNTRUSTED
+        │  no net · ro fs │
+        │  no caps · nobody│
+        └─────────────────┘
+```
+
+Everything crossing the boundary is minimized: the plugin receives **only** the
+scan target (read-only) and returns **only** a findings JSON document on stdout.
+Nothing else — no network, no host filesystem, no env, no secrets.
+
+## The contract (`argus.plugin.v1`)
+
+- **Input:** the scan target is mounted read-only at `/scan` (the container's
+  workdir). No arguments carry host paths or secrets.
+- **Output:** a single JSON document on **stdout**:
+  ```json
+  {
+    "schema": "argus.plugin.v1",
+    "findings": [
+      {"id": "...", "severity": "high", "title": "...", "description": "...",
+       "location": "src/app.py:42", "cwe": "CWE-89", "cve": "CVE-..."}
+    ]
+  }
+  ```
+- Exit non-zero or malformed output → the run **degrades** to a failed result;
+  it never crashes the scan.
+
+## Sandbox hardening (enforced in `build_sandbox_argv`)
+
+| Control | Flag | Why |
+|---|---|---|
+| No egress (default) | `--network none` | the single biggest anti-exfiltration control |
+| Read-only rootfs | `--read-only` + `--tmpfs /tmp:rw,noexec,nosuid` | no tampering, no dropped executables |
+| Drop privileges | `--cap-drop ALL`, `--security-opt no-new-privileges` | no capability abuse / setuid escalation |
+| Non-root | `--user 65534:65534` (nobody) | owns nothing on the host |
+| Resource caps | `--memory`, `--cpus`, `--pids-limit` | DoS containment |
+| Read-only input | `-v <target>:/scan:ro` | plugin can read the code, not modify it |
+| No host reach | **no `-e`**, **no `docker.sock`**, **never `--privileged`** | no secrets, no host control, no escape |
+| Pinned image | `repo@sha256:...` required | no mutable-tag swap |
+
+Network egress is **opt-in** per plugin and is **denied outright for unverified
+plugins** unless the operator explicitly opts in.
+
+## Untrusted output validation (`validate_findings`)
+
+A plugin's output is attacker-controlled data that flows into SARIF, Markdown,
+the browser viewer, and the PDF report — so it is validated and sanitized at the
+boundary, not on render alone:
+
+- Envelope + `schema` checked; `findings` must be a list; **count is capped**.
+- **Severity is coerced** to the known enum (unknown → `UNKNOWN`); never trusted
+  verbatim.
+- Free-text fields are **length-bounded** and **stripped of control characters**
+  (defence-in-depth vs terminal / Markdown / HTML injection).
+- `location` is **rejected if absolute or contains `..`** — a plugin cannot
+  claim a host path or escape the scan root.
+- Every finding is tagged `metadata.untrusted = true` and `scanner = plugin/<name>`.
+
+## Trust tiers
+
+| Tier | Source | Sandbox | Attestation label | Run policy |
+|---|---|---|---|---|
+| `first-party` | Huntridge-signed | hardened | first-party | default |
+| `verified` | third-party, Huntridge-reviewed + signed | hardened | verified | default |
+| `unverified` | third-party, unreviewed | hardened (max) | **unverified** | **explicit opt-in**, no network |
+
+Unverified plugins never run silently and are flagged in the attestation so
+downstream consumers can weight the results.
+
+## Attestation & audit
+
+Every plugin run is recorded (`plugin_provenance`) into the scan results and
+flows into the in-toto / OpenVEX cosign attestation, extending the existing
+toolchain-provenance block:
+
+```json
+{"plugin": {"name": "...", "version": "...", "image": "repo@sha256:...",
+            "digest": "sha256:...", "trust_tier": "unverified",
+            "signature_verified": false, "sandboxed": true, "network": "none"}}
+```
+
+A consumer of the attestation can therefore see *exactly* which plugins ran, by
+digest and trust tier, and whether any were unverified.
+
+## Image supply chain
+
+Plugin images must be **digest-pinned**; the planned cosign step verifies the
+image signature before run (mirroring how Argus already cosign-verifies its own
+images and digest-pins third-party ones). `PluginSpec.signature_verified` is the
+hook the verifier sets, and it is surfaced in the attestation.
+
+## Residual risks (be honest)
+
+- **Container escape** is the ultimate risk; the hardening above closes the
+  common vectors (privileged, socket, caps, root) but a kernel 0-day could still
+  defeat namespace isolation. Run untrusted plugins on hosts you can afford to
+  treat as compromised, or on a microVM runtime (gVisor / Kata) for a stronger
+  boundary — a future option, not assumed here.
+- **DoS** is contained (limits + timeout) but not eliminated.
+- **Malicious findings** are validated/sanitized, but renderers must still
+  escape output — this is defence-in-depth, not a substitute for output encoding.
+- Network-allowed plugins can exfiltrate by definition — only grant it to
+  trusted tiers with a clear reason.

--- a/examples/plugins/hello-plugin/Dockerfile
+++ b/examples/plugins/hello-plugin/Dockerfile
@@ -1,0 +1,16 @@
+# Reference Argus plugin image.
+#
+# Argus runs this under the plugin sandbox (docs/plugin-sandbox.md):
+#   --network none --read-only --cap-drop ALL --security-opt no-new-privileges
+#   --user 65534:65534  -v <target>:/scan:ro
+# so the plugin must: read only from /scan, write findings JSON to stdout, and
+# need no network, no writable disk (a tmpfs is provided at /tmp), and no root.
+#
+# Production plugins should pin the base image by digest (FROM python@sha256:...);
+# left as a tag here for example readability.
+FROM python:3.14-alpine
+
+COPY plugin.py /plugin.py
+
+# Emits an argus.plugin.v1 findings document on stdout.
+ENTRYPOINT ["python3", "/plugin.py"]

--- a/examples/plugins/hello-plugin/README.md
+++ b/examples/plugins/hello-plugin/README.md
@@ -1,0 +1,50 @@
+# hello-plugin — a reference Argus plugin
+
+A minimal plugin that demonstrates the `argus.plugin.v1` contract: it scans the
+target for TODO/FIXME markers and reports them as findings. Use it as a template.
+
+See [`docs/plugin-sandbox.md`](../../../docs/plugin-sandbox.md) for the full
+contract, threat model, and sandbox guarantees.
+
+## The contract
+
+A plugin is a container image that:
+
+1. Reads the scan target, mounted **read-only at `/scan`** (the workdir).
+2. Writes a single JSON document to **stdout**:
+
+   ```json
+   {
+     "schema": "argus.plugin.v1",
+     "findings": [
+       {"id": "...", "severity": "high|medium|low|info",
+        "title": "...", "description": "...",
+        "location": "relative/path.py:42", "cwe": "CWE-89", "cve": "CVE-..."}
+     ]
+   }
+   ```
+
+Only `severity` and one of `id`/`title` are meaningful minimums; unknown
+severities are coerced to `unknown`, and `location` must be **relative** (absolute
+paths and `..` are dropped by Argus as untrusted).
+
+## How Argus runs it (you don't have to)
+
+Argus executes the image in a locked-down sandbox — no network, read-only root
+filesystem, all capabilities dropped, non-root, resource-limited, with the target
+mounted read-only. Your plugin therefore must not need network, writable disk
+(a `tmpfs` is available at `/tmp`), or root.
+
+## Build & try locally
+
+```bash
+docker build -t hello-plugin:dev examples/plugins/hello-plugin
+# Simulate the sandbox invocation Argus would use:
+docker run --rm --network none --read-only --cap-drop ALL \
+  --security-opt no-new-privileges --user 65534:65534 \
+  --tmpfs /tmp:rw,noexec,nosuid,size=64m -v "$PWD:/scan:ro" \
+  hello-plugin:dev
+```
+
+In production, pin the image by digest and have Huntridge sign/verify it — see
+the trust tiers in the threat model.

--- a/examples/plugins/hello-plugin/plugin.py
+++ b/examples/plugins/hello-plugin/plugin.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Reference Argus plugin — emits an ``argus.plugin.v1`` document on stdout.
+
+Trivial demonstration of the plugin contract: walk the read-only scan target at
+``/scan`` and report TODO/FIXME/XXX markers as INFO findings. Real plugins do
+something useful; this shows the I/O contract and that a plugin needs no host
+access beyond ``/scan`` (read-only) and stdout.
+
+Runs under the Argus plugin sandbox: no network, read-only root filesystem,
+non-root (nobody), all capabilities dropped. See docs/plugin-sandbox.md.
+"""
+
+import json
+import os
+import re
+
+SCAN_ROOT = "/scan"
+_MARKER = re.compile(r"\b(TODO|FIXME|XXX)\b")
+
+
+def main() -> None:
+    findings = []
+    for root, _dirs, files in os.walk(SCAN_ROOT):
+        for name in files:
+            path = os.path.join(root, name)
+            try:
+                with open(path, encoding="utf-8", errors="ignore") as handle:
+                    for lineno, line in enumerate(handle, start=1):
+                        if _MARKER.search(line):
+                            rel = os.path.relpath(path, SCAN_ROOT)
+                            findings.append(
+                                {
+                                    "id": f"hello-{rel}-{lineno}",
+                                    "severity": "info",
+                                    "title": "TODO/FIXME marker",
+                                    "description": line.strip()[:200],
+                                    "location": f"{rel}:{lineno}",
+                                }
+                            )
+            except OSError:
+                continue
+    print(json.dumps({"schema": "argus.plugin.v1", "findings": findings}))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description
Threat model, ADR, and a working **prototype** for running untrusted third-party plugins as **isolated containers** — the design we discussed (containers for *plugin isolation*, not source obfuscation; plugins called out in the attestation; non-sponsored plugins not trusted).

## Changes Made
- [x] Added new scanner/workflow (plugin runtime framework)
- [x] Updated documentation

### Details
- **`argus/core/plugin_runtime.py`** — the sandbox + trust boundary:
  - `build_sandbox_argv` — hardened `docker run`: `--network none` (default-deny egress), `--read-only` + `noexec,nosuid` tmpfs, `--cap-drop ALL`, `--security-opt no-new-privileges`, `--user 65534:65534`, memory/cpu/pids limits, target mounted **read-only** at `/scan`, **digest-pinned image required**, and **no** `-e` host env/secrets, **no** docker socket, **never** `--privileged`.
  - `validate_findings` — treats plugin output as attacker-controlled: enforces the `argus.plugin.v1` envelope, caps count, coerces severity (unknown→`UNKNOWN`), bounds length + strips control chars, and **rejects absolute / `..` locations**.
  - **Trust tiers** (`first-party` / `verified` / `unverified`); unverified requires explicit opt-in and gets no network.
  - `plugin_provenance` — records name/version/image **digest**/trust-tier/`signature_verified` for the attestation, so every plugin is called out by trust level.
  - `run_plugin` — a hostile/broken plugin **degrades to a failed result**, never crashes the scan (runner injected for testability).
- **21 security tests** — sandbox flags present, escape vectors absent, untrusted-output handling, trust policy. No Docker needed.
- **`docs/plugin-sandbox.md`** — trust boundary, contract, hardening table, output validation, trust tiers, attestation schema, image supply chain, residual risks (incl. container-escape honesty + microVM as a future option).
- **`examples/plugins/hello-plugin/`** — reference plugin + contract.
- **ADR-031** + `.ai/architecture.yaml` component blurb (both mirror blocks).

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed

### Test Results
`pytest argus/tests/core/test_plugin_runtime.py` → **21 passed**. Architecture-sync gate passes; YAML valid.

## Security Considerations
- [x] Security enhancement

### Security Details
This *is* the security-sensitive surface. Defaults are hostile-by-assumption: deny-all network, read-only/no-cap/non-root container, no secrets crossing the boundary, digest-pinned images, and validated+sanitized output. Unverified plugins are opt-in and flagged in the attestation. Residual risks (kernel-level container escape, network-allowed exfiltration) are documented, not hidden.

## AI Context Updates (.ai/)
- [x] `.ai/architecture.yaml` updated
- [x] `.ai/decisions.yaml` updated (ADR-031)

## Checklist
- [x] Code follows project style guidelines
- [x] All tests pass
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Prototype of the plugin-sandbox design; stable `argus.plugins.v1` entry-point contract + cosign image-signature verification are follow-ups.
