### PR TITLE
fix(scn-detector): emit scanner-summary-scn artifact so SCN analysis reaches the aggregator

### DIFF
--- a/.github/actions/scn-detector/README.md
+++ b/.github/actions/scn-detector/README.md
@@ -400,7 +400,7 @@ Located at `.github/actions/scn-detector/profiles/fedramp-low.yml`
 The action uploads the following artifacts (90-day retention for compliance):
 
 - **`scn-reports-{job_id}`** - Full analysis (iac-changes.json, scn-classifications.json, scn-audit-trail.json)
-- **`scn-summary-{job_id}`** - Markdown summary (scn-report.md)
+- **`scanner-summary-scn-{job_id}`** - Markdown summary (scn-report.md), collected by the `security-summary` aggregator
 
 ## Troubleshooting
 

--- a/.github/actions/scn-detector/TESTING.md
+++ b/.github/actions/scn-detector/TESTING.md
@@ -372,7 +372,7 @@ For each test PR, verify:
 - [ ] ✅ GitHub Issues created for non-routine changes
 - [ ] ✅ Issue labels applied correctly (`scn`, `scn:adaptive`, etc.)
 - [ ] ✅ Issue timelines calculated correctly
-- [ ] ✅ Artifacts uploaded (scn-reports, scn-summary)
+- [ ] ✅ Artifacts uploaded (scn-reports, scanner-summary-scn)
 - [ ] ✅ Job summary appears in Actions tab
 - [ ] ✅ Outputs are set correctly
 - [ ] ✅ Workflow passes/fails based on `fail_on_category`

--- a/.github/actions/scn-detector/action.yml
+++ b/.github/actions/scn-detector/action.yml
@@ -187,10 +187,20 @@ runs:
           echo "manual_review_count=0" >> "$GITHUB_OUTPUT"
         fi
 
-        # Copy markdown summary for PR comment and step summary
+        # Render the raw report to the job step summary, then build a wrapped
+        # copy for the security-summary aggregator. The aggregator collects
+        # `scanner-summary-*` artifacts and unwraps a single outer <details>
+        # into a `#### heading`, so wrapping here makes SCN render with a
+        # scanner heading alongside the other scanners' collapsible sections.
         if [ -f "scn-reports/scn-report.md" ]; then
-          cp scn-reports/scn-report.md scn-summaries/scn-report.md
           cat scn-reports/scn-report.md >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "<details><summary>🔐 FedRAMP SCN Analysis (Compliance)</summary>"
+            echo ""
+            cat scn-reports/scn-report.md
+            echo ""
+            echo "</details>"
+          } > scn-summaries/scn-report.md
         fi
 
         # Handle fail_on_category
@@ -219,7 +229,7 @@ runs:
     - name: Upload SCN summary
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
-        name: scn-summary-${{ inputs.job_id }}
+        name: scanner-summary-scn-${{ inputs.job_id }}
         path: scn-summaries/
         retention-days: 7
       if: always()
@@ -235,7 +245,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
       with:
-        summary_file: scn-summaries/scn-report.md
+        summary_file: scn-reports/scn-report.md
         comment_marker: scn-detector-comment-marker
         title: '🔐 FedRAMP SCN Analysis'
         fallback_message: 'No SCN analysis available'


### PR DESCRIPTION
## Description
The `security-summary` aggregator collects summary artifacts matching `scanner-summary-*`, stitches their markdown into the combined report, and unwraps a single outer `<details>` into a scanner heading. `scanner-scn-detector` uploaded its summary as `scn-summary-<job_id>`, so the aggregator never collected it — FedRAMP SCN analysis silently disappeared from the aggregated security summary.

## Changes Made
- [ ] Added new scanner/workflow
- [x] Modified existing scanner/workflow
- [x] Updated documentation
- [x] Fixed bug
- [ ] Other (please specify)

### Details
- **Which workflows/scanners are affected?** `.github/actions/scn-detector` only.
- **What fixes are included?**
  - Rename the summary artifact `scn-summary-<job_id>` → `scanner-summary-scn-<job_id>` so the aggregator's default `scanner-summary-*` pattern picks it up.
  - Wrap the aggregation copy in `<details><summary>🔐 FedRAMP SCN Analysis (Compliance)</summary>` so it renders with a scanner heading alongside the other scanners' collapsible sections (matching the per-scanner format from #334).
  - Point the PR comment at the raw report (`scn-reports/scn-report.md`) since the `scn-summaries/` copy is now wrapped for aggregation.
  - Update README/TESTING artifact-name references.
- **Any breaking changes?** The uploaded artifact name changes. `scn-reports-<job_id>` (full analysis) is unchanged; only the summary artifact is renamed. No consumers other than the aggregator reference it.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results
- `python3 -c "import yaml; yaml.safe_load(...)"` → YAML OK
- Verified against the aggregator contract in `security-summary/scripts/generate_summary.py`: `summary_pattern` default is `scanner-summary-*`; `normalize_summary` unwraps a single outer `<details>` into a `#### <title>` heading — the wrapper added here produces `#### FedRAMP SCN Analysis (Compliance)`.

## Security Considerations
- [x] No security impact
- [ ] Security enhancement
- [ ] Potential security implications (explain below)

### Security Details
No change to what is scanned or emitted; only the artifact name and summary formatting change. Compliance (FedRAMP SCN) findings now correctly surface in the aggregated report instead of being silently dropped.

## AI Context Updates (.ai/)
- [x] N/A - No .ai/ updates needed

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Closes #331