### PR TITLE
fix(ci): emit scanner-summary artifacts + fix per-scanner PR comments

### DIFF
--- a/.github/workflows/scanner-bandit.yml
+++ b/.github/workflows/scanner-bandit.yml
@@ -75,7 +75,7 @@ jobs:
           python -m argus scan bandit \
             --path "$SCAN_PATH" \
             --severity-threshold "$SEVERITY_THRESHOLD" \
-            --format terminal --format sarif --format json \
+            --format terminal --format sarif --format json --format markdown \
             --output-dir ./argus-results \
             --verbose
         env:
@@ -91,6 +91,30 @@ jobs:
           path: ./argus-results/
           retention-days: 30
 
+      - name: Build scanner summary
+        if: always()
+        run: |
+          mkdir -p scanner-summaries
+          {
+            echo "<details><summary>🐍 Bandit (Python SAST)</summary>"
+            echo ""
+            if [ -f ./argus-results/argus-summary.md ]; then
+              cat ./argus-results/argus-summary.md
+            else
+              echo "_No 🐍 Bandit (Python SAST) findings summary was produced._"
+            fi
+            echo ""
+            echo "</details>"
+          } > scanner-summaries/bandit.md
+
+      - name: Upload scanner summary
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: scanner-summary-bandit
+          path: scanner-summaries/
+          retention-days: 30
+
       - name: Upload SARIF
         if: inputs.enable_code_security && always() && github.actor != 'nektos/act'
         uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
@@ -99,10 +123,10 @@ jobs:
         continue-on-error: true
 
       - name: Comment PR with results
-        if: github.event_name == 'pull_request' && inputs.post_pr_comment
+        if: always() && github.event_name == 'pull_request' && inputs.post_pr_comment
         uses: huntridge-labs/argus/.github/actions/comment-pr@1.8.1
         with:
-          summary_file: ./argus-results/argus-results.md
+          summary_file: ./argus-results/argus-summary.md
           comment_marker: bandit-scanner-comment-marker
           title: 'Bandit Python Security Results'
           fallback_message: 'No Bandit results available'

--- a/.github/workflows/scanner-checkov.yml
+++ b/.github/workflows/scanner-checkov.yml
@@ -79,7 +79,7 @@ jobs:
           python -m argus scan checkov \
             --path "$SCAN_PATH" \
             --severity-threshold "$SEVERITY_THRESHOLD" \
-            --format terminal --format sarif --format json \
+            --format terminal --format sarif --format json --format markdown \
             --output-dir ./argus-results \
             --verbose
         env:
@@ -96,6 +96,30 @@ jobs:
           path: ./argus-results/
           retention-days: 30
 
+      - name: Build scanner summary
+        if: always()
+        run: |
+          mkdir -p scanner-summaries
+          {
+            echo "<details><summary>🏗️ Checkov (IaC)</summary>"
+            echo ""
+            if [ -f ./argus-results/argus-summary.md ]; then
+              cat ./argus-results/argus-summary.md
+            else
+              echo "_No 🏗️ Checkov (IaC) findings summary was produced._"
+            fi
+            echo ""
+            echo "</details>"
+          } > scanner-summaries/checkov.md
+
+      - name: Upload scanner summary
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: scanner-summary-checkov
+          path: scanner-summaries/
+          retention-days: 30
+
       - name: Upload SARIF
         if: inputs.enable_code_security && always() && github.actor != 'nektos/act'
         uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
@@ -104,10 +128,10 @@ jobs:
         continue-on-error: true
 
       - name: Comment PR with results
-        if: github.event_name == 'pull_request' && inputs.post_pr_comment
+        if: always() && github.event_name == 'pull_request' && inputs.post_pr_comment
         uses: huntridge-labs/argus/.github/actions/comment-pr@1.8.1
         with:
-          summary_file: ./argus-results/argus-results.md
+          summary_file: ./argus-results/argus-summary.md
           comment_marker: checkov-scanner-comment-marker
           title: 'Checkov IaC Security Results'
           fallback_message: 'No Checkov results available'

--- a/.github/workflows/scanner-clamav.yml
+++ b/.github/workflows/scanner-clamav.yml
@@ -70,7 +70,7 @@ jobs:
           python -m argus scan clamav \
             --path "$SCAN_PATH" \
             --severity-threshold "$SEVERITY_THRESHOLD" \
