### PR TITLE
fix(ci): route infrastructure key to per-scanner workflows; deprecate wrappers

### DIFF
--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -1,5 +1,11 @@
 # Dependency Security Scanner - Reusable Workflow
 #
+# DEPRECATED (#327): This compound wrapper does not emit scanner-summary-* artifacts
+# or PR comments, so its findings never reach an aggregated summary. It is not used by
+# reusable-security-hardening.yml (which runs scanner-osv.yml + scanner-dependency-review.yml
+# directly). Prefer those per-scanner workflows; this file is retained only for backward
+# compatibility and will be removed in a future release.
+#
 # COMPOUND WRAPPER: Runs OSV (via argus CLI) + Dependency Review scanners in parallel.
 # OSV scanning: argus/scanners/osv.py (invoked via `python -m argus scan osv`)
 # Dependency Review: .github/actions/scanner-dependency-review/action.yml (GitHub-native)

--- a/.github/workflows/infrastructure-scan.yml
+++ b/.github/workflows/infrastructure-scan.yml
@@ -1,5 +1,12 @@
 # Infrastructure Security Scanner - Reusable Workflow
 #
+# DEPRECATED (#327): This compound wrapper does not emit scanner-summary-* artifacts
+# or PR comments, so its findings never reach an aggregated summary. It is no longer
+# used by reusable-security-hardening.yml — the `infrastructure` scanner key now runs
+# the per-scanner scanner-trivy-iac.yml + scanner-checkov.yml workflows, which produce
+# summaries, comments, and correct failure gating. Prefer those directly; this file is
+# retained only for backward compatibility and will be removed in a future release.
+#
 # COMPOUND WRAPPER: Runs Trivy IaC + Checkov scanners in parallel via the argus CLI.
 # Scanner implementations: argus/scanners/trivy_iac.py, argus/scanners/checkov.py
 #

--- a/.github/workflows/reusable-security-hardening.yml
+++ b/.github/workflows/reusable-security-hardening.yml
@@ -250,7 +250,6 @@ jobs:
       run_bandit: ${{ steps.resolve.outputs.run_bandit }}
       run_gitleaks: ${{ steps.resolve.outputs.run_gitleaks }}
       run_container: ${{ steps.resolve.outputs.run_container }}
-      run_infrastructure: ${{ steps.resolve.outputs.run_infrastructure }}
       run_sbom: ${{ steps.resolve.outputs.run_sbom }}
       run_trivy_iac: ${{ steps.resolve.outputs.run_trivy_iac }}
       run_checkov: ${{ steps.resolve.outputs.run_checkov }}
@@ -280,7 +279,6 @@ jobs:
           [bandit]=false
           [gitleaks]=false
           [container]=false
-          [infrastructure]=false
           [trivy-iac]=false
           [checkov]=false
           [trivy-container]=false
@@ -294,7 +292,7 @@ jobs:
           [supply-chain]=false
         )
 
-        DEFAULT_SCANNERS=(codeql opengrep bandit gitleaks container infrastructure sbom)
+        DEFAULT_SCANNERS=(codeql opengrep bandit gitleaks container trivy-iac checkov sbom)
         SELECTED=()
 
         normalize() {
@@ -325,7 +323,7 @@ jobs:
           case "$token" in
             '' ) ;;
             all|full)
-              local -a exclude=(trivy-iac checkov sbom trivy-container grype zap dependency-review)
+              local -a exclude=(sbom trivy-container grype zap dependency-review)
               for key in "${!RUN[@]}"; do
                 if [[ " ${exclude[*]} " != *" ${key} "* ]]; then
                   add_scanner "$key"
@@ -341,7 +339,12 @@ jobs:
             bandit) add_scanner bandit ;;
             gitleaks|git-leaks) add_scanner gitleaks ;;
             container|containers|container-scan|docker) add_scanner container ;;
-            infrastructure|infra|iac|terraform) add_scanner infrastructure ;;
+            infrastructure|infra|iac|terraform)
+              # `infrastructure` is an alias for the trivy-iac + checkov per-scanner
+              # workflows (the compound infrastructure-scan.yml is deprecated, #327).
+              add_scanner trivy-iac
+              add_scanner checkov
+              ;;
             sbom) add_scanner sbom ;;
             trivy-iac|trivyiac) add_scanner trivy-iac ;;
             checkov) add_scanner checkov ;;
@@ -560,23 +563,6 @@ jobs:
       pull-requests: write
     secrets: inherit
 
