### PR TITLE
fix(ci): make grype/trivy-container PR-comment markers distinct

### DIFF
--- a/.github/workflows/scanner-grype.yml
+++ b/.github/workflows/scanner-grype.yml
@@ -161,6 +161,6 @@ jobs:
         uses: huntridge-labs/argus/.github/actions/comment-pr@1.8.1
         with:
           summary_file: ./argus-results/argus-summary.md
-          comment_marker: container-${{ inputs.scan_name || 'grype-scan' }}-comment-marker
+          comment_marker: grype-${{ inputs.scan_name || 'grype-scan' }}-comment-marker
           title: 'Grype Container Scan Results'
           fallback_message: 'No Grype results available'

--- a/.github/workflows/scanner-trivy-container.yml
+++ b/.github/workflows/scanner-trivy-container.yml
@@ -161,6 +161,6 @@ jobs:
         uses: huntridge-labs/argus/.github/actions/comment-pr@1.8.1
         with:
           summary_file: ./argus-results/argus-summary.md
-          comment_marker: container-${{ inputs.scan_name || 'trivy-scan' }}-comment-marker
+          comment_marker: trivy-container-${{ inputs.scan_name || 'trivy-scan' }}-comment-marker
           title: 'Trivy Container Scan Results'
           fallback_message: 'No Trivy container results available'


### PR DESCRIPTION
## Description
`scanner-grype.yml` and `scanner-trivy-container.yml` both default `scan_name` to `container`, and both built their comment marker as `container-${scan_name}-comment-marker` — so both resolved to **`container-container-comment-marker`**. Running both on the same PR (as the hardening pipeline does) made each overwrite the other's comment; only the last-running scanner's results survived.

Closes #329.

## Type of Change
- [x] Bug fix

## Changes Made
- Prefixed each marker with the scanner name so they're unique regardless of `scan_name`:
  - grype → `grype-${scan_name}-comment-marker`
  - trivy-container → `trivy-container-${scan_name}-comment-marker`

## Testing
- [x] Manual testing performed

### Test Results
- Both workflows validate as YAML; actionlint pre-commit hook passes.
- Markers now resolve to distinct values (`grype-container-…` vs `trivy-container-container-…`).

## Security Considerations
- [x] No security impact (PR-comment identity only)

## AI Context Updates (.ai/)
- [x] N/A

## Checklist
- [x] Code follows project style guidelines
- [x] All tests pass
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Closes #329 · part of the reusable-workflow reliability cluster (#322)