### PR TITLE
fix(docker): harden release tool downloads with retries + temp-file extract

### DIFF
--- a/docker/Dockerfile.cli
+++ b/docker/Dockerfile.cli
@@ -25,36 +25,29 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
       echo "64bit" > /tmp/arch_trivy && echo "amd64" > /tmp/arch_go && echo "x86" > /tmp/arch_opengrep && echo "x64" > /tmp/arch_gitleaks; \
     fi
 
-# Trivy
-RUN ARCH=$(cat /tmp/arch_trivy) && \
-    curl -sSfL "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-${ARCH}.tar.gz" \
-      | tar -xz -C /usr/local/bin trivy
-
-# Grype
-RUN ARCH=$(cat /tmp/arch_go) && \
-    curl -sSfL "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_${ARCH}.tar.gz" \
-      | tar -xz -C /usr/local/bin grype
-
-# Syft
-RUN ARCH=$(cat /tmp/arch_go) && \
-    curl -sSfL "https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_${ARCH}.tar.gz" \
-      | tar -xz -C /usr/local/bin syft
-
-# Gitleaks
-RUN ARCH=$(cat /tmp/arch_gitleaks) && \
-    curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_${ARCH}.tar.gz" \
-      | tar -xz -C /usr/local/bin gitleaks
-
-# Actionlint
-RUN ARCH=$(cat /tmp/arch_go) && \
-    curl -sSfL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_${ARCH}.tar.gz" \
-      | tar -xz -C /usr/local/bin actionlint
-
-# OpenGrep
-RUN ARCH=$(cat /tmp/arch_opengrep) && \
-    curl -sSfL "https://github.com/opengrep/opengrep/releases/download/v${OPENGREP_VERSION}/opengrep_manylinux_${ARCH}" \
-      -o /usr/local/bin/opengrep && \
-    chmod +x /usr/local/bin/opengrep
+# Download binary tools. dl() fetches to a temp file with retries so a transient
+# GitHub 5xx/timeout/conn-reset is retried instead of failing the release
+# (see #320), and tar/install only run on a complete download — no partial-stream
+# corruption from a broken `curl | tar` pipe. Retries are scoped to transient
+# errors (408/429/5xx/timeouts + connection-refused); a 404 (bad version pin)
+# still fails fast rather than retrying, so it surfaces loudly.
+RUN set -eu && \
+    dl() { curl -fsSL --retry 5 --retry-delay 2 --retry-connrefused --connect-timeout 10 -o "$2" "$1"; } && \
+    TRIVY_ARCH=$(cat /tmp/arch_trivy) && GO_ARCH=$(cat /tmp/arch_go) && \
+    OG_ARCH=$(cat /tmp/arch_opengrep) && GL_ARCH=$(cat /tmp/arch_gitleaks) && \
+    dl "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-${TRIVY_ARCH}.tar.gz" /tmp/trivy.tgz && \
+    tar -xzf /tmp/trivy.tgz -C /usr/local/bin trivy && \
+    dl "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_${GO_ARCH}.tar.gz" /tmp/grype.tgz && \
+    tar -xzf /tmp/grype.tgz -C /usr/local/bin grype && \
+    dl "https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_${GO_ARCH}.tar.gz" /tmp/syft.tgz && \
+    tar -xzf /tmp/syft.tgz -C /usr/local/bin syft && \
+    dl "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_${GL_ARCH}.tar.gz" /tmp/gitleaks.tgz && \
+    tar -xzf /tmp/gitleaks.tgz -C /usr/local/bin gitleaks && \
+    dl "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_${GO_ARCH}.tar.gz" /tmp/actionlint.tgz && \
+    tar -xzf /tmp/actionlint.tgz -C /usr/local/bin actionlint && \
+    dl "https://github.com/opengrep/opengrep/releases/download/v${OPENGREP_VERSION}/opengrep_manylinux_${OG_ARCH}" /tmp/opengrep && \
+    install -m 0755 /tmp/opengrep /usr/local/bin/opengrep && \
+    rm -f /tmp/trivy.tgz /tmp/grype.tgz /tmp/syft.tgz /tmp/gitleaks.tgz /tmp/actionlint.tgz /tmp/opengrep
 
 # ---------------------------------------------------------------------------
 # Stage 2: Runtime image

--- a/docker/Dockerfile.opengrep
+++ b/docker/Dockerfile.opengrep
@@ -3,15 +3,19 @@ FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6ee
 ARG OPENGREP_VERSION=1.23.0
 ARG TARGETARCH
 
+# Fetch to a temp file with retries (transient GitHub 5xx/timeout/conn-reset are
+# retried; a 404 still fails fast), then install only on a complete download. See #320.
 RUN apk add --no-cache curl && \
     if [ "$TARGETARCH" = "arm64" ]; then \
       ARCH="aarch64"; \
     else \
       ARCH="x86"; \
     fi && \
