### PR TITLE
fix(ci): surface scanner failures — gate continue-on-error on allow_failure

### DIFF
--- a/.github/workflows/reusable-security-hardening.yml
+++ b/.github/workflows/reusable-security-hardening.yml
@@ -453,6 +453,7 @@ jobs:
     if: needs.scan-coordinator.outputs.run_codeql == 'true'
     uses: huntridge-labs/argus/.github/workflows/scanner-codeql.yml@1.8.1
     with:
+      allow_failure: ${{ inputs.allow_failure }}
       codeql_languages: ${{ inputs.codeql_languages }}
       config_file: ${{ inputs.codeql_config_file }}
       post_pr_comment: false
@@ -471,6 +472,7 @@ jobs:
     if: needs.scan-coordinator.outputs.run_opengrep == 'true'
     uses: huntridge-labs/argus/.github/workflows/scanner-opengrep.yml@1.8.1
     with:
+      allow_failure: ${{ inputs.allow_failure }}
       post_pr_comment: false
       enable_code_security: ${{ inputs.enable_code_security }}
       fail_on_severity: ${{ inputs.allow_failure == false && inputs.severity_threshold || 'none' }}
@@ -487,6 +489,7 @@ jobs:
     if: needs.scan-coordinator.outputs.run_bandit == 'true'
     uses: huntridge-labs/argus/.github/workflows/scanner-bandit.yml@1.8.1
     with:
+      allow_failure: ${{ inputs.allow_failure }}
       post_pr_comment: false
       enable_code_security: ${{ inputs.enable_code_security }}
       fail_on_severity: ${{ inputs.allow_failure == false && inputs.severity_threshold || 'none' }}
@@ -504,6 +507,7 @@ jobs:
     if: needs.scan-coordinator.outputs.run_gitleaks == 'true'
     uses: huntridge-labs/argus/.github/workflows/scanner-gitleaks.yml@1.8.1
     with:
+      allow_failure: ${{ inputs.allow_failure }}
       post_pr_comment: false
       enable_code_security: ${{ inputs.enable_code_security }}
       fail_on_severity: ${{ inputs.allow_failure == false && inputs.severity_threshold || 'none' }}
@@ -526,6 +530,7 @@ jobs:
     if: needs.scan-coordinator.outputs.run_clamav == 'true'
     uses: huntridge-labs/argus/.github/workflows/scanner-clamav.yml@1.8.1
     with:
+      allow_failure: ${{ inputs.allow_failure }}
       post_pr_comment: false
       enable_code_security: ${{ inputs.enable_code_security }}
       scan_path: ${{ inputs.clamav_scan_path }}
@@ -577,6 +582,7 @@ jobs:
     if: needs.scan-coordinator.outputs.run_sbom == 'true'
     uses: huntridge-labs/argus/.github/workflows/scanner-syft.yml@1.8.1
     with:
+      allow_failure: ${{ inputs.allow_failure }}
       enable_code_security: ${{ inputs.enable_code_security }}
     permissions:
       contents: read
@@ -592,6 +598,7 @@ jobs:
     if: needs.scan-coordinator.outputs.run_trivy_iac == 'true'
     uses: huntridge-labs/argus/.github/workflows/scanner-trivy-iac.yml@1.8.1
     with:
+      allow_failure: ${{ inputs.allow_failure }}
       iac_path: ${{ inputs.iac_path }}
       post_pr_comment: false
       enable_code_security: ${{ inputs.enable_code_security }}
@@ -609,6 +616,7 @@ jobs:
     if: needs.scan-coordinator.outputs.run_checkov == 'true'
     uses: huntridge-labs/argus/.github/workflows/scanner-checkov.yml@1.8.1
     with:
+      allow_failure: ${{ inputs.allow_failure }}
       iac_path: ${{ inputs.iac_path }}
       post_pr_comment: false
       enable_code_security: ${{ inputs.enable_code_security }}
@@ -626,6 +634,7 @@ jobs:
     if: needs.scan-coordinator.outputs.run_trivy_container == 'true'
     uses: huntridge-labs/argus/.github/workflows/scanner-trivy-container.yml@1.8.1
     with:
+      allow_failure: ${{ inputs.allow_failure }}
       image_ref: 'nginx:latest'
       post_pr_comment: false
       enable_code_security: ${{ inputs.enable_code_security }}
@@ -644,6 +653,7 @@ jobs:
     if: needs.scan-coordinator.outputs.run_grype == 'true'
     uses: huntridge-labs/argus/.github/workflows/scanner-grype.yml@1.8.1
     with:
+      allow_failure: ${{ inputs.allow_failure }}
       image_ref: 'nginx:latest'
       post_pr_comment: false
       enable_code_security: ${{ inputs.enable_code_security }}
@@ -662,6 +672,7 @@ jobs:
     if: needs.scan-coordinator.outputs.run_zap == 'true'
     uses: huntridge-labs/argus/.github/workflows/scanner-zap.yml@1.8.1
     with:
+      allow_failure: ${{ inputs.allow_failure }}
       scan_mode: ${{ inputs.zap_scan_mode }}
       scan_type: ${{ inputs.zap_scan_type }}
       target_url: ${{ inputs.zap_target_urls }}
@@ -686,6 +697,7 @@ jobs:
     if: needs.scan-coordinator.outputs.run_osv == 'true'
     uses: huntridge-labs/argus/.github/workflows/scanner-osv.yml@1.8.1
     with:
+      allow_failure: ${{ inputs.allow_failure }}
       post_pr_comment: false
       enable_code_security: ${{ inputs.enable_code_security }}
       fail_on_severity: ${{ inputs.allow_failure == false && inputs.severity_threshold || 'none' }}
@@ -705,6 +717,7 @@ jobs:
     if: needs.scan-coordinator.outputs.run_dependency_review == 'true'
     uses: huntridge-labs/argus/.github/workflows/scanner-dependency-review.yml@1.8.1
     with:
+      allow_failure: ${{ inputs.allow_failure }}
       post_pr_comment: false
       enable_code_security: ${{ inputs.enable_code_security }}
       fail_on_severity: ${{ inputs.allow_failure == false && inputs.severity_threshold || 'none' }}
@@ -725,6 +738,7 @@ jobs:
     if: needs.scan-coordinator.outputs.run_supply_chain == 'true'
     uses: huntridge-labs/argus/.github/workflows/scanner-supply-chain.yml@1.8.1
     with:
+      allow_failure: ${{ inputs.allow_failure }}
       post_pr_comment: false
       enable_code_security: ${{ inputs.enable_code_security }}
       scan_path: ${{ inputs.supply_chain_scan_path }}

--- a/.github/workflows/scanner-bandit.yml
+++ b/.github/workflows/scanner-bandit.yml
@@ -12,6 +12,11 @@ on:
   workflow_dispatch:
   workflow_call:
     inputs:
+      allow_failure:
+        description: 'When true (default) the scan never fails the job (non-blocking); when false, a scan crash or a fail_on_severity breach fails the job so a caller/pipeline can gate on it.'
+        required: false
+        type: boolean
+        default: true
       post_pr_comment:
         description: 'Whether to post PR comments'
         required: false
@@ -49,7 +54,7 @@ jobs:
     name: Bandit Python Security
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    continue-on-error: true
+    continue-on-error: ${{ inputs.allow_failure == true }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/scanner-checkov.yml
+++ b/.github/workflows/scanner-checkov.yml
@@ -12,6 +12,11 @@ on:
   workflow_dispatch:
   workflow_call:
     inputs:
+      allow_failure:
+        description: 'When true (default) the scan never fails the job (non-blocking); when false, a scan crash or a fail_on_severity breach fails the job so a caller/pipeline can gate on it.'
+        required: false
+        type: boolean
+        default: true
       iac_path:
         description: 'Relative path to the infrastructure-as-code directory to scan'
         required: false
@@ -53,7 +58,7 @@ jobs:
     name: Checkov Security Scan
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    continue-on-error: true
+    continue-on-error: ${{ inputs.allow_failure == true }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/scanner-clamav.yml
+++ b/.github/workflows/scanner-clamav.yml
@@ -12,6 +12,11 @@ on:
   workflow_dispatch:
   workflow_call:
     inputs:
+      allow_failure:
+        description: 'When true (default) the scan never fails the job (non-blocking); when false, a scan crash or a fail_on_severity breach fails the job so a caller/pipeline can gate on it.'
+        required: false
+        type: boolean
+        default: true
       post_pr_comment:
         description: 'Whether to post PR comments'
         required: false
@@ -44,7 +49,7 @@ jobs:
     name: ClamAV Malware Scan
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    continue-on-error: true
+    continue-on-error: ${{ inputs.allow_failure == true }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/scanner-codeql.yml
+++ b/.github/workflows/scanner-codeql.yml
@@ -15,6 +15,11 @@ on:
   workflow_dispatch:
   workflow_call:
     inputs:
+      allow_failure:
+        description: 'When true (default) the scan never fails the job (non-blocking); when false, a scan crash or a fail_on_severity breach fails the job so a caller/pipeline can gate on it.'
+        required: false
+        type: boolean
+        default: true
       codeql_languages:
         description: 'Comma-separated list of languages for CodeQL analysis (e.g., "python,javascript"). Leave empty for auto-detection.'
         required: false
@@ -172,7 +177,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: generate-codeql-matrix
     timeout-minutes: 45
-    continue-on-error: true
+    continue-on-error: ${{ inputs.allow_failure == true }}
     if: github.actor != 'nektos/act'
 
     strategy:

--- a/.github/workflows/scanner-dependency-review.yml
+++ b/.github/workflows/scanner-dependency-review.yml
@@ -15,6 +15,11 @@ on:
   workflow_dispatch:
   workflow_call:
     inputs:
+      allow_failure:
+        description: 'When true (default) the scan never fails the job (non-blocking); when false, a scan crash or a fail_on_severity breach fails the job so a caller/pipeline can gate on it.'
+        required: false
+        type: boolean
+        default: true
       post_pr_comment:
         description: 'Whether to post PR comments'
         required: false
@@ -62,7 +67,7 @@ jobs:
     name: Dependency Review
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    continue-on-error: true
+    continue-on-error: ${{ inputs.allow_failure == true }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/scanner-gitleaks.yml
+++ b/.github/workflows/scanner-gitleaks.yml
@@ -14,6 +14,11 @@ on:
   workflow_dispatch:
   workflow_call:
     inputs:
+      allow_failure:
+        description: 'When true (default) the scan never fails the job (non-blocking); when false, a scan crash or a fail_on_severity breach fails the job so a caller/pipeline can gate on it.'
+        required: false
+        type: boolean
+        default: true
       post_pr_comment:
         description: 'Whether to post PR comments'
         required: false
@@ -70,7 +75,7 @@ jobs:
     name: Secrets Detection - Gitleaks
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    continue-on-error: true
+    continue-on-error: ${{ inputs.allow_failure == true }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/scanner-grype.yml
+++ b/.github/workflows/scanner-grype.yml
@@ -32,6 +32,11 @@ on:
         default: 'none'
   workflow_call:
     inputs:
+      allow_failure:
+        description: 'When true (default) the scan never fails the job (non-blocking); when false, a scan crash or a fail_on_severity breach fails the job so a caller/pipeline can gate on it.'
+        required: false
+        type: boolean
+        default: true
       image_ref:
         description: 'Container image reference to scan (e.g., nginx:latest, ghcr.io/owner/image:tag)'
         required: true
@@ -78,7 +83,7 @@ jobs:
     name: Grype Container Scan
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    continue-on-error: true
+    continue-on-error: ${{ inputs.allow_failure == true }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/scanner-opengrep.yml
+++ b/.github/workflows/scanner-opengrep.yml
@@ -12,6 +12,11 @@ on:
   workflow_dispatch:
   workflow_call:
     inputs:
+      allow_failure:
+        description: 'When true (default) the scan never fails the job (non-blocking); when false, a scan crash or a fail_on_severity breach fails the job so a caller/pipeline can gate on it.'
+        required: false
+        type: boolean
+        default: true
       post_pr_comment:
         description: 'Whether to post PR comments'
         required: false
@@ -49,7 +54,7 @@ jobs:
     name: OpenGrep SAST
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    continue-on-error: true
+    continue-on-error: ${{ inputs.allow_failure == true }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/scanner-osv.yml
+++ b/.github/workflows/scanner-osv.yml
@@ -12,6 +12,11 @@ on:
   workflow_dispatch:
   workflow_call:
     inputs:
+      allow_failure:
+        description: 'When true (default) the scan never fails the job (non-blocking); when false, a scan crash or a fail_on_severity breach fails the job so a caller/pipeline can gate on it.'
+        required: false
+        type: boolean
+        default: true
       post_pr_comment:
         description: 'Whether to post PR comments'
         required: false
@@ -54,7 +59,7 @@ jobs:
     name: OSV Dependency Scan
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    continue-on-error: true
+    continue-on-error: ${{ inputs.allow_failure == true }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/scanner-supply-chain.yml
+++ b/.github/workflows/scanner-supply-chain.yml
@@ -12,6 +12,11 @@ on:
   workflow_dispatch:
   workflow_call:
     inputs:
+      allow_failure:
+        description: 'When true (default) the scan never fails the job (non-blocking); when false, a scan crash or a fail_on_severity breach fails the job so a caller/pipeline can gate on it.'
+        required: false
+        type: boolean
+        default: true
       post_pr_comment:
         description: 'Whether to post PR comments'
         required: false
@@ -54,7 +59,7 @@ jobs:
     name: Supply Chain Security Scan
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    continue-on-error: true
+    continue-on-error: ${{ inputs.allow_failure == true }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/scanner-syft.yml
+++ b/.github/workflows/scanner-syft.yml
@@ -33,6 +33,11 @@ on:
         default: 'cyclonedx-json'
   workflow_call:
     inputs:
+      allow_failure:
+        description: 'When true (default) the scan never fails the job (non-blocking); when false, a scan crash or a fail_on_severity breach fails the job so a caller/pipeline can gate on it.'
+        required: false
+        type: boolean
+        default: true
       enable_code_security:
         description: 'Whether GitHub Code Security is enabled for this repository'
         required: false
@@ -75,7 +80,7 @@ jobs:
     name: Generate SBOM
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    continue-on-error: true
+    continue-on-error: ${{ inputs.allow_failure == true }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/scanner-trivy-container.yml
+++ b/.github/workflows/scanner-trivy-container.yml
@@ -32,6 +32,11 @@ on:
         default: 'none'
   workflow_call:
     inputs:
+      allow_failure:
+        description: 'When true (default) the scan never fails the job (non-blocking); when false, a scan crash or a fail_on_severity breach fails the job so a caller/pipeline can gate on it.'
+        required: false
+        type: boolean
+        default: true
       image_ref:
         description: 'Container image reference to scan (e.g., nginx:latest, ghcr.io/owner/image:tag)'
         required: true
@@ -78,7 +83,7 @@ jobs:
     name: Trivy Container Scan
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    continue-on-error: true
+    continue-on-error: ${{ inputs.allow_failure == true }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/scanner-trivy-iac.yml
+++ b/.github/workflows/scanner-trivy-iac.yml
@@ -12,6 +12,11 @@ on:
   workflow_dispatch:
   workflow_call:
     inputs:
+      allow_failure:
+        description: 'When true (default) the scan never fails the job (non-blocking); when false, a scan crash or a fail_on_severity breach fails the job so a caller/pipeline can gate on it.'
+        required: false
+        type: boolean
+        default: true
       iac_path:
         description: 'Relative path to the infrastructure-as-code directory to scan'
         required: false
@@ -44,7 +49,7 @@ jobs:
     name: Trivy IaC Security Scan
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    continue-on-error: true
+    continue-on-error: ${{ inputs.allow_failure == true }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/scanner-zap-from-config.yml
+++ b/.github/workflows/scanner-zap-from-config.yml
@@ -56,6 +56,11 @@ on:
         type: string
   workflow_call:
     inputs:
+      allow_failure:
+        description: 'When true (default) the scan never fails the job (non-blocking); when false, a scan crash or a fail_on_severity breach fails the job so a caller/pipeline can gate on it.'
+        required: false
+        type: boolean
+        default: true
       config_file:
         description: 'Path to ZAP config file (YAML, JSON, or JS)'
         required: true
@@ -101,7 +106,7 @@ jobs:
     needs: parse-config
     if: needs.parse-config.outputs.has_scans == 'true'
     timeout-minutes: 60
-    continue-on-error: true
+    continue-on-error: ${{ inputs.allow_failure == true }}
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Description
Every reusable scanner workflow set job-level `continue-on-error: true` **unconditionally** (only `scanner-zap.yml` did it correctly). Because each is the only job in its workflow, the run always concluded `success`, so `needs.scanner-*.result` in the orchestrator was **always** `success` — the `security-summary` status table always rendered ✅ PASS and `fail_on_scanner_failure` never fired. A crashed scanner, or a real `fail_on_severity` breach, produced a green pipeline and an "✅ all scanners completed successfully" comment.

Closes #323. (Part of the reusable-workflow reliability cluster surfaced with #322.)

## Type of Change
- [x] Bug fix

## Changes Made
- Added an `allow_failure` boolean input (default **`true`**, preserving today's non-blocking behavior for standalone callers) to the 14 leaf scanner reusable workflows.
- Changed `continue-on-error: true` → `continue-on-error: ${{ inputs.allow_failure == true }}` (mirrors the existing `scanner-zap.yml` pattern).
- Threaded `allow_failure: ${{ inputs.allow_failure }}` from `reusable-security-hardening.yml` into each **leaf** scanner call (14). The orchestrator's own `allow_failure` already defaults to `false`, so the hardening pipeline now correctly fails when a scanner crashes or breaches the threshold.
- Compound wrappers (`container-scan.yml`, `infrastructure-scan.yml`) are intentionally **not** threaded — they lack the input and are tracked separately in #326 / #327.

## Testing
- [x] Manual testing performed

### Test Results
- All 15 changed workflows validate as YAML; the repo's actionlint pre-commit hook passes.
- Verified the `allow_failure` passthrough appears in exactly the **14 leaf** scanner call blocks and **0** times in the `scanner-container` / `scanner-infrastructure` blocks.
- Standalone default behavior unchanged (`allow_failure` defaults `true`). Step-level `continue-on-error` on SARIF-upload steps is left as-is (intentional — don't fail a scan because SARIF upload hiccuped).

## Security Considerations
- [x] Security enhancement — the hosted pipeline can no longer report a green, "all clear" result when a scanner crashed or found blocking issues.

## AI Context Updates (.ai/)
- [x] N/A - No .ai/ updates needed

## Checklist
- [x] Code follows project style guidelines
- [x] All tests pass
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Closes #323 · Refs #322, #326, #327