### PR TITLE
fix(ci): apply CodeQL disable before emitting run_codeql output

### DIFF
--- a/.github/workflows/reusable-security-hardening.yml
+++ b/.github/workflows/reusable-security-hardening.yml
@@ -389,6 +389,28 @@ jobs:
           for key in "${DEFAULT_SCANNERS[@]}"; do add_scanner "$key"; done
         fi
 
+        # Disable CodeQL BEFORE emitting run_* outputs. CodeQL requires GitHub
+        # Code Security to be enabled; when it isn't we must finalize
+        # RUN[codeql]=false here so the emit loop below writes run_codeql=false
+        # and RUN_ANY reflects the real selection. Doing this after the loop
+        # (the previous behavior) left a stale run_codeql=true in
+        # $GITHUB_OUTPUT, so the scanner-codeql job still triggered despite the
+        # "skipped" warning.
+        ENABLE_CODE_SECURITY="${{ inputs.enable_code_security }}"
+        if [[ "${RUN[codeql]}" == "true" && "$ENABLE_CODE_SECURITY" != "true" ]]; then
+          echo "::warning title=CodeQL Disabled::GitHub Code Security is not enabled for this repository. CodeQL scanning will be skipped."
+          RUN[codeql]=false
+          # Remove codeql as a discrete element. Substring replacement
+          # (${SELECTED[@]/codeql}) would leave an empty "" entry that pollutes
+          # selected_scanners and selected_scanners_json.
+          PRUNED=()
+          for item in "${SELECTED[@]}"; do
+            [[ "$item" == "codeql" ]] && continue
+            PRUNED+=("$item")
+          done
+          SELECTED=("${PRUNED[@]}")
+        fi
+
         RUN_ANY=false
         for key in "${!RUN[@]}"; do
           if [[ "${RUN[$key]}" == "true" ]]; then
@@ -400,13 +422,6 @@ jobs:
 
         if [[ "$RUN_ANY" == "false" ]]; then
           echo "::warning title=No scanners selected::No scanners were selected. The workflow will execute the summary only."
-        fi
-
-        ENABLE_CODE_SECURITY="${{ inputs.enable_code_security }}"
-        if [[ "${RUN[codeql]}" == "true" && "$ENABLE_CODE_SECURITY" != "true" ]]; then
-          echo "::warning title=CodeQL Disabled::GitHub Code Security is not enabled for this repository. CodeQL scanning will be skipped."
-          RUN[codeql]=false
-          SELECTED=("${SELECTED[@]/codeql}")
         fi
 
         echo "run_any=$RUN_ANY" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Description
The `scan-coordinator` job in `reusable-security-hardening.yml` emitted every `run_<scanner>` output in a loop, then disabled CodeQL **afterward** when GitHub Code Security wasn't enabled. Since `run_codeql=true` had already been written to `$GITHUB_OUTPUT`, setting `RUN[codeql]=false` later had no effect on the job output — the `scanner-codeql` job (gated on `needs.scan-coordinator.outputs.run_codeql`) still triggered despite the "CodeQL will be skipped" warning, and then failed for lack of Code Security.

## Changes Made
- [ ] Added new scanner/workflow
- [x] Modified existing scanner/workflow
- [ ] Updated documentation
- [x] Fixed bug
- [ ] Other (please specify)

### Details
- **Affected workflow:** `.github/workflows/reusable-security-hardening.yml` (scan-coordinator resolve step).
- Move the CodeQL-disable guard **ahead of** the `run_*` emit loop so:
  - `run_codeql=false` is actually written to `$GITHUB_OUTPUT` — the `scanner-codeql` job is truly skipped.
  - `RUN_ANY` is computed from the final selection, so the "no scanners selected" warning now fires when CodeQL was the only pick.
  - `codeql` is removed from `SELECTED` as a discrete element. The previous `${SELECTED[@]/codeql}` substring replacement blanked the element to `""`, polluting `selected_scanners` / `selected_scanners_json` with an empty entry.
- **Breaking changes?** None. Behavior only changes in the (previously broken) path where CodeQL is selected but Code Security is disabled — it now correctly skips instead of running and failing.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results
YAML parses; actionlint (pre-commit "Lint GitHub Actions workflow files") passes. Simulated the reordered resolve logic under `set -euo pipefail`:
- `codeql,opengrep,bandit` + Code Security **off** → `run_codeql=false`, `run_any=true`, `selected_scanners_json=["opengrep","bandit"]` (no empty entry).
- `codeql` only + Code Security **off** → `run_codeql=false`, `run_any=false` ("no scanners" warning fires), empty selection, no `set -u` crash on empty-array expansion (verified on bash 5.x; safe on all bash ≥ 4.4 runners).

## Security Considerations
- [ ] No security impact
- [x] Security enhancement
- [ ] Potential security implications (explain below)

### Security Details
Prevents a confusing failure mode where CodeQL appeared "skipped" in logs but the job actually ran and failed, and ensures the resolved scanner set reported downstream is accurate.

## AI Context Updates (.ai/)
- [x] N/A - No .ai/ updates needed

## Checklist
- [x] Code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Closes #330

## Notes for reviewers
Open PR #337 also edits `reusable-security-hardening.yml` (the `DEFAULT_SCANNERS` list and the `infrastructure` alias, a different region). This change touches only the resolve step's emit-ordering, so the two should merge cleanly; if #337 lands first this branch will just need a trivial rebase.