-    curl -sSfL "https://github.com/opengrep/opengrep/releases/download/v${OPENGREP_VERSION}/opengrep_manylinux_${ARCH}" \
-      -o /usr/local/bin/opengrep && \
-    chmod +x /usr/local/bin/opengrep
+    curl -fsSL --retry 5 --retry-delay 2 --retry-connrefused --connect-timeout 10 \
+      -o /tmp/opengrep \
+      "https://github.com/opengrep/opengrep/releases/download/v${OPENGREP_VERSION}/opengrep_manylinux_${ARCH}" && \
+    install -m 0755 /tmp/opengrep /usr/local/bin/opengrep && \
+    rm -f /tmp/opengrep
 
 FROM python:3.14.6-slim@sha256:b877e50bd90de10af8d82c57a022fc2e0dc731c5320d762a27986facfc3355c1
 

--- a/docker/Dockerfile.supply-chain
+++ b/docker/Dockerfile.supply-chain
@@ -3,14 +3,19 @@ FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6ee
 ARG ACTIONLINT_VERSION=1.7.12
 ARG TARGETARCH
 
+# Fetch to a temp file with retries (transient GitHub 5xx/timeout/conn-reset are
+# retried; a 404 still fails fast), then extract only on a complete download. See #320.
 RUN apk add --no-cache curl && \
     if [ "$TARGETARCH" = "arm64" ]; then \
       ARCH="arm64"; \
     else \
       ARCH="amd64"; \
     fi && \
-    curl -sSfL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_${ARCH}.tar.gz" \
-      | tar -xz -C /usr/local/bin actionlint
+    curl -fsSL --retry 5 --retry-delay 2 --retry-connrefused --connect-timeout 10 \
+      -o /tmp/actionlint.tgz \
+      "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_${ARCH}.tar.gz" && \
+    tar -xzf /tmp/actionlint.tgz -C /usr/local/bin actionlint && \
+    rm -f /tmp/actionlint.tgz
 
 FROM python:3.14.6-alpine@sha256:26730869004e2b9c4b9ad09cab8625e81d256d1ce97e72df5520e806b1709f92
 


### PR DESCRIPTION
## Description
Release container builds fail on any transient GitHub Releases hiccup because the Dockerfiles `curl` their tools with **no retry** and pipe straight to `tar`. A single 5xx/timeout aborts the whole release.

Run [28816212165](https://github.com/huntridge-labs/argus/actions/runs/28816212165): the Grype asset returned a **504**, `curl -f` produced no body, the piped `tar` choked (`gzip: invalid magic`), and the build failed.

Closes #320.

## Changes Made
- [ ] Added new scanner/workflow
- [x] Modified existing scanner/workflow
- [ ] Updated documentation
- [x] Fixed bug

### Details
Every tool download now:
1. **Retries transient failures** — `curl --retry 5 --retry-delay 2 --retry-connrefused --connect-timeout 10`. Covers 408/429/5xx/timeouts (incl. the 504 that broke the release) + connection-refused.
   - Deliberately **not** `--retry-all-errors`: a **404** means a bad version pin and must fail fast and loud, not retry 5×. (Verified: a 404 exits non-zero near-instantly.)
2. **Downloads to a temp file, then `tar -xzf` / `install`** instead of `curl | tar`. curl can fully retry a partial/corrupt download, and `tar`/`install` only run on a complete file — no partial-stream corruption (the `gzip: invalid magic` failure mode).

Files:
- `docker/Dockerfile.cli` — trivy, grype, syft, gitleaks, actionlint, opengrep. The six separate download `RUN`s are consolidated into one `RUN` with a small `dl()` helper so the retry policy lives in a single place.
- `docker/Dockerfile.opengrep` — opengrep (raw binary → `install -m 0755`).
- `docker/Dockerfile.supply-chain` — actionlint.

No version changes; pins and arch mapping are untouched.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

### Test Results
- `sh -n` syntax check on all three edited `RUN` bodies: OK.
- **End-to-end against a live release asset** (actionlint 1.7.12 linux amd64), exact command form:
  - download with retry flags → 2.35 MB tarball ✅
  - `tar -xzf … actionlint` + `install -m 0755` → executable extracted ✅
  - negative test: a 404 URL **fails fast** (non-zero, near-instant, no retry loop) ✅
- Full container builds run in CI on this PR (`Build Images` matrix).

## Security Considerations
- [ ] No security impact
- [x] Security enhancement

### Security Details
Improves supply-chain robustness of the build (no behavior change to what's fetched — same URLs, same pinned versions, same SHA-pinned base images). `-fsSL` retained. Retries are bounded and scoped to transient errors, so a wrong/removed pinned asset still fails the build rather than being silently retried.

## AI Context Updates (.ai/)
- [x] N/A - No .ai/ updates needed

## Checklist
- [x] Code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Closes #320
Refs release run 28816212165

## Notes
Doesn't address the deeper "pull 8+ tools from GitHub on every build" cost — that's the ECR pull-through cache / digest-pinned mirror work tracked separately. This just stops transient blips from failing releases.