### PR TITLE
fix(deps): remove invalid docker pre-release ignore from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,15 +60,15 @@ updates:
         patterns:
           - "*"
 
-    # Skip Python pre-release base images. Dependabot's docker manager sorts
-    # e.g. python:3.15.0b2-alpine ahead of the stable 3.14.x line and proposes
-    # it (see #290); Dependabot owns the Dockerfile FROM lines (Renovate, which
-    # has ignoreUnstable, only handles the ARG tool versions + source-pinned
-    # tags). Track stable Python only — the final X.Y.0 release is still picked
-    # up; only aN / bN / rcN pre-releases are ignored.
-    ignore:
-      - dependency-name: "python"
-        versions: ["*0a*", "*0b*", "*0rc*"]
+    # NOTE on Python pre-release base images (#290): Dependabot's docker manager
+    # can sort e.g. python:3.15.0b2-alpine ahead of the stable 3.14.x line. There
+    # is NO valid dependabot.yml way to filter these out — docker `ignore.versions`
+    # uses Bundler version-requirement syntax, so substring globs like "*0b*" are
+    # rejected as invalid version requirements (they broke config validation), and
+    # ignoring pre-release docker tags via `versions` is unsupported upstream
+    # (dependabot-core #15154). A pre-release base-image PR, if it recurs, is caught
+    # by the mandatory manual review below + the 7-day cooldown; FROM lines are
+    # SHA-digest pinned, so nothing auto-applies. Revisit if #15154 ships a fix.
 
     commit-message:
       prefix: "chore(deps)"


### PR DESCRIPTION
## Description
The Dependabot config check is failing on `main`:
```
The property '#/updates/1/ignore/0/versions' includes invalid version requirements for a docker ignore condition
```
`updates[1]` is the **docker** ecosystem block. Its Python pre-release ignore used substring globs (`versions: ["*0a*", "*0b*", "*0rc*"]`), which are **not valid Bundler version requirements** — the syntax docker `ignore.versions` requires. The condition was latent until #318 touched `dependabot.yml` and triggered a full re-validation.

## Changes Made
- [ ] Added new scanner/workflow
- [ ] Modified existing scanner/workflow
- [ ] Updated documentation
- [x] Fixed bug
- [x] Other (please specify): Dependabot config validation fix

### Details
- Removed the invalid docker `ignore` condition and replaced it with a comment documenting the constraint.
- Because the globs were never valid Bundler syntax, the condition **provided no real protection** even before it started failing validation.
- There is **no supported `dependabot.yml` way** to ignore pre-release docker tags via `versions` ([dependabot-core #15154](https://github.com/dependabot/dependabot-core/issues/15154)). The Python pre-release concern from #290 is instead covered by safeguards already in the file: **mandatory manual review**, the **7-day cooldown**, and **SHA-digest-pinned `FROM` lines** (nothing auto-applies).
- The npm `conventional-changelog-conventionalcommits` major-ignore added in #318 is **unaffected** — it uses `update-types`, which is valid.

No breaking changes.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results
Validated the config parses and the offending condition is gone:
```
updates[0] ecosystem=pip      ignore=None
updates[1] ecosystem=docker   ignore=None   ← invalid condition removed
updates[2] ecosystem=npm      ignore=[{... update-types: [version-update:semver-major]}]  ← valid
```

## Security Considerations
- [x] No security impact
- [ ] Security enhancement
- [ ] Potential security implications (explain below)

### Security Details
Dependabot config only. `FROM` lines remain SHA-digest pinned; the 7-day cooldown and manual-review policy are unchanged, so a stray pre-release base-image PR is still gated by human review.

## AI Context Updates (.ai/)
- [ ] `.ai/architecture.yaml` updated (if components/structure changed)
- [ ] `.ai/workflows.yaml` updated (if commands/tasks changed)
- [ ] `.ai/decisions.yaml` updated (if design decision made)
- [ ] `.ai/errors.yaml` updated (if common error addressed)
- [x] N/A - No .ai/ updates needed

## Checklist
- [x] Code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Closes #
Refs #290, #318

## Screenshots/Logs (if applicable)
N/A