### PR TITLE
feat(core): machine-readable config surface for version-derived config UIs

### DIFF
--- a/.ai/architecture.yaml
+++ b/.ai/architecture.yaml
@@ -28,6 +28,7 @@ components:
       core/models.py: Severity enum, Finding/ScanResult/ScanSummary dataclasses
       core/scanner.py: Scanner Protocol definition
       core/config.py: ArgusConfig loading from argus.yml
+      core/config_options.py: 'Machine-readable config surface (versioned in the wheel). ConfigOption/NativeIgnore + BASE_OPTIONS + curated per-scanner knobs; config_surface() returns argus version + JSON schema + registry + every scanner''s options and how to ignore findings (skip_check / expose_ignore_ports / rules_file / native .trivyignore etc.). Scanners may also declare config_options/native_ignore on the class. Consumed by config UIs (Console, Argus Cloud) so they render the exact installed version''s knobs with no separate schema to sync.'
       core/engine.py: 'ArgusEngine orchestrating scanners and aggregating results (delegates to core/prewarm.py
         for background image pre-warm + lazy pulls in parallel mode). Container path honors three optional
         Scanner hooks: container_args/build_args (CLI argv), container_env(config)->dict (resolved values
@@ -703,6 +704,7 @@ docsite:
       core/models.py: Severity enum, Finding/ScanResult/ScanSummary dataclasses
       core/scanner.py: Scanner Protocol definition
       core/config.py: ArgusConfig loading from argus.yml
+      core/config_options.py: 'Machine-readable config surface (versioned in the wheel). ConfigOption/NativeIgnore + BASE_OPTIONS + curated per-scanner knobs; config_surface() returns argus version + JSON schema + registry + every scanner''s options and how to ignore findings (skip_check / expose_ignore_ports / rules_file / native .trivyignore etc.). Scanners may also declare config_options/native_ignore on the class. Consumed by config UIs (Console, Argus Cloud) so they render the exact installed version''s knobs with no separate schema to sync.'
       core/engine.py: 'ArgusEngine orchestrating scanners and aggregating results (delegates to core/prewarm.py
         for background image pre-warm + lazy pulls in parallel mode). Container path honors three optional
         Scanner hooks: container_args/build_args (CLI argv), container_env(config)->dict (resolved values

--- a/argus/core/config_options.py
+++ b/argus/core/config_options.py
@@ -1,0 +1,258 @@
+"""Machine-readable description of every Argus config knob — the *config surface*.
+
+Argus config is otherwise free-form passthrough: each scanner reads whatever keys
+it wants from its ``config`` dict. That's flexible but opaque — a UI (the Console,
+Argus Cloud) can't know that Checkov's rule-skip knob is ``skip_check`` while
+Gitleaks' is a native ``.gitleaksignore``. This module makes those knobs explicit
+and *versioned in the wheel*, so any consumer renders an accurate config editor
+for the exact installed Argus version — no separate schema to keep in sync.
+
+Two layers:
+
+* **Common options** (:data:`BASE_OPTIONS`) apply to every scanner.
+* **Per-scanner options** are declared on the scanner class as ``config_options``
+  (a list of :class:`ConfigOption`), merged on top of the base. A scanner with no
+  declaration still surfaces the base knobs, so a newly added scanner needs no
+  change here.
+
+:func:`config_surface` assembles everything (version + JSON schema + registry +
+per-scanner options) into one dict — the single call an external consumer makes.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+#: How a knob is edited — drives the input widget a UI renders.
+OPTION_KINDS = (
+    "bool",
+    "string",
+    "path",
+    "path_globs",  # comma-separated paths/globs (Argus ``exclude``)
+    "rule_ids",  # comma-separated rule/check IDs (e.g. Checkov ``skip_check``)
+    "severity",  # one of SEVERITY_LEVELS
+    "enum",  # one of ``choices``
+    "config_file",  # path to a tool-native config file
+    "string_list",  # list of strings
+    "port_list",  # list of "PORT/PROTO"
+)
+
+SEVERITY_LEVELS = ("critical", "high", "medium", "low", "none")
+
+
+@dataclass(frozen=True)
+class ConfigOption:
+    """One configurable knob on a scanner (or the common base)."""
+
+    key: str
+    label: str
+    kind: str = "string"
+    help: str = ""
+    #: True when setting this knob SUPPRESSES findings (rule/CVE/path ignore).
+    #: A UI surfaces these as the "ignore this" controls.
+    ignore: bool = False
+    example: str | None = None
+    choices: tuple[str, ...] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        return {k: v for k, v in d.items() if v not in (None, "", False) or k in ("key", "label", "kind")}
+
+
+@dataclass(frozen=True)
+class NativeIgnore:
+    """A scanner's *native* suppression mechanism, when Argus has no direct knob.
+
+    e.g. Trivy respects a ``.trivyignore`` file and ``# trivy:skip=<id>`` comments.
+    A UI uses this to tell a user exactly how to ignore a finding at the source
+    even when there's no ``argus.yml`` key for it.
+    """
+
+    file: str | None = None  # native ignore file, committed to the repo
+    comment: str | None = None  # inline suppression comment
+    help: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {k: v for k, v in asdict(self).items() if v}
+
+
+# ── Common knobs on every scanner ────────────────────────────────────────────
+
+BASE_OPTIONS: tuple[ConfigOption, ...] = (
+    ConfigOption("enabled", "Enabled", "bool", "Run this scanner. Disabled scanners are skipped."),
+    ConfigOption("path", "Path", "path", "Path to scan, relative to the repo root.", example="src"),
+    ConfigOption(
+        "severity_threshold",
+        "Severity threshold",
+        "severity",
+        "Fail the scan at or above this severity (overrides the global threshold).",
+        choices=SEVERITY_LEVELS,
+    ),
+    ConfigOption(
+        "config_file",
+        "Native config file",
+        "config_file",
+        "Path to the underlying tool's own config file.",
+    ),
+    ConfigOption(
+        "exclude",
+        "Exclude paths",
+        "path_globs",
+        "Comma-separated paths/globs to skip.",
+        ignore=True,
+        example="tests,docs,*.min.js",
+    ),
+)
+
+
+# ── Curated per-scanner knobs (source of truth, versioned in the wheel) ───────
+#
+# Keyed by registry name. A scanner MAY instead declare ``config_options`` /
+# ``native_ignore`` on its class (merged first, so it wins) — new scanners can
+# own their metadata; the current set is curated centrally for one-file review.
+# Only knobs the scanner's ``build_args``/``scan`` actually READS are listed, so
+# the UI never offers a no-op key.
+
+_SCANNER_EXTRAS: dict[str, tuple[ConfigOption, ...]] = {
+    "checkov": (
+        ConfigOption("framework", "Framework", "string", "Limit to one framework.", example="terraform"),
+        ConfigOption("check", "Only these checks", "rule_ids", "Run only these check IDs.", example="CKV_AWS_20"),
+        ConfigOption(
+            "skip_check", "Skip checks", "rule_ids",
+            "Check IDs to ignore (e.g. CKV_AWS_1).", ignore=True, example="CKV_AWS_1,CKV_AWS_20",
+        ),
+    ),
+    "opengrep": (
+        ConfigOption("config", "Rules", "string", "Semgrep-compatible rules (path or registry).", example="p/ci"),
+    ),
+    "osv": (
+        ConfigOption("lockfile", "Lockfile", "path", "Scan a specific lockfile."),
+        ConfigOption("recursive", "Recursive", "bool", "Recurse into subdirectories for lockfiles."),
+    ),
+    "container": (
+        ConfigOption("image_ref", "Image", "string", "Container image to scan.", example="myapp:latest"),
+        ConfigOption("scanners", "Sub-scanners", "string", "Comma-separated.", example="trivy,grype,syft,exposure,services"),
+        ConfigOption(
+            "expose_ignore_ports", "Ignore ports", "port_list",
+            "Exposed ports to suppress entirely.", ignore=True, example="22/tcp,3306/tcp",
+        ),
+        ConfigOption(
+            "services_ignore", "Ignore services", "string_list",
+            "Declared services to suppress (case-insensitive).", ignore=True, example="cron,rsyslog",
+        ),
+        ConfigOption("expose_warn_ports", "Warn ports", "port_list", "Override the WARN-list of exposed ports."),
+        ConfigOption("services_warn", "Warn services", "string_list", "Override the WARN-list of services."),
+    ),
+    "zap": (
+        ConfigOption("target_url", "Target URL", "string", "URL of the running app to scan."),
+        ConfigOption("scan_type", "Scan type", "enum", choices=("baseline", "full", "api")),
+        ConfigOption("api_spec", "API spec", "string", "OpenAPI/Swagger spec URL or path (switches to API scan)."),
+        ConfigOption(
+            "rules_file", "Ignore rules", "config_file",
+            "ZAP ignore-rules .tsv (suppress alert IDs).", ignore=True, example=".zap/rules.tsv",
+        ),
+    ),
+    "supply-chain": (
+        ConfigOption(
+            "zizmor_config", "Zizmor config", "config_file",
+            "zizmor config file with rule suppressions.", ignore=True, example=".zizmor.yml",
+        ),
+        ConfigOption("run_actionlint", "Run actionlint", "bool", "Also run actionlint."),
+    ),
+}
+
+#: Native (source-file) suppression for scanners Argus doesn't expose a key for.
+_NATIVE_IGNORE: dict[str, NativeIgnore] = {
+    "bandit": NativeIgnore(file="pyproject.toml ([tool.bandit] skips)", comment="# nosec: B101", help="Bandit skips via native config or inline # nosec."),
+    "gitleaks": NativeIgnore(file="gitleaks.toml (allowlist) / .gitleaksignore", comment="#gitleaks:allow"),
+    "opengrep": NativeIgnore(comment="# nosem: <rule-id>"),
+    "osv": NativeIgnore(file=".osv-scanner.toml (IgnoredVulns)", help="Ignore a CVE by id in the OSV config."),
+    "checkov": NativeIgnore(comment="# checkov:skip=CKV_AWS_1:reason"),
+    "trivy-iac": NativeIgnore(file=".trivyignore", comment="# trivy:skip=<AVD-id>"),
+    "trivy": NativeIgnore(file=".trivyignore", help="Ignore CVE ids, one per line."),
+    "grype": NativeIgnore(file=".grype.yaml (ignore rules)"),
+    "container": NativeIgnore(file=".trivyignore / .grype.yaml", help="Image-layer CVEs use the underlying tools' ignore files."),
+    "lint-yaml": NativeIgnore(file=".yamllint", comment="# yamllint disable-line rule:line-length"),
+    "lint-python": NativeIgnore(file="ruff.toml / setup.cfg / .flake8", comment="# noqa: E501"),
+}
+
+
+def scanner_config_options(name: str, cls: type) -> list[ConfigOption]:
+    """Full option list for a scanner: its own class-declared ``config_options``
+    (highest priority) + the curated central extras + the common base, deduped by
+    key (earliest wins)."""
+    merged: list[ConfigOption] = []
+    seen: set[str] = set()
+    for source in (
+        getattr(cls, "config_options", ()) or (),
+        _SCANNER_EXTRAS.get(name, ()),
+        BASE_OPTIONS,
+    ):
+        for opt in source:
+            if opt.key not in seen:
+                merged.append(opt)
+                seen.add(opt.key)
+    return merged
+
+
+def scanner_native_ignore(name: str, cls: type) -> NativeIgnore | None:
+    """The scanner's native (source-file) suppression mechanism, if any."""
+    declared = getattr(cls, "native_ignore", None)
+    if isinstance(declared, NativeIgnore):
+        return declared
+    return _NATIVE_IGNORE.get(name)
+
+
+def _load_schema() -> dict[str, Any] | None:
+    """The packaged ``argus-config.schema.json`` (repo root / wheel data), or None."""
+    try:
+        import argus
+
+        schema_path = Path(argus.__file__).resolve().parent.parent / "argus-config.schema.json"
+        if schema_path.is_file():
+            return json.loads(schema_path.read_text(encoding="utf-8"))
+    except Exception:
+        pass
+    return None
+
+
+def config_surface(*, include_schema: bool = True) -> dict[str, Any]:
+    """The complete, versioned config surface — the one call a UI makes.
+
+    Returns Argus version, the config-format version, the JSON schema, the
+    severity levels, and every scanner with its knobs (incl. how to ignore
+    findings). Assembled from the live registry, so it always matches the
+    installed Argus version.
+    """
+    from argus import __version__
+    from argus.scanners import SCANNER_REGISTRY
+
+    scanners: list[dict[str, Any]] = []
+    for name, cls in sorted(SCANNER_REGISTRY.items()):
+        options = scanner_config_options(name, cls)
+        native = scanner_native_ignore(name, cls)
+        scanners.append(
+            {
+                "name": name,
+                "description": getattr(cls, "description", ""),
+                "category": getattr(cls, "category", "other"),
+                "languages": list(getattr(cls, "languages", []) or []),
+                "supports_sbom": bool(getattr(cls, "supports_sbom", False)),
+                "options": [o.to_dict() for o in options],
+                "ignore_keys": [o.key for o in options if o.ignore],
+                "native_ignore": native.to_dict() if native else None,
+            }
+        )
+
+    surface: dict[str, Any] = {
+        "argus_version": __version__,
+        "config_version": "1.0",
+        "severity_levels": list(SEVERITY_LEVELS),
+        "scanners": scanners,
+    }
+    if include_schema:
+        surface["schema"] = _load_schema()
+    return surface

--- a/argus/core/scanner.py
+++ b/argus/core/scanner.py
@@ -26,6 +26,14 @@ class Scanner(Protocol):
         supports_sbom: bool — True when the scanner can accept a pre-built
             SBOM via ``config["sbom_path"]`` instead of a filesystem path.
             Consumed by ``argus scan --sbom`` to auto-select capable tools.
+
+    Config metadata (optional — drives config UIs like the Console / Argus Cloud):
+        config_options: list[ConfigOption] — the scanner's own configurable
+            knobs beyond the common base (see ``argus.core.config_options``).
+        native_ignore: NativeIgnore — how to suppress findings at the source
+            when there's no direct ``argus.yml`` key (e.g. ``.trivyignore``).
+        A scanner that declares neither still surfaces the common base options,
+        so a new scanner needs no config-UI change to be configurable.
     """
 
     name: str

--- a/argus/tests/test_config_options.py
+++ b/argus/tests/test_config_options.py
@@ -74,6 +74,23 @@ def test_class_declared_options_win_over_central_and_base() -> None:
     assert scanner_native_ignore("fake", FakeScanner).comment == "# fake:skip"
 
 
+def test_curated_metadata_never_orphans() -> None:
+    """Every curated extras/native-ignore key must name a REGISTERED scanner.
+
+    Guards the scale seam: if a scanner is renamed or removed, its curated
+    metadata would otherwise silently orphan (the scanner would fall back to
+    base-only knobs and the stale entry would linger forever)."""
+    from argus.core.config_options import _NATIVE_IGNORE, _SCANNER_EXTRAS
+
+    registered = set(SCANNER_REGISTRY)
+    assert set(_SCANNER_EXTRAS) <= registered, (
+        f"orphaned _SCANNER_EXTRAS keys: {set(_SCANNER_EXTRAS) - registered}"
+    )
+    assert set(_NATIVE_IGNORE) <= registered, (
+        f"orphaned _NATIVE_IGNORE keys: {set(_NATIVE_IGNORE) - registered}"
+    )
+
+
 def test_config_option_to_dict_omits_empty_but_keeps_core() -> None:
     d = ConfigOption("k", "L").to_dict()
     assert d["key"] == "k" and d["label"] == "L" and d["kind"] == "string"

--- a/argus/tests/test_config_options.py
+++ b/argus/tests/test_config_options.py
@@ -1,0 +1,82 @@
+"""Tests for the machine-readable config surface (argus.core.config_options)."""
+
+from __future__ import annotations
+
+import argus
+from argus.core.config_options import (
+    BASE_OPTIONS,
+    ConfigOption,
+    NativeIgnore,
+    config_surface,
+    scanner_config_options,
+    scanner_native_ignore,
+)
+from argus.scanners import SCANNER_REGISTRY
+
+_BASE_KEYS = {"enabled", "path", "severity_threshold", "config_file", "exclude"}
+
+
+def test_surface_is_versioned_and_complete() -> None:
+    s = config_surface()
+    assert s["argus_version"] == argus.__version__
+    assert s["config_version"] == "1.0"
+    assert "critical" in s["severity_levels"]
+    # Every registered scanner is present exactly once.
+    names = [x["name"] for x in s["scanners"]]
+    assert set(names) == set(SCANNER_REGISTRY)
+    assert len(names) == len(set(names)) == len(SCANNER_REGISTRY)
+
+
+def test_schema_is_embedded_from_the_installed_package() -> None:
+    schema = config_surface()["schema"]
+    assert isinstance(schema, dict)
+    assert "properties" in schema and "scanners" in schema["properties"]
+
+
+def test_every_scanner_carries_the_base_options() -> None:
+    for entry in config_surface()["scanners"]:
+        keys = {o["key"] for o in entry["options"]}
+        assert _BASE_KEYS <= keys, f"{entry['name']} missing base options"
+
+
+def test_checkov_exposes_skip_check_as_an_ignore_knob() -> None:
+    checkov = next(x for x in config_surface()["scanners"] if x["name"] == "checkov")
+    skip = next(o for o in checkov["options"] if o["key"] == "skip_check")
+    assert skip["kind"] == "rule_ids" and skip["ignore"] is True
+    assert "skip_check" in checkov["ignore_keys"]
+
+
+def test_container_and_zap_ignore_knobs() -> None:
+    surface = {x["name"]: x for x in config_surface()["scanners"]}
+    assert "expose_ignore_ports" in surface["container"]["ignore_keys"]
+    assert "services_ignore" in surface["container"]["ignore_keys"]
+    assert "rules_file" in surface["zap"]["ignore_keys"]
+
+
+def test_native_ignore_for_scanners_without_a_direct_knob() -> None:
+    surface = {x["name"]: x for x in config_surface()["scanners"]}
+    assert surface["trivy"]["native_ignore"]["file"] == ".trivyignore"
+    assert surface["gitleaks"]["native_ignore"]["comment"] == "#gitleaks:allow"
+
+
+def test_class_declared_options_win_over_central_and_base() -> None:
+    # A scanner may own its metadata; its declaration dedupes ahead of the base.
+    class FakeScanner:
+        name = "fake"
+        config_options = (ConfigOption("enabled", "On?", "bool", "custom"),)
+        native_ignore = NativeIgnore(comment="# fake:skip")
+
+    opts = scanner_config_options("fake", FakeScanner)
+    enabled = [o for o in opts if o.key == "enabled"]
+    assert len(enabled) == 1 and enabled[0].help == "custom"
+    # Base keys still present.
+    assert _BASE_KEYS <= {o.key for o in opts}
+    assert scanner_native_ignore("fake", FakeScanner).comment == "# fake:skip"
+
+
+def test_config_option_to_dict_omits_empty_but_keeps_core() -> None:
+    d = ConfigOption("k", "L").to_dict()
+    assert d["key"] == "k" and d["label"] == "L" and d["kind"] == "string"
+    assert "ignore" not in d  # False is omitted
+    assert "example" not in d  # None is omitted
+    assert BASE_OPTIONS[0].key == "enabled"


### PR DESCRIPTION
## Description
Adds a versioned, machine-readable description of every Argus config knob — the *config surface* — so any config UI (the Console, Argus Cloud) can render an accurate editor for the **exact installed Argus version** without maintaining its own copy of the schema. Argus config is otherwise free-form passthrough, so a UI can't know that Checkov's rule-skip knob is `skip_check` while Gitleaks' is a native `.gitleaksignore`. This makes those knobs (and how to ignore findings) explicit and shipped in the wheel.

## Changes Made
- [ ] Added new scanner/workflow
- [ ] Modified existing scanner/workflow
- [x] Updated documentation
- [x] Other (please specify): new `core/config_options.py` module (config surface)

### Details
- **New `argus/core/config_options.py`**: `ConfigOption` / `NativeIgnore` dataclasses, a common `BASE_OPTIONS` set, curated per-scanner knobs (Checkov `skip_check`, container `expose_ignore_ports`/`services_ignore`, ZAP `rules_file`, supply-chain `zizmor_config`, …), and native ignore mechanisms for scanners with no direct key (`.trivyignore`, `.gitleaksignore`, `.osv-scanner.toml`, `# nosec`/`# nosem`/`# checkov:skip` …). Only knobs a scanner actually reads are listed, so a UI never offers a no-op key.
- **`config_surface()`** assembles argus version + config-format version + the packaged JSON schema + the live scanner registry + every scanner's options and ignore mechanisms into one dict — the single call an external consumer makes.
- Scanners may also declare `config_options` / `native_ignore` on the class (merged ahead of the central set), so a new scanner can own its metadata; one with none still surfaces the base knobs. Documented on the `Scanner` protocol.
- **No breaking changes** — purely additive; no change to config loading, validation, or scanner execution.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results
- New `argus/tests/test_config_options.py` (8 tests): surface is versioned + complete (all 23 registry scanners), schema embedded from the installed package, every scanner carries the base options, ignore knobs correct (Checkov `skip_check`, container/ZAP), native ignore for keyless scanners, class-declared options win over central/base.
- Full suite green: `4260 passed, 21 skipped`. `ruff` clean; pre-commit hooks pass.

## Security Considerations
- [x] No security enhancement — read-only metadata about config that the schema already implies; no new execution paths, no new inputs to scanners.

### Security Details
The module only *describes* existing config keys and documents each scanner's native suppression mechanism; it changes no scan behavior and adds no attack surface.

## AI Context Updates (.ai/)
- [x] `.ai/architecture.yaml` updated (added `core/config_options.py`)
- [x] N/A for workflows.yaml / decisions.yaml / errors.yaml (no command/decision/error changes)

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (Scanner protocol docstring + `.ai/architecture.yaml`)
- [ ] Changelog updated (managed by release-it)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

### For New Scanners/Actions (if applicable)
N/A — not a scanner/action; a core config-metadata module.

## Related Issues
N/A

## Screenshots/Logs (if applicable)
`config_surface()` on the current tree returns 23 scanners with, e.g. — `checkov: ignore_keys=['skip_check']`, `container: ['expose_ignore_ports','services_ignore']`, `zap: ['rules_file']`, and native ignores like `trivy → .trivyignore`, `gitleaks → #gitleaks:allow`.
