### PR TITLE
fix(ci): repair linting summary status table + output contract

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -155,14 +155,35 @@ jobs:
     needs: [yaml-lint, json-lint, python-lint, javascript-lint, dockerfile-lint, terraform-lint]
     if: always()
     outputs:
-      status: ${{ steps.summary.outputs.status }}
-      issues_found: ${{ steps.summary.outputs.total_issues }}
+      status: ${{ steps.summary.outputs.overall_status }}
+      issues_found: ${{ steps.totals.outputs.total_issues }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
+
+      - name: Tally linter issue counts
+        id: totals
+        env:
+          YAML_ISSUES: ${{ needs.yaml-lint.outputs.yaml_issues }}
+          JSON_ISSUES: ${{ needs.json-lint.outputs.json_issues }}
+          PYTHON_ISSUES: ${{ needs.python-lint.outputs.python_issues }}
+          JS_ISSUES: ${{ needs.javascript-lint.outputs.js_issues }}
+          DOCKER_ISSUES: ${{ needs.dockerfile-lint.outputs.docker_issues }}
+          TERRAFORM_ISSUES: ${{ needs.terraform-lint.outputs.terraform_issues }}
+        run: |
+          total=0
+          for v in "$YAML_ISSUES" "$JSON_ISSUES" "$PYTHON_ISSUES" "$JS_ISSUES" "$DOCKER_ISSUES" "$TERRAFORM_ISSUES"; do
+            case "$v" in
+              ''|*[!0-9]*) n=0 ;;
+              *) n="$v" ;;
+            esac
+            total=$((total + n))
+          done
+          echo "total_issues=$total" >> "$GITHUB_OUTPUT"
+          echo "Linting issues found: $total"
 
       - name: Generate Linting Summary
         id: summary
@@ -171,11 +192,28 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           post_pr_comment: ${{ inputs.post_pr_comment }}
+          # Render the per-linter pass/fail table so a skipped/failed linter is
+          # visible instead of the report reading "clean". The workflow's fail
+          # contract stays governed solely by fail_on_issues below, so
+          # fail_on_scanner_failure is left off here. (Hard-failing on a crashed
+          # linter is limited by the lint jobs' continue-on-error — which also
+          # absorbs linters' non-zero-on-findings exit — and is tracked as a
+          # follow-up in #325.)
+          fail_on_scanner_failure: false
+          scan_statuses: |
+            {
+              "yaml":       "${{ needs.yaml-lint.result }}",
+              "json":       "${{ needs.json-lint.result }}",
+              "python":     "${{ needs.python-lint.result }}",
+              "javascript": "${{ needs.javascript-lint.result }}",
+              "dockerfile": "${{ needs.dockerfile-lint.result }}",
+              "terraform":  "${{ needs.terraform-lint.result }}"
+            }
 
       - name: Fail if issues found
-        if: inputs.fail_on_issues == true && steps.summary.outputs.total_issues != '0'
+        if: inputs.fail_on_issues == true && steps.totals.outputs.total_issues != '0'
         run: |
-          echo "::error::Found ${STEPS_SUMMARY_OUTPUTS_TOTAL_ISSUES} linting issues"
+          echo "::error::Found ${TOTAL} linting issues"
           exit 1
         env:
-          STEPS_SUMMARY_OUTPUTS_TOTAL_ISSUES: ${{ steps.summary.outputs.total_issues }}
+          TOTAL: ${{ steps.totals.outputs.total_issues }}


### PR DESCRIPTION
## Description
`linting.yml` invoked the `linting-summary` action **without `scan_statuses`** (so no per-linter pass/fail table rendered) and read two outputs that **don't exist** — `steps.summary.outputs.status` and `.total_issues`. Consequences:
- workflow outputs `linting_status` / `issues_found` were always empty;
- the "Fail if issues found" gate compared `'' != '0'` (always true), so any caller setting `fail_on_issues: true` failed the job **even with zero issues**.

Refs #325.

## Type of Change
- [x] Bug fix

## Changes Made
- **Pass `scan_statuses`** (each linter's `needs.*.result`) so the pass/fail table renders — a skipped/failed linter is now visible instead of the report reading "clean". `fail_on_scanner_failure` is left off; the job's fail contract stays governed solely by `fail_on_issues`.
- **Add a "Tally linter issue counts" step** that sums the per-linter `issues_count` outputs (robust to empty/non-numeric → 0) and exposes the real `total_issues`; wire `status` → `overall_status` and `issues_found` → the tally.
- **Point the `fail_on_issues` gate at the real tally**, so it fires on actual issues instead of always.

### Known limitation (follow-up in #325)
Full hard-gating on a *crashed* linter is still limited by the lint jobs' `continue-on-error: true`, which also absorbs linters' non-zero-on-findings exit — so a crash can surface as `success`. Unlike the scanner side (#333), removing/gating that here risks conflating findings with crashes, so it's intentionally left as a scoped follow-up. This PR makes results **visible** and fixes the **output/gate** bugs with zero regression to the fail contract.

## Testing
- [x] Manual testing performed

### Test Results
- `linting.yml` validates as YAML; actionlint pre-commit hook passes.
- Unit-tested the tally shell logic against mixed inputs (`3, "", 5, "oops", 0, 2` → `10`), confirming empty/non-numeric coerce to 0.

## Security Considerations
- [x] Security enhancement — issue counts flow through `env:` (not inline in `run:`); `scan_statuses`/`needs.*.result` are GitHub-computed values, not untrusted input.

## AI Context Updates (.ai/)
- [x] N/A - No .ai/ updates needed

## Checklist
- [x] Code follows project style guidelines
- [x] All tests pass
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Refs #325 · part of the reusable-workflow reliability cluster (#322)