### PR TITLE
fix(ci): bring scanner-zap PR comment + summary to parity (closes #324, #328)

### DIFF
--- a/.github/workflows/scanner-zap.yml
+++ b/.github/workflows/scanner-zap.yml
@@ -212,7 +212,7 @@ jobs:
 
           ARGUS_CMD="$ARGUS_CMD --scan-type $SCAN_TYPE"
           ARGUS_CMD="$ARGUS_CMD --severity-threshold $SEVERITY_THRESHOLD"
-          ARGUS_CMD="$ARGUS_CMD --format terminal --format sarif --format json"
+          ARGUS_CMD="$ARGUS_CMD --format terminal --format sarif --format json --format markdown"
           ARGUS_CMD="$ARGUS_CMD --output-dir ./argus-results"
           ARGUS_CMD="$ARGUS_CMD --verbose"
 
@@ -239,11 +239,38 @@ jobs:
           path: ./argus-results/
           retention-days: 30
 
+      - name: Build scanner summary
+        if: always()
+        env:
+          SCAN_NAME: ${{ inputs.scan_name || 'zap-scan' }}
+        run: |
+          mkdir -p scanner-summaries
+          SAFE=$(printf '%s' "$SCAN_NAME" | tr -c 'A-Za-z0-9._-' '_')
+          {
+            echo "<details><summary>🕷️ OWASP ZAP (DAST) (${SCAN_NAME})</summary>"
+            echo ""
+            if [ -f ./argus-results/argus-summary.md ]; then
+              cat ./argus-results/argus-summary.md
+            else
+              echo "_No 🕷️ OWASP ZAP (DAST) findings summary was produced._"
+            fi
+            echo ""
+            echo "</details>"
+          } > "scanner-summaries/zap-${SAFE}.md"
+
+      - name: Upload scanner summary
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: scanner-summary-zap-${{ inputs.scan_name || 'zap-scan' }}
+          path: scanner-summaries/
+          retention-days: 30
+
       - name: Comment PR with results
-        if: github.event_name == 'pull_request' && inputs.post_pr_comment
+        if: always() && github.event_name == 'pull_request' && inputs.post_pr_comment
         uses: huntridge-labs/argus/.github/actions/comment-pr@1.8.1
         with:
-          summary_file: ./argus-results/argus-results.md
+          summary_file: ./argus-results/argus-summary.md
           comment_marker: zap-dast-comment-${{ inputs.scan_name || 'zap-scan' }}
           title: 'ZAP DAST Scan Results'
           fallback_message: 'No ZAP results available'

--- a/tests/unit/test_reusable_scanner_summaries.py
+++ b/tests/unit/test_reusable_scanner_summaries.py
@@ -20,8 +20,11 @@ WORKFLOWS = pathlib.Path(__file__).resolve().parents[2] / ".github" / "workflows
 
 # CLI-inline leaf scanners that feed the consolidated comment. codeql / syft /
 # dependency-review delegate to composite actions that emit their own
-# scanner-summary-* artifact; zap has its own scanner-zap-summary path. New
-# inline scanners should be added here (and emit a scanner-summary-* artifact).
+# scanner-summary-* artifact. The direct scanner-zap.yml workflow runs the CLI
+# inline and posts its own PR comment, so it must emit scanner-summary-zap too
+# (scanner-zap-from-config.yml is the separate matrix path that aggregates via
+# the scanner-zap-summary composite action). New inline scanners should be
+# added here (and emit a scanner-summary-* artifact).
 CLI_SCANNERS = [
     "bandit",
     "checkov",
@@ -33,6 +36,7 @@ CLI_SCANNERS = [
     "trivy-iac",
     "grype",
     "trivy-container",
+    "zap",
 ]
 
 


### PR DESCRIPTION
## Description
The #334 sweep that fixed per-scanner PR comments and `scanner-summary-*` artifacts skipped `scanner-zap.yml`, leaving ZAP (DAST) with the exact defects tracked in **#324** and **#328**. This brings ZAP to parity with the other 10 inline CLI scanners.

## Changes Made
- [ ] Added new scanner/workflow
- [x] Modified existing scanner/workflow
- [ ] Updated documentation
- [x] Fixed bug
- [x] Other (contract test)

### Details
**Affected:** `.github/workflows/scanner-zap.yml` only. Three defects fixed:
- **#324a** — no `--format markdown`, so the argus markdown reporter never wrote `argus-summary.md`; the comment step pointed at a nonexistent `argus-results.md` and always posted "No ZAP results available". → added `--format markdown`; repointed `summary_file` to `argus-summary.md`.
- **#328** — the "Comment PR" gate lacked `always()`, so when ZAP findings breached `fail_on_severity` and the scan step exited non-zero, the comment was skipped exactly when it mattered. → guarded with `always()`.
- **#322 (for zap)** — no `scanner-summary-zap` artifact, so ZAP findings never reached the `security-summary` aggregator. → build + upload a collapsible `scanner-summary-zap-<scan_name>` artifact, mirroring grype/trivy-container.

**Not changed:** `scanner-zap-from-config.yml` — it aggregates via the `scanner-zap-summary` composite action, which parses the JSON reports (`*.json`, already emitted at line 143). It does **not** depend on the markdown summary, so no change is needed there. Verified against `scanner-zap-summary/action.yml:119`.

**Breaking changes?** None. New artifact name + corrected comment behavior only.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results
- Added `zap` to `CLI_SCANNERS` in `tests/unit/test_reusable_scanner_summaries.py`; the contract test passes (`1 passed`), locking the summary upload in so it can't be dropped again.
- YAML parses; actionlint + yamllint (pre-commit) green.

## Security Considerations
- [x] No security impact

### Security Details
No change to what ZAP scans or emits; only summary formatting, the comment gate, and a new summary artifact. `scan_name` is passed via an env var and shell-sanitized (`tr -c 'A-Za-z0-9._-' '_'`) before use in a filename, matching the grype pattern.

## AI Context Updates (.ai/)
- [x] N/A - No .ai/ updates needed

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Closes #324
Closes #328