-            --format terminal --format sarif --format json \
+            --format terminal --format sarif --format json --format markdown \
             --output-dir ./argus-results \
             --verbose
         env:
@@ -85,6 +85,30 @@ jobs:
           path: ./argus-results/
           retention-days: 30
 
+      - name: Build scanner summary
+        if: always()
+        run: |
+          mkdir -p scanner-summaries
+          {
+            echo "<details><summary>🦠 ClamAV (Malware)</summary>"
+            echo ""
+            if [ -f ./argus-results/argus-summary.md ]; then
+              cat ./argus-results/argus-summary.md
+            else
+              echo "_No 🦠 ClamAV (Malware) findings summary was produced._"
+            fi
+            echo ""
+            echo "</details>"
+          } > scanner-summaries/clamav.md
+
+      - name: Upload scanner summary
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: scanner-summary-clamav
+          path: scanner-summaries/
+          retention-days: 30
+
       - name: Upload SARIF
         if: inputs.enable_code_security && always() && github.actor != 'nektos/act'
         uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
@@ -93,10 +117,10 @@ jobs:
         continue-on-error: true
 
       - name: Comment PR with results
-        if: github.event_name == 'pull_request' && inputs.post_pr_comment
+        if: always() && github.event_name == 'pull_request' && inputs.post_pr_comment
         uses: huntridge-labs/argus/.github/actions/comment-pr@1.8.1
         with:
-          summary_file: ./argus-results/argus-results.md
+          summary_file: ./argus-results/argus-summary.md
           comment_marker: clamav-scanner-comment-marker
           title: 'ClamAV Malware Scan Results'
           fallback_message: 'No ClamAV results available'

--- a/.github/workflows/scanner-gitleaks.yml
+++ b/.github/workflows/scanner-gitleaks.yml
@@ -97,7 +97,7 @@ jobs:
           python -m argus scan gitleaks \
             --path "$SCAN_PATH" \
             --severity-threshold "$SEVERITY_THRESHOLD" \
-            --format terminal --format sarif --format json \
+            --format terminal --format sarif --format json --format markdown \
             --output-dir ./argus-results \
             --verbose
         env:
@@ -115,6 +115,30 @@ jobs:
           path: ./argus-results/
           retention-days: 30
 
+      - name: Build scanner summary
+        if: always()
+        run: |
+          mkdir -p scanner-summaries
+          {
+            echo "<details><summary>🔑 Gitleaks (Secrets)</summary>"
+            echo ""
+            if [ -f ./argus-results/argus-summary.md ]; then
+              cat ./argus-results/argus-summary.md
+            else
+              echo "_No 🔑 Gitleaks (Secrets) findings summary was produced._"
+            fi
+            echo ""
+            echo "</details>"
+          } > scanner-summaries/gitleaks.md
+
+      - name: Upload scanner summary
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: scanner-summary-gitleaks
+          path: scanner-summaries/
+          retention-days: 30
+
       - name: Upload SARIF
         if: inputs.enable_code_security && always() && github.actor != 'nektos/act'
         uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
@@ -123,10 +147,10 @@ jobs:
         continue-on-error: true
 
       - name: Comment PR with results
-        if: github.event_name == 'pull_request' && inputs.post_pr_comment
+        if: always() && github.event_name == 'pull_request' && inputs.post_pr_comment
         uses: huntridge-labs/argus/.github/actions/comment-pr@1.8.1
         with:
-          summary_file: ./argus-results/argus-results.md
+          summary_file: ./argus-results/argus-summary.md
           comment_marker: gitleaks-scanner-comment-marker
           title: 'Gitleaks Secrets Detection Results'
           fallback_message: 'No Gitleaks results available'

--- a/.github/workflows/scanner-grype.yml
+++ b/.github/workflows/scanner-grype.yml
@@ -105,7 +105,7 @@ jobs:
             --image "$IMAGE_REF" \
             --scanners grype \
             --severity-threshold "$SEVERITY_THRESHOLD" \
-            --format terminal --format sarif --format json \
+            --format terminal --format sarif --format json --format markdown \
             --output-dir ./argus-results \
             --verbose
         env:
@@ -122,6 +122,33 @@ jobs:
           path: ./argus-results/
           retention-days: 30
 