-  scanner-infrastructure:
-    name: Infrastructure Scanner
-    needs: scan-coordinator
-    if: needs.scan-coordinator.outputs.run_infrastructure == 'true'
-    uses: huntridge-labs/argus/.github/workflows/infrastructure-scan.yml@1.8.1
-    with:
-      iac_path: ${{ inputs.iac_path }}
-      post_pr_comment: false
-      enable_code_security: ${{ inputs.enable_code_security }}
-      fail_on_severity: ${{ inputs.allow_failure == false && inputs.severity_threshold || 'none' }}
-    permissions:
-      contents: read
-      security-events: write
-      actions: read
-      pull-requests: write
-    secrets: inherit
-
   scanner-sbom:
     name: SBOM Generator
     needs: scan-coordinator
@@ -774,7 +760,6 @@ jobs:
       - scanner-gitleaks
       - scanner-clamav
       - scanner-container
-      - scanner-infrastructure
       - scanner-sbom
       - scanner-trivy-iac
       - scanner-checkov
@@ -817,7 +802,6 @@ jobs:
               "gitleaks":          "${{ needs.scanner-gitleaks.result }}",
               "clamav":            "${{ needs.scanner-clamav.result }}",
               "container":         "${{ needs.scanner-container.result }}",
-              "infrastructure":    "${{ needs.scanner-infrastructure.result }}",
               "sbom":              "${{ needs.scanner-sbom.result }}",
               "trivy-iac":         "${{ needs.scanner-trivy-iac.result }}",
               "checkov":           "${{ needs.scanner-checkov.result }}",


### PR DESCRIPTION
## Description
The compound `infrastructure-scan.yml` / `dependency-scan.yml` wrappers emit **no** `scanner-summary-*` artifacts and no PR comments, so their findings never reached the aggregated comment (#327). They also **duplicate** the per-scanner workflows (`scanner-trivy-iac.yml`, `scanner-checkov.yml`, `scanner-osv.yml`) which — after #333/#334 — already produce summaries, comments, and correct failure gating, and already accept the same `iac_path` input (defaulting to `'infrastructure'`).

Per the chosen approach, consolidate on the per-scanner workflows rather than duplicating emit logic into the wrappers.

Closes #327.

## Type of Change
- [x] Bug fix
- [x] Other: workflow consolidation / deprecation

## Changes Made
- **Coordinator:** the `infrastructure` scanner key (plus the legacy `infrastructure-only` scan type and the `all`/default set) now expands to **trivy-iac + checkov**, running `scanner-trivy-iac.yml` + `scanner-checkov.yml`. Removed the `infrastructure` RUN key, its `run_infrastructure` output, and trivy-iac/checkov from the `all` exclude list.
- Removed the `scanner-infrastructure` job (sole consumer of `infrastructure-scan.yml`) and its `security-summary` `needs` + `scan_statuses` entries. trivy-iac and checkov were already wired into the summary, so their findings + status now flow through.
- Added **deprecation notices** to `infrastructure-scan.yml` and `dependency-scan.yml` (retained for backward compatibility; `dependency-scan.yml` was never wired into the orchestrator anyway).

No new input threading needed — the orchestrator already passed `iac_path`, `allow_failure`, and `fail_on_severity` to `scanner-trivy-iac` / `scanner-checkov`.

## Testing
- [x] Manual testing performed

### Test Results
- All three workflows validate as YAML; actionlint pre-commit hook passes.
- No dangling `scanner-infrastructure` / `run_infrastructure` references remain.
- Simulated the edited coordinator resolve logic:
  - `all` → `trivy-iac=true, checkov=true`
  - `infrastructure` → `trivy-iac=true, checkov=true`
  - `trivy-iac` (standalone) → trivy-iac only
  - the `infrastructure` RUN key no longer exists; DEFAULT set updated.

## Behavior note
Selecting `infrastructure` now runs the two per-scanner jobs (which post their own summaries + comments) instead of the single compound job. Net coverage is identical (trivy-iac + checkov); findings now actually surface in the aggregated comment.

## Security Considerations
- [x] Security enhancement — IaC findings (trivy-iac + checkov) now reach the consolidated comment instead of living only in job logs.

## AI Context Updates (.ai/)
- [x] N/A - No .ai/ updates needed (no `.ai/` reference to these workflows)

## Checklist
- [x] Code follows project style guidelines
- [x] All tests pass
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Closes #327 · part of the reusable-workflow reliability cluster (#322); builds on #333/#334