### PR TITLE
test(contract): argus.plugins.v1 conformance tests + stability policy (ADR-032)

### DIFF
--- a/.ai/decisions.yaml
+++ b/.ai/decisions.yaml
@@ -2500,3 +2500,45 @@ decisions:
     related_adrs:
     - ADR-018
     - ADR-023
+  ADR-032:
+    title: Versioned plugin contract (argus.plugins.v1) enforced by conformance tests
+    date: '2026-06-17'
+    status: accepted
+    context: 'Third parties and Argus Enterprise build on a surface of the core
+      (Finding/ScanResult/Severity data shapes, the Scanner protocol, the
+      argus.reporters seam). These are separately-released, runtime-coupled
+      packages, so a breaking change in core can silently break a downstream
+      plugin when a user upgrades core — unacceptable for a security tool whose
+      paid plugins must keep working. We chose a RANGES compatibility model (not
+      lockstep), which only works if "compatible" is defined and breaks are caught.'
+    decision: 'Declare a stable, semver-governed public contract — argus.plugins.v1,
+      documented in docs/plugin-contract.md — and ENFORCE it with conformance
+      tests (argus/tests/test_plugin_contract.py) that run in core CI on every PR.
+      A change that removes/renames a contract field, Severity member, protocol
+      method, or the reporters entry-point group fails CI before merge. Policy:
+      additive changes are compatible; a break requires argus.plugins.v2 + a core
+      major bump. Downstreams pin a compatible range and add a load-time version
+      guard that degrades gracefully on mismatch (Argus Enterprise does this).'
+    alternatives_considered:
+    - name: Lockstep versioning (enterprise version == core version)
+      rejected_because: 'Simplest "always compatible" story but rigid — every core
+        patch forces a downstream release. Ranges + contract + guard is the
+        standard open-core approach and scales to external plugin authors.'
+    - name: Documentation only, no executable contract
+      rejected_because: 'Docs drift; nothing stops a core PR from breaking the
+        surface. Conformance tests make the contract executable + enforced.'
+    consequences:
+      positive:
+      - A core PR cannot merge a contract break (conformance tests fail CI)
+      - Defines precisely what "compatible" means for the ranges model
+      - External plugin authors get a documented, stable target
+      negative:
+      - The console/browser seams aren't on main yet, so their conformance tests
+        join later (only the data + reporter + scanner surface is guaranteed now)
+      - Adds a discipline cost — contract changes must be deliberate
+    implementation: 'docs/plugin-contract.md (the surface + stability policy);
+      argus/tests/test_plugin_contract.py (conformance suite). Complements ADR-031
+      (the container plugin sandbox) and the reporters seam (ADR-023).'
+    related_adrs:
+    - ADR-023
+    - ADR-031

--- a/argus/tests/test_plugin_contract.py
+++ b/argus/tests/test_plugin_contract.py
@@ -1,0 +1,159 @@
+"""Conformance tests for the ``argus.plugins.v1`` public contract.
+
+These pin the **stable surface third-party plugins (and Argus Enterprise) build
+on**: the ``Finding`` / ``ScanResult`` / ``Severity`` data shapes, the
+``Scanner`` protocol, and the ``argus.reporters`` extension seam. A breaking
+change to any of these fails CI **before merge**, so "update core → break a
+downstream plugin" can't slip through silently.
+
+Stability policy (see ``docs/plugin-contract.md`` / ADR-032): no breaking changes
+to this surface within a major version — adding fields/members is fine, removing
+or renaming one is a breaking change that requires a new contract version and a
+core major bump. Assertions use **subset** checks so additions stay compatible.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import types
+
+from argus.core.models import Finding, ScanResult, Severity
+from argus.core.scanner import Scanner
+from argus.reporters import (
+    ENTRY_POINT_GROUP,
+    available_reporters,
+    get_reporter,
+)
+from argus.reporters import _iter_entry_points, _reset_registry_cache_for_tests
+
+
+class TestFindingContract:
+    REQUIRED = {"id", "severity", "title"}
+    OPTIONAL = {"description", "location", "cwe", "cve", "scanner", "metadata"}
+
+    def test_fields_present(self):
+        names = {f.name for f in dataclasses.fields(Finding)}
+        missing = (self.REQUIRED | self.OPTIONAL) - names
+        assert not missing, f"Finding lost contract fields: {missing}"
+
+    def test_optional_fields_have_defaults(self):
+        fields = {f.name: f for f in dataclasses.fields(Finding)}
+        for name in self.OPTIONAL:
+            f = fields[name]
+            has_default = (
+                f.default is not dataclasses.MISSING
+                or f.default_factory is not dataclasses.MISSING  # type: ignore[misc]
+            )
+            assert has_default, f"contract optional field {name!r} must keep a default"
+
+    def test_minimal_construction(self):
+        f = Finding(id="F1", severity=Severity.HIGH, title="t")
+        assert f.id == "F1" and f.severity is Severity.HIGH
+
+    def test_to_dict_keys_and_severity_is_string(self):
+        d = Finding(id="F1", severity=Severity.HIGH, title="t").to_dict()
+        contract_keys = self.REQUIRED | self.OPTIONAL
+        assert contract_keys <= set(d), f"to_dict dropped contract keys: {contract_keys - set(d)}"
+        assert d["severity"] == "high"  # serialized as the string value, not the enum
+
+
+class TestScanResultContract:
+    def test_fields_present(self):
+        names = {f.name for f in dataclasses.fields(ScanResult)}
+        assert {"scanner", "findings"} <= names
+
+    def test_to_dict_exposes_scanner_and_findings(self):
+        r = ScanResult(scanner="plugin/x", findings=[Finding(id="F", severity=Severity.LOW, title="t")])
+        d = r.to_dict()
+        assert {"scanner", "findings"} <= set(d)
+        assert isinstance(d["findings"], list) and d["findings"][0]["severity"] == "low"
+
+
+class TestSeverityContract:
+    EXPECTED = {
+        "CRITICAL": "critical", "HIGH": "high", "MEDIUM": "medium",
+        "LOW": "low", "INFO": "info", "UNKNOWN": "unknown",
+    }
+
+    def test_members_and_values(self):
+        for name, value in self.EXPECTED.items():
+            assert hasattr(Severity, name), f"Severity lost member {name}"
+            assert getattr(Severity, name).value == value
+
+    def test_from_string_coerces(self):
+        assert Severity.from_string("HIGH") is Severity.HIGH
+        assert Severity.from_string("  critical ") is Severity.CRITICAL
+        assert Severity.from_string("not-a-severity") is Severity.UNKNOWN
+
+
+class TestScannerProtocolContract:
+    def test_conforming_object_is_a_scanner(self):
+        class MyScanner:
+            name = "my-scanner"
+            supports_sbom = False  # part of the Scanner contract (data member)
+
+            def scan(self, path, config=None):  # noqa: ARG002
+                return ScanResult(scanner=self.name)
+
+            def is_available(self):
+                return True
+
+            def install_command(self):
+                return None
+
+            def tool_version(self):
+                return None
+
+        assert isinstance(MyScanner(), Scanner)
+
+    def test_missing_method_is_not_a_scanner(self):
+        class NotAScanner:
+            name = "broken"
+            # no scan()
+
+        assert not isinstance(NotAScanner(), Scanner)
+
+
+class TestReporterSeamContract:
+    def test_entry_point_group_is_stable(self):
+        assert ENTRY_POINT_GROUP == "argus.reporters"
+
+    def test_builtin_reporters_resolve(self):
+        names = available_reporters()
+        assert {"json", "sarif", "markdown"} <= set(names)
+        assert get_reporter("json") is not None
+
+    def test_external_reporter_discovered_via_seam(self, monkeypatch):
+        # A third party registers a reporter under the argus.reporters group.
+        class _ExternalReporter:
+            name = "contract-probe"
+
+            def report(self, summary, output_dir=None):  # noqa: ARG002 - Reporter contract
+                return ""
+
+        def _fake_ep_load():
+            ep = types.SimpleNamespace(
+                name="contract-probe",
+                value="some_pkg.mod:ExternalReporter",  # not argus.reporters.* → external
+                load=lambda: _ExternalReporter,
+            )
+            return [ep]
+
+        monkeypatch.setattr("argus.reporters._iter_entry_points", _fake_ep_load)
+        _reset_registry_cache_for_tests()
+        try:
+            assert "contract-probe" in available_reporters()
+        finally:
+            monkeypatch.undo()
+            _reset_registry_cache_for_tests()
+
+    # NOTE: the "external cannot shadow a built-in name" protection is a security
+    # property of the reporters loader itself (it requires the real built-in entry
+    # point to be present alongside the external one). It is exercised in the
+    # reporters module's own test suite, not here — this conformance suite pins the
+    # public *contract* surface, not the loader's internal precedence rules.
+
+
+def test_iter_entry_points_targets_the_group():
+    # The discovery helper exists and is the seam the contract relies on.
+    assert callable(_iter_entry_points)

--- a/docs/plugin-contract.md
+++ b/docs/plugin-contract.md
@@ -1,0 +1,70 @@
+# Plugin contract — `argus.plugins.v1`
+
+The **stable public surface** that third-party plugins (and Argus Enterprise)
+build on. Anything documented here is contract: Argus commits not to break it
+within a major version. It is enforced by conformance tests
+(`argus/tests/test_plugin_contract.py`) that run on every PR — **a change that
+breaks the contract fails CI before merge**, so "update Argus, break a plugin"
+cannot slip through. See [ADR-032](../.ai/decisions.yaml).
+
+## Stability policy
+
+- **No breaking changes within a major version.** Adding a field, a `Severity`
+  member, or a new entry-point group is backward-compatible. Removing or
+  renaming a documented field/member/method is breaking → it requires a new
+  contract version (`argus.plugins.v2`) and a **major version bump** of
+  `argus-security`.
+- Downstreams pin a **compatible range** (e.g. `argus-security>=1.4,<2.0`) and
+  should add a load-time version guard that degrades gracefully on a mismatch
+  rather than crashing (this is what Argus Enterprise does).
+
+## The contract surface
+
+### Data shapes (`argus.core.models`)
+
+- **`Finding`** — fields: `id`, `severity` (a `Severity`), `title` (required);
+  `description`, `location`, `cwe`, `cve`, `scanner`, `metadata` (optional, with
+  defaults). `to_dict()` emits those keys with `severity` as its string value.
+- **`ScanResult`** — fields include `scanner` and `findings`; `to_dict()` exposes
+  both, with each finding serialized.
+- **`Severity`** — members `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`, `INFO`, `UNKNOWN`
+  (values are the lowercase names). `Severity.from_string(s)` coerces a string
+  (case-insensitive, trimmed); unknown input → `UNKNOWN` (never raises).
+
+### Scanner protocol (`argus.core.scanner.Scanner`)
+
+A `runtime_checkable` Protocol. A conforming scanner provides the data members
+`name: str` and `supports_sbom: bool`, and the methods `scan(path, config=None)
+-> ScanResult`, `is_available() -> bool`, `install_command() -> str | None`,
+`tool_version() -> str | None`.
+
+### Reporter seam (`argus.reporters`)
+
+- Entry-point group: **`argus.reporters`** (the constant
+  `argus.reporters.ENTRY_POINT_GROUP`).
+- A reporter is a class implementing **`report(summary, output_dir=None)`**.
+- A third-party package registers one via
+  `[project.entry-points."argus.reporters"]`; it is discovered and resolvable
+  through `available_reporters()` / `get_reporter(name)`. External reporters
+  **cannot shadow a built-in name** (the loader rejects that).
+
+## Seams still being promoted into the contract
+
+The interactive-extension seams — `argus.console_providers` and
+`argus.viewers.browser_plugins` (plus the `app.state` helper surface) — and the
+container plugin sandbox (`argus.core.plugin_runtime`, ADR-031) are part of the
+plugin story but are **not yet on `main`** (they ride with the TUI/viewer work).
+Their conformance tests join this suite when those seams land in a release; until
+then, only the surface above is a stability guarantee.
+
+## How this protects downstreams
+
+1. **Versioned contract** (this doc) — defines "compatible".
+2. **Conformance tests in core CI** — a contract break fails core CI pre-merge.
+3. **Downstream range pin** — pip refuses to install an out-of-range core while
+   the plugin is installed.
+4. **Load-time version guard** — a forced mismatch degrades gracefully with an
+   actionable "update the plugin" message instead of crashing.
+
+Layers 1–2 live here in the OSS core; 3–4 live in each plugin (e.g. Argus
+Enterprise's `compat` guard).


### PR DESCRIPTION
## Description
The "latest core never breaks latest enterprise" guarantee, OSS half: a **versioned, executable plugin contract** (`argus.plugins.v1`) so a core change that breaks the surface third-party plugins / Argus Enterprise depend on **fails CI before merge** — the break-detection layer of the ranges compatibility model.

## Changes Made
- [x] Updated documentation
- [x] Other (please specify): conformance test suite

### Details
- **`argus/tests/test_plugin_contract.py`** — 14 conformance tests pinning the stable surface: `Finding`/`ScanResult`/`Severity` data shapes + `to_dict`, the `Scanner` protocol, and the `argus.reporters` entry-point seam (incl. external-reporter discovery). Subset assertions, so *adding* fields/members stays compatible; *removing/renaming* one fails CI. Writing them surfaced two real contract facts I'd misremembered — `Scanner` requires the `supports_sbom` data member, and reporters implement `report(summary, output_dir=None)`.
- **`docs/plugin-contract.md`** — the `argus.plugins.v1` surface + stability policy (no breaking changes within a major; break → `v2` + major bump) + how the four layers protect downstreams (versioned contract → conformance tests → range pin → load-time guard).
- **ADR-032** — versioned contract enforced by conformance tests; ranges over lockstep.

The console/browser seams (`argus.console_providers`, `argus.viewers.browser_plugins`) and the sandbox (ADR-031, #296) aren't on `main` yet, so their conformance tests join this suite when those seams land — documented.

## Testing
- [x] Unit tests added/updated

### Test Results
`pytest argus/tests/test_plugin_contract.py` → **14 passed**. Architecture-sync gate passes; ruff clean; YAML valid.

## Security Considerations
- [x] Security enhancement

### Security Details
Protects paid/downstream plugins from silently breaking on a core upgrade — important for a security tool. Pure additive test/doc; no runtime behavior change.

## AI Context Updates (.ai/)
- [x] `.ai/decisions.yaml` updated (ADR-032)

## Checklist
- [x] Code follows project style guidelines
- [x] All tests pass
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
OSS half of the compatibility strategy; pairs with the enterprise runtime version guard + release/dep tooling (private repo). Complements #296 (plugin sandbox / ADR-031).
