### PR TITLE
fix(ci): gate container scan on failures + status-table the summary

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -174,7 +174,7 @@ jobs:
     needs: discover-containers
     if: needs.discover-containers.outputs.has_containers == 'true'
     timeout-minutes: 30
-    continue-on-error: true
+    continue-on-error: ${{ inputs.allow_failure == true }}
 
     strategy:
       fail-fast: false
@@ -229,6 +229,17 @@ jobs:
             echo "build_success=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Fail if the image build failed
+        # A failed build (build step is continue-on-error) skips the scan below,
+        # leaving the image unscanned. Surface that as a failure unless the
+        # caller opted into allow_failure, so an unscanned container can't pass green.
+        if: steps.build.outputs.build_success != 'true' && inputs.allow_failure == false
+        env:
+          CONTAINER_NAME: ${{ matrix.container.name }}
+        run: |
+          echo "::error::Container build failed for ${CONTAINER_NAME} — image was not scanned."
+          exit 1
+
       - name: Run security scanners via argus CLI
         id: scan
         if: steps.build.outputs.build_success == 'true'
@@ -279,7 +290,7 @@ jobs:
     runs-on: ubuntu-latest
     if: inputs.scan_mode == 'remote' && inputs.image_ref != ''
     timeout-minutes: 30
-    continue-on-error: true
+    continue-on-error: ${{ inputs.allow_failure == true }}
 
     steps:
       - name: Checkout repository
@@ -378,3 +389,13 @@ jobs:
           title: '🐳 Container Security Scan Results'
           comment_marker: 'container-scan-parallel-comment'
           post_pr_comment: ${{ inputs.post_pr_comment }}
+          # Render the pass/fail table and gate on it so a failed build or scan
+          # can't pass green. A build/remote-scan failure is masked into
+          # `success` unless allow_failure is false (see the gated job-level
+          # continue-on-error above), so this table + gate is the surfacing point.
+          fail_on_scanner_failure: ${{ inputs.allow_failure == false }}
+          scan_statuses: |
+            {
+              "container-build-and-scan": "${{ needs.build-and-scan.result }}",
+              "container-remote-scan": "${{ needs.scan-remote-image.result }}"
+            }

--- a/.github/workflows/reusable-security-hardening.yml
+++ b/.github/workflows/reusable-security-hardening.yml
@@ -550,6 +550,7 @@ jobs:
     with:
       post_pr_comment: false
       enable_code_security: ${{ inputs.enable_code_security }}
+      allow_failure: ${{ inputs.allow_failure }}
       fail_on_severity: ${{ inputs.allow_failure == false && inputs.severity_threshold || 'none' }}
     permissions:
       contents: read


### PR DESCRIPTION
## Description
The `container-scan-summary` job called `security-summary` **without `scan_statuses`**, so `overall_status` was always `unknown` and `fail_on_scanner_failure` could never fire. Combined with unconditional job-level `continue-on-error` on `build-and-scan` / `scan-remote-image` (which also swallowed the intentional `exit $SCAN_EXIT` threshold result) and a build step that only records `build_success=false`, a **failed Docker build or scan crash produced a green pipeline with the container never scanned**.

Refs #326.

## Type of Change
- [x] Bug fix

## Changes Made
- Gate both scan jobs' job-level `continue-on-error` on `allow_failure` (mirrors #333; the input already exists), so a scan crash / threshold breach surfaces when `allow_failure` is false.
- Add a **"Fail if the image build failed"** guard so a failed build (the build step is `continue-on-error`) can't leave the image silently unscanned.
- Pass `scan_statuses` (build-and-scan + scan-remote-image results) and `fail_on_scanner_failure` to the container summary so the pass/fail table renders and gates.
- Thread `allow_failure` from the orchestrator's `scanner-container` call (the compound wrapper intentionally skipped in #333).

`container-scan.yml` already emits `--format markdown` + `scanner-summary-container-*`, so its detail path was already correct — this PR is purely the status-gating.

## Behavior note
Standalone `container-scan.yml` already defaults `allow_failure: false`, so its failures now correctly surface (opt out with `allow_failure: true`) instead of passing green.

## Testing
- [x] Manual testing performed

### Test Results
- Both workflows validate as YAML; actionlint pre-commit hook passes.
- Verified only the two **job-level** `continue-on-error` lines were gated (three step-level ones left intact), the build-failure guard uses `env:` (injection-safe), and the orchestrator threads `allow_failure` to `scanner-container`.

## Security Considerations
- [x] Security enhancement — a container that failed to build/scan can no longer pass as green/all-clear.

## AI Context Updates (.ai/)
- [x] N/A - No .ai/ updates needed

## Checklist
- [x] Code follows project style guidelines
- [x] All tests pass
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Refs #326 · part of the reusable-workflow reliability cluster (#322); mirrors #333