### PR TITLE
fix(release): pin conventionalcommits to v9 + guard changelog structure

### DIFF
--- a/.ai/errors.yaml
+++ b/.ai/errors.yaml
@@ -678,3 +678,57 @@ errors:
         '
       reference: argus/containers.py + .github/workflows/release.yml (promote/cosign/notes loops) + scripts/ci/check_container_images.py
     symptom: manifest unknown|<scanner>:<version> failed manifest check|pinned image tag does not resolve after release
+  EMPTY_CHANGELOG_CONVENTIONALCOMMITS_V10_INCOMPATIBLE_WITH_RELEASE_IT:
+    category: release
+    context: 'The release-preview / release-it changelog renders EMPTY — just the
+
+      version header (e.g. ``## [1.8.1](compare/1.8.0...1.8.1)``) with no
+
+      ``### Maintenance`` / ``### Dependencies`` sections and no commit
+
+      entries, even though there are conventional ``chore(deps):`` commits
+
+      since the last tag.
+
+      '
+    root_cause: 'A major bump of ``conventional-changelog-conventionalcommits``
+
+      to v10 (Dependabot npm-major, PR #316). v10 replaced Handlebars
+
+      template *strings* with render *functions* (``@conventional-changelog/
+
+      template``), which require ``conventional-changelog-writer@9``. But
+
+      ``@release-it/conventional-changelog@11`` (latest) still pins
+
+      ``conventional-changelog@7`` → ``writer@8`` (Handlebars) and expects
+
+      the preset at ``^9.3.1``. writer@8 handed v10 function templates
+
+      compiles to nothing: commits parse and pass filtering (transform
+
+      returns kept=true) but the template layer renders empty. The
+
+      ``hidden`` → ``effect`` config change in v10 is a red herring here —
+
+      even ``effect: bump`` stays empty because the writer can''t render.
+
+      '
+    solution:
+      steps:
+      - 'Pin ``conventional-changelog-conventionalcommits`` to ``^9.3.1`` in package.json (align with what @release-it/conventional-changelog@11 supports). NOT a git revert of the merge — a forward constraint fix.'
+      - 'Add a Dependabot ``ignore`` for that dep''s ``version-update:semver-major`` (npm ecosystem) so v10 is not re-proposed until the release toolchain adopts the render-function stack (conventional-changelog@8 / writer@9).'
+      - 'Guard in CI: the release-preview "Verify changelog structure" step hard-fails when a release is expected but the changelog body has no sections/entries — catches this class of preset/writer incompatibility for any dep.'
+      note: 'Verify locally without cutting a release: ``npx release-it --changelog
+
+        --no-git.requireUpstream --hooks.before:init=true`` (prints the changelog
+
+        and exits; the hook override skips the npm test before:init hook). A
+
+        clean migration to v10 is blocked until @release-it/conventional-changelog
+
+        ships render-function support.
+
+        '
+      reference: package.json + .github/dependabot.yml + .github/workflows/release-preview.yml + scripts/release-it-process-changelog.js
+    symptom: empty changelog|release preview shows only version header|no Maintenance/Dependencies section|chore(deps) commits missing from changelog

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -105,6 +105,21 @@ updates:
           - "minor"
           - "patch"
 
+    # Hold conventional-changelog-conventionalcommits at v9.x. v10 replaced
+    # Handlebars template strings with render functions (@conventional-changelog/
+    # template), which require conventional-changelog-writer@9. Our release
+    # toolchain's writer is pinned transitively by @release-it/conventional-
+    # changelog@11 (latest), which still depends on conventional-changelog@7 →
+    # writer@8 (Handlebars) and conventionalcommits@^9.3.1. Under v10 the
+    # changelog renders EMPTY (commits parse + pass filtering but the Handlebars
+    # writer can't compile function templates). Re-enable the major bump once
+    # @release-it/conventional-changelog ships support for the render-function
+    # stack (core@8 / writer@9). See the release-preview "Verify changelog
+    # structure" gate.
+    ignore:
+      - dependency-name: "conventional-changelog-conventionalcommits"
+        update-types: ["version-update:semver-major"]
+
     commit-message:
       prefix: "chore(deps)"
 

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -177,8 +177,45 @@ jobs:
           path: release_output.txt
           retention-days: 7
 
+      - name: Verify changelog structure
+        # Gate: if release-it would cut a release, the generated changelog MUST
+        # contain sections/entries. A version bump with an EMPTY changelog body
+        # is the signature of a conventional-changelog preset/writer
+        # incompatibility (e.g. conventionalcommits v10 render-function templates
+        # vs the Handlebars conventional-changelog-writer@8 our release toolchain
+        # pins). This blocks such a dependency update from merging.
+        run: |
+          if ! grep -q "Let's release" release_output.txt; then
+            echo "No release expected for this PR; skipping changelog structure check."
+            exit 0
+          fi
+
+          # Extract the changelog body the same way the preview does.
+          sed -n '/^Changelog:/,/^Updating version/p' release_output.txt \
+            | sed '1d;$d' > changelog_check.md
+
+          # A healthy changelog has at least one section (### ...) or entry (* / -).
+          if grep -qE '^[[:space:]]*(\*|-|###)[[:space:]]' changelog_check.md; then
+            echo "✅ Changelog structure OK — sections/entries present."
+            exit 0
+          fi
+
+          echo "::error title=Empty changelog::A release is expected but the generated changelog has no sections or entries."
+          echo ""
+          echo "This is the signature of a conventional-changelog preset/writer incompatibility."
+          echo "Most likely a conventional-changelog-conventionalcommits major bump (v10+) whose"
+          echo "render-function templates are not understood by the Handlebars-based"
+          echo "conventional-changelog-writer@8 that @release-it/conventional-changelog@11 pins."
+          echo ""
+          echo "Fix: keep conventional-changelog-conventionalcommits at ^9.3.1 until the release"
+          echo "toolchain adopts the render-function stack (conventional-changelog@8 / writer@9)."
+          echo ""
+          echo "----- rendered changelog body (empty) -----"
+          cat changelog_check.md
+          exit 1
+
       - name: Comment PR
-        if: success() && github.event.pull_request.head.repo.full_name == github.repository
+        if: always() && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         continue-on-error: true
         with:

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@digitalroute/cz-conventional-changelog-for-jira": "^8.0.1",
     "@octokit/plugin-paginate-rest": "^14.0.0",
-    "conventional-changelog-conventionalcommits": "^10.2.0",
+    "conventional-changelog-conventionalcommits": "^9.3.1",
     "cz-emoji-conventional": "^1.2.1",
     "dateformat": "^5.0.3",
     "husky": "^9.1.7"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^14.0.0
         version: 14.0.0(@octokit/core@7.0.6)
       conventional-changelog-conventionalcommits:
-        specifier: ^10.2.0
-        version: 10.2.0
+        specifier: ^9.3.1
+        version: 9.3.1
       cz-emoji-conventional:
         specifier: ^1.2.1
         version: 1.2.1(@types/node@25.7.0)
@@ -634,10 +634,6 @@ packages:
 
   conventional-changelog-angular@9.2.1:
     resolution: {integrity: sha512-oWSL6ZhnXbYraOFTK3PgRAQJ8fADDAEv5K6AdeyQPLvjFmhG8+ejL0jZZp/R7vTmGJaBvZEE+sE7dB4bCv7sAw==}
-    engines: {node: '>=22'}
-
-  conventional-changelog-conventionalcommits@10.2.0:
-    resolution: {integrity: sha512-UtlM9GqolY7OmlQh5L/UEVoKsTUpTgUVy1PU8JN5gl5Ydaejb7WRklGliG1SKPxxj7hzA173eG3Kt5fYWE2pmg==}
     engines: {node: '>=22'}
 
   conventional-changelog-conventionalcommits@9.3.1:
@@ -2324,10 +2320,6 @@ snapshots:
       compare-func: 2.0.0
 
   conventional-changelog-angular@9.2.1:
-    dependencies:
-      '@conventional-changelog/template': 1.2.1
-
-  conventional-changelog-conventionalcommits@10.2.0:
     dependencies:
       '@conventional-changelog/template': 1.2.1
 


### PR DESCRIPTION
## Description
The `conventional-changelog-conventionalcommits` **9.3.1 → 10.2.0** bump (#316) broke changelog generation — the release-preview / release-it changelog renders **empty** (version header only, no `### Maintenance` / `### Dependencies` sections and no `chore(deps)` entries).

## Changes Made
- [ ] Added new scanner/workflow
- [ ] Modified existing scanner/workflow
- [ ] Updated documentation
- [x] Fixed bug
- [x] Other (please specify): dependency pin + CI guard + dependabot ignore

### Details
**Root cause (dry-run verified):** v10 replaced Handlebars template *strings* with render *functions* (`@conventional-changelog/template`), which require `conventional-changelog-writer@9`. But `@release-it/conventional-changelog@11` (latest) still pins `conventional-changelog@7` → `writer@8` (Handlebars) and expects the preset at `^9.3.1`. writer@8 handed v10's function templates renders nothing: commits parse and pass filtering (transform returns `kept=true`) but the template layer produces no output. A clean migration to v10 is **not possible** until the release plugin adopts the render-function stack (core@8 / writer@9).

- **`package.json`** — pin `conventional-changelog-conventionalcommits` to `^9.3.1`. This is a forward constraint fix, **not** a git revert of #316 (the merge stays in history).
- **`.github/dependabot.yml`** — `ignore` `version-update:semver-major` for that dep (npm ecosystem) so v10 isn't re-proposed until the toolchain supports it, with an explanatory comment.
- **`.github/workflows/release-preview.yml`** — new **"Verify changelog structure"** step that hard-fails when a release is expected but the changelog body has no sections/entries (catches this class of preset/writer incompatibility for any dep). Comment PR switched to `if: always()` so the preview still posts on failure.
- **`.ai/errors.yaml`** — record the incompatibility, root cause, and fix.

No breaking changes.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results
Dry run (no release performed):
```
$ npx release-it --changelog --no-git.requireUpstream --hooks.before:init=true
## [1.8.1](.../compare/1.8.0...1.8.1) (2026-07-06)
### Maintenance
* **deps:** bump conventional-changelog-conventionalcommits (#316) ...
* **deps:** bump the npm-minor-patch group with 3 updates (#317) ...
* **deps:** Update container-images (#315) ...
* **deps:** Update github-actions-minor-patch (#314) ...
```
Post-processor (`release-it-process-changelog.js`) then categorizes these into the `### Dependencies` section as before. Before the fix the same command emitted only the version header.

## Security Considerations
- [x] No security impact
- [ ] Security enhancement
- [ ] Potential security implications (explain below)

### Security Details
Dependency version constraint + CI/config only. No runtime or scanner behavior change.

## AI Context Updates (.ai/)
- [ ] `.ai/architecture.yaml` updated (if components/structure changed)
- [ ] `.ai/workflows.yaml` updated (if commands/tasks changed)
- [ ] `.ai/decisions.yaml` updated (if design decision made)
- [x] `.ai/errors.yaml` updated (if common error addressed)
- [ ] N/A - No .ai/ updates needed

## Checklist
- [x] Code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [x] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Closes #

## Screenshots/Logs (if applicable)
N/A