+      - name: Build scanner summary
+        if: always()
+        env:
+          SCAN_NAME: ${{ inputs.scan_name || 'grype-scan' }}
+        run: |
+          mkdir -p scanner-summaries
+          SAFE=$(printf '%s' "$SCAN_NAME" | tr -c 'A-Za-z0-9._-' '_')
+          {
+            echo "<details><summary>🐳 Grype (Container) (${SCAN_NAME})</summary>"
+            echo ""
+            if [ -f ./argus-results/argus-summary.md ]; then
+              cat ./argus-results/argus-summary.md
+            else
+              echo "_No 🐳 Grype (Container) findings summary was produced._"
+            fi
+            echo ""
+            echo "</details>"
+          } > "scanner-summaries/grype-${SAFE}.md"
+
+      - name: Upload scanner summary
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: scanner-summary-grype-${{ inputs.scan_name || 'grype-scan' }}
+          path: scanner-summaries/
+          retention-days: 30
+
       - name: Upload SARIF
         if: inputs.enable_code_security && always() && github.actor != 'nektos/act'
         uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
@@ -130,10 +157,10 @@ jobs:
         continue-on-error: true
 
       - name: Comment PR with results
-        if: github.event_name == 'pull_request' && inputs.post_pr_comment
+        if: always() && github.event_name == 'pull_request' && inputs.post_pr_comment
         uses: huntridge-labs/argus/.github/actions/comment-pr@1.8.1
         with:
-          summary_file: ./argus-results/argus-results.md
+          summary_file: ./argus-results/argus-summary.md
           comment_marker: container-${{ inputs.scan_name || 'grype-scan' }}-comment-marker
           title: 'Grype Container Scan Results'
           fallback_message: 'No Grype results available'

--- a/.github/workflows/scanner-opengrep.yml
+++ b/.github/workflows/scanner-opengrep.yml
@@ -75,7 +75,7 @@ jobs:
           python -m argus scan opengrep \
             --path "$SCAN_PATH" \
             --severity-threshold "$SEVERITY_THRESHOLD" \
-            --format terminal --format sarif --format json \
+            --format terminal --format sarif --format json --format markdown \
             --output-dir ./argus-results \
             --verbose
         env:
@@ -91,6 +91,30 @@ jobs:
           path: ./argus-results/
           retention-days: 30
 
+      - name: Build scanner summary
+        if: always()
+        run: |
+          mkdir -p scanner-summaries
+          {
+            echo "<details><summary>🔎 OpenGrep (SAST)</summary>"
+            echo ""
+            if [ -f ./argus-results/argus-summary.md ]; then
+              cat ./argus-results/argus-summary.md
+            else
+              echo "_No 🔎 OpenGrep (SAST) findings summary was produced._"
+            fi
+            echo ""
+            echo "</details>"
+          } > scanner-summaries/opengrep.md
+
+      - name: Upload scanner summary
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: scanner-summary-opengrep
+          path: scanner-summaries/
+          retention-days: 30
+
       - name: Upload SARIF
         if: inputs.enable_code_security && always() && github.actor != 'nektos/act'
         uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
@@ -99,10 +123,10 @@ jobs:
         continue-on-error: true
 
       - name: Comment PR with results
-        if: github.event_name == 'pull_request' && inputs.post_pr_comment
+        if: always() && github.event_name == 'pull_request' && inputs.post_pr_comment
         uses: huntridge-labs/argus/.github/actions/comment-pr@1.8.1
         with:
-          summary_file: ./argus-results/argus-results.md
+          summary_file: ./argus-results/argus-summary.md
           comment_marker: opengrep-comment-marker
           title: 'OpenGrep SAST Results'
           fallback_message: 'No OpenGrep results available'

--- a/.github/workflows/scanner-osv.yml
+++ b/.github/workflows/scanner-osv.yml
@@ -80,7 +80,7 @@ jobs:
           python -m argus scan osv \
             --path "$SCAN_PATH" \
             --severity-threshold "$SEVERITY_THRESHOLD" \
-            --format terminal --format sarif --format json \
+            --format terminal --format sarif --format json --format markdown \
             --output-dir ./argus-results \
             --verbose
         env:
@@ -97,6 +97,30 @@ jobs:
           path: ./argus-results/
           retention-days: 30
 
+      - name: Build scanner summary
+        if: always()
+        run: |
+          mkdir -p scanner-summaries
+          {
+            echo "<details><summary>📦 OSV (Dependencies)</summary>"
+            echo ""
+            if [ -f ./argus-results/argus-summary.md ]; then
+              cat ./argus-results/argus-summary.md
+            else
+              echo "_No 📦 OSV (Dependencies) findings summary was produced._"
+            fi
+            echo ""
+            echo "</details>"
+          } > scanner-summaries/osv.md
+
+      - name: Upload scanner summary
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: scanner-summary-osv
+          path: scanner-summaries/
+          retention-days: 30
+
       - name: Upload SARIF
         if: inputs.enable_code_security && always() && github.actor != 'nektos/act'
         uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
@@ -105,10 +129,10 @@ jobs:
         continue-on-error: true
 
       - name: Comment PR with results
-        if: github.event_name == 'pull_request' && inputs.post_pr_comment
+        if: always() && github.event_name == 'pull_request' && inputs.post_pr_comment
         uses: huntridge-labs/argus/.github/actions/comment-pr@1.8.1
         with:
-          summary_file: ./argus-results/argus-results.md
+          summary_file: ./argus-results/argus-summary.md
           comment_marker: osv-scanner-comment-marker
           title: 'OSV Dependency Scan Results'
           fallback_message: 'No OSV results available'

--- a/.github/workflows/scanner-supply-chain.yml
+++ b/.github/workflows/scanner-supply-chain.yml
@@ -80,7 +80,7 @@ jobs:
           python -m argus scan supply-chain \
             --path "$SCAN_PATH" \
             --severity-threshold "$SEVERITY_THRESHOLD" \
-            --format terminal --format sarif --format json \
+            --format terminal --format sarif --format json --format markdown \
             --output-dir ./argus-results \
             --verbose
         env:
@@ -98,6 +98,30 @@ jobs:
           path: ./argus-results/
           retention-days: 30
 
+      - name: Build scanner summary
+        if: always()
+        run: |
+          mkdir -p scanner-summaries
+          {
+            echo "<details><summary>🔗 Supply Chain (zizmor + actionlint)</summary>"
+            echo ""
+            if [ -f ./argus-results/argus-summary.md ]; then
+              cat ./argus-results/argus-summary.md
+            else
+              echo "_No 🔗 Supply Chain (zizmor + actionlint) findings summary was produced._"
+            fi
+            echo ""
+            echo "</details>"
+          } > scanner-summaries/supply-chain.md
+
+      - name: Upload scanner summary
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: scanner-summary-supply-chain
+          path: scanner-summaries/
+          retention-days: 30
+
       - name: Upload SARIF
         if: inputs.enable_code_security && always() && github.actor != 'nektos/act'
         uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
@@ -106,10 +130,10 @@ jobs:
         continue-on-error: true
 
       - name: Comment PR with results
-        if: github.event_name == 'pull_request' && inputs.post_pr_comment
+        if: always() && github.event_name == 'pull_request' && inputs.post_pr_comment
         uses: huntridge-labs/argus/.github/actions/comment-pr@1.8.1
         with:
-          summary_file: ./argus-results/argus-results.md
+          summary_file: ./argus-results/argus-summary.md
           comment_marker: supply-chain-scanner-comment-marker
           title: 'Supply Chain Security Results'
           fallback_message: 'No Supply Chain results available'

--- a/.github/workflows/scanner-trivy-container.yml
+++ b/.github/workflows/scanner-trivy-container.yml
@@ -105,7 +105,7 @@ jobs:
             --image "$IMAGE_REF" \
             --scanners trivy \
             --severity-threshold "$SEVERITY_THRESHOLD" \
-            --format terminal --format sarif --format json \
+            --format terminal --format sarif --format json --format markdown \
             --output-dir ./argus-results \
             --verbose
         env:
@@ -122,6 +122,33 @@ jobs:
           path: ./argus-results/
           retention-days: 30
 
+      - name: Build scanner summary
+        if: always()
+        env:
+          SCAN_NAME: ${{ inputs.scan_name || 'trivy-scan' }}
+        run: |
+          mkdir -p scanner-summaries
+          SAFE=$(printf '%s' "$SCAN_NAME" | tr -c 'A-Za-z0-9._-' '_')
+          {
+            echo "<details><summary>🐳 Trivy Container (${SCAN_NAME})</summary>"
+            echo ""
+            if [ -f ./argus-results/argus-summary.md ]; then
+              cat ./argus-results/argus-summary.md
+            else
+              echo "_No 🐳 Trivy Container findings summary was produced._"
+            fi
+            echo ""
+            echo "</details>"
+          } > "scanner-summaries/trivy-container-${SAFE}.md"
+
+      - name: Upload scanner summary
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: scanner-summary-trivy-container-${{ inputs.scan_name || 'trivy-scan' }}
+          path: scanner-summaries/
+          retention-days: 30
+
       - name: Upload SARIF
         if: inputs.enable_code_security && always() && github.actor != 'nektos/act'
         uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
@@ -130,10 +157,10 @@ jobs:
         continue-on-error: true
 
       - name: Comment PR with results
-        if: github.event_name == 'pull_request' && inputs.post_pr_comment
+        if: always() && github.event_name == 'pull_request' && inputs.post_pr_comment
         uses: huntridge-labs/argus/.github/actions/comment-pr@1.8.1
         with:
-          summary_file: ./argus-results/argus-results.md
+          summary_file: ./argus-results/argus-summary.md
           comment_marker: container-${{ inputs.scan_name || 'trivy-scan' }}-comment-marker
           title: 'Trivy Container Scan Results'
           fallback_message: 'No Trivy container results available'

--- a/.github/workflows/scanner-trivy-iac.yml
+++ b/.github/workflows/scanner-trivy-iac.yml
@@ -70,7 +70,7 @@ jobs:
           python -m argus scan trivy-iac \
             --path "$SCAN_PATH" \
             --severity-threshold "$SEVERITY_THRESHOLD" \
-            --format terminal --format sarif --format json \
+            --format terminal --format sarif --format json --format markdown \
             --output-dir ./argus-results \
             --verbose
         env:
@@ -85,6 +85,30 @@ jobs:
           path: ./argus-results/
           retention-days: 30
 
+      - name: Build scanner summary
+        if: always()
+        run: |
+          mkdir -p scanner-summaries
+          {
+            echo "<details><summary>🏗️ Trivy IaC</summary>"
+            echo ""
+            if [ -f ./argus-results/argus-summary.md ]; then
+              cat ./argus-results/argus-summary.md
+            else
+              echo "_No 🏗️ Trivy IaC findings summary was produced._"
+            fi
+            echo ""
+            echo "</details>"
+          } > scanner-summaries/trivy-iac.md
+
+      - name: Upload scanner summary
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: scanner-summary-trivy-iac
+          path: scanner-summaries/
+          retention-days: 30
+
       - name: Upload SARIF
         if: inputs.enable_code_security && always() && github.actor != 'nektos/act'
         uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
@@ -93,10 +117,10 @@ jobs:
         continue-on-error: true
 
       - name: Comment PR with results
-        if: github.event_name == 'pull_request' && inputs.post_pr_comment
+        if: always() && github.event_name == 'pull_request' && inputs.post_pr_comment
         uses: huntridge-labs/argus/.github/actions/comment-pr@1.8.1
         with:
-          summary_file: ./argus-results/argus-results.md
+          summary_file: ./argus-results/argus-summary.md
           comment_marker: trivy-iac-scanner-comment-marker
           title: 'Trivy IaC Security Results'
           fallback_message: 'No Trivy IaC results available'

--- a/tests/unit/test_reusable_scanner_summaries.py
+++ b/tests/unit/test_reusable_scanner_summaries.py
@@ -1,0 +1,61 @@
+"""Contract test for reusable scanner workflows (issue #322).
+
+The `security-summary` aggregator stitches the consolidated PR comment's
+findings detail from artifacts matching ``scanner-summary-*``. Leaf scanner
+reusable workflows that run the CLI inline must therefore each upload a
+``scanner-summary-<name>`` artifact — otherwise their findings silently vanish
+from the aggregated comment (the #322 regression).
+
+This test locks that contract in so a new or edited scanner workflow can't
+quietly drop the summary upload again.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import yaml
+
+WORKFLOWS = pathlib.Path(__file__).resolve().parents[2] / ".github" / "workflows"
+
+# CLI-inline leaf scanners that feed the consolidated comment. codeql / syft /
+# dependency-review delegate to composite actions that emit their own
+# scanner-summary-* artifact; zap has its own scanner-zap-summary path. New
+# inline scanners should be added here (and emit a scanner-summary-* artifact).
+CLI_SCANNERS = [
+    "bandit",
+    "checkov",
+    "clamav",
+    "gitleaks",
+    "opengrep",
+    "osv",
+    "supply-chain",
+    "trivy-iac",
+    "grype",
+    "trivy-container",
+]
+
+
+def _uploaded_artifact_names(workflow: pathlib.Path) -> list[str]:
+    data = yaml.safe_load(workflow.read_text(encoding="utf-8"))
+    names: list[str] = []
+    for job in (data.get("jobs") or {}).values():
+        for step in job.get("steps") or []:
+            uses = step.get("uses", "") if isinstance(step, dict) else ""
+            if isinstance(uses, str) and "upload-artifact" in uses:
+                names.append(str((step.get("with") or {}).get("name", "")))
+    return names
+
+
+def test_cli_scanner_workflows_emit_scanner_summary_artifact():
+    missing = []
+    for scanner in CLI_SCANNERS:
+        wf = WORKFLOWS / f"scanner-{scanner}.yml"
+        assert wf.is_file(), f"missing reusable workflow: {wf.name}"
+        names = _uploaded_artifact_names(wf)
+        if not any(n.startswith(f"scanner-summary-{scanner}") for n in names):
+            missing.append(scanner)
+    assert not missing, (
+        "reusable scanner workflows missing a scanner-summary-<name> artifact "
+        f"(findings would be dropped from the consolidated comment, #322): {missing}"
+    )


### PR DESCRIPTION
## Description
Two coupled reusable-pipeline defects meant scanner findings were invisible in **both** the consolidated comment and the per-scanner comment:

- **#322** — leaf scanners uploaded `<name>-reports`, but `security-summary` only stitches detail from `scanner-summary-*`, so the consolidated comment showed a pass/fail table with **zero finding detail** for 10 scanners.
- **#324** — the per-scanner `comment-pr` pointed at `argus-results.md`, but the scan step never emitted markdown and the reporter writes `argus-summary.md`, so every standalone scanner comment fell through to **"No results available."**

Closes #322, #324, #328.

## Type of Change
- [x] Bug fix

## Changes Made
For the 10 CLI-inline scanners (bandit, checkov, clamav, gitleaks, opengrep, osv, supply-chain, trivy-iac, grype, trivy-container):
- Add `--format markdown` to the scan step (produces `argus-summary.md`).
- Point `comment-pr` at `./argus-results/argus-summary.md` (**#324**).
- Add `always()` to the comment gate so it still posts on a threshold breach (**#328**).
- Build a **collapsible** `scanner-summaries/<name>.md` and upload it as `scanner-summary-<name>`, matching the aggregator's default pattern (**#322**).
- Matrix scanners (grype, trivy-container) suffix both the artifact name and the internal `.md` filename with a **sanitized** `scan_name`, so parallel legs don't collide under the aggregator's `merge-multiple` download (addresses the matrix-collision item from #332).
- Add `tests/unit/test_reusable_scanner_summaries.py` locking the contract so a future scanner can't silently drop the summary upload (the issue's bonus ask).

codeql / syft / dependency-review already emit `scanner-summary-*` via their composite actions; zap has its own `scanner-zap-summary` path — all left unchanged.

### Rendering note
The aggregator's `normalize_summary` unwraps a single outer `<details>` into a heading, so each section is collapsible in the scanner's **standalone** artifact and renders as an expanded `####` heading in the **consolidated** comment (consistent with the existing Syft/CodeQL behavior). Making it collapsible in the consolidated comment too would be a small `security-summary` change — out of scope here.

## Testing
- [x] Manual testing performed

### Test Results
- All 10 changed workflows validate as YAML; actionlint pre-commit hook passes.
- `pytest tests/unit/test_reusable_scanner_summaries.py` passes (asserts each CLI scanner emits `scanner-summary-<name>`).
- Verified matrix scanners sanitize `scan_name` into both the artifact name and the internal filename.

## Security Considerations
- [x] Security enhancement — scanner findings now actually reach the PR (both per-scanner and consolidated), instead of silently showing "no results."

## AI Context Updates (.ai/)
- [x] N/A - No .ai/ updates needed

## Checklist
- [x] Code follows project style guidelines
- [x] Tests added/updated
- [x] All tests pass
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Closes #322, #324, #328 · Refs #332 (matrix-collision item), #323 (merged, #333)