### PR TITLE
fix(ci): separate linter tool errors from findings and surface them (closes #325)

### DIFF
--- a/.github/actions/linter-dockerfile/README.md
+++ b/.github/actions/linter-dockerfile/README.md
@@ -23,6 +23,7 @@ This action checks Dockerfiles for best practices and common issues. It uploads 
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
 | `fail_on_issues` | Fail the job if issues are found | No | `false` |
+| `fail_on_tool_error` | Fail the job when the linter tool itself errors (a crash — argus exit code 2), independent of `fail_on_issues`. Tool errors are always surfaced in the job log, status table, and PR comment; this only makes them block. | No | `false` |
 | `paths` | Paths to search for Dockerfiles (space-separated) | No | `.` |
 | `config_file` | Path to Hadolint configuration file | No | `''` |
 | `ignore_rules` | Hadolint rules to ignore (comma-separated) | No | `''` |
@@ -32,6 +33,7 @@ This action checks Dockerfiles for best practices and common issues. It uploads 
 | Output | Description |
 |--------|-------------|
 | `issues_count` | Number of linting issues found |
+| `tool_status` | Whether the linter tool ran cleanly: `ok`, or `error` when the tool itself crashed (argus exit code 2). |
 
 ## Artifacts
 

--- a/.github/actions/linter-dockerfile/action.yml
+++ b/.github/actions/linter-dockerfile/action.yml
@@ -39,11 +39,22 @@ inputs:
     description: 'Whether to post PR comments'
     required: false
     default: 'false'
+  fail_on_tool_error:
+    description: |
+      Fail the job when hadolint itself errors (a tool crash — argus exit code 2),
+      independent of fail_on_issues. Default false: a tool error is always surfaced
+      in the job log, the status table, and the PR comment, but only blocks the job
+      when this is set to true.
+    required: false
+    default: 'false'
 
 outputs:
   issues_count:
     description: 'Number of linting issues found'
     value: ${{ steps.scan.outputs.issue_count }}
+  tool_status:
+    description: 'Whether hadolint ran cleanly: "ok", or "error" when the tool itself crashed (argus exit code 2).'
+    value: ${{ steps.scan.outputs.tool_status }}
 
 runs:
   using: 'composite'
@@ -86,7 +97,10 @@ runs:
           SEVERITY="info"
         fi
 
-        SCAN_EXIT=0
+        # argus scan exit codes: 0 = clean, 1 = findings over threshold,
+        # 2 = tool error (hadolint/argus itself crashed). Capture combined
+        # output so a crash can be echoed into the console AND the summary.
+        set +e
         python -m argus scan lint-dockerfile \
           --path "${SCAN_PATH}" \
           --severity-threshold "${SEVERITY}" \
@@ -94,18 +108,53 @@ runs:
           --output-dir ./dockerfile-lint-reports \
           --output-vars ./dockerfile-lint-reports/counts.env \
           --no-timestamp \
-          || SCAN_EXIT=$?
+          2>&1 | tee dockerfile-lint-reports/output.log
+        SCAN_EXIT=${PIPESTATUS[0]}
+        set -e
 
-        # Forward counts to GitHub Actions outputs
+        # Forward counts + a machine-readable exit code to job outputs.
         [ -f dockerfile-lint-reports/counts.env ] && cat dockerfile-lint-reports/counts.env >> "$GITHUB_OUTPUT"
+        echo "scan_exit=${SCAN_EXIT}" >> "$GITHUB_OUTPUT"
 
-        # Copy markdown summary for PR comment and step summary
-        if [ -f "dockerfile-lint-reports/argus-summary.md" ]; then
-          cp dockerfile-lint-reports/argus-summary.md scanner-summaries/dockerfile-lint.md
-          cat dockerfile-lint-reports/argus-summary.md >> "$GITHUB_STEP_SUMMARY"
+        # Distinguish a tool error (exit 2) from findings (exit 1). A tool error
+        # means the result is untrustworthy, so surface it in the job log now; it
+        # is also carried up via the tool_status output (status table) and the
+        # summary banner below (PR comment).
+        if [ "${SCAN_EXIT}" -eq 2 ]; then
+          echo "tool_status=error" >> "$GITHUB_OUTPUT"
+          echo "::error title=Dockerfile linter error::hadolint (argus lint-dockerfile) exited with a tool error (code 2). The Dockerfile lint result is incomplete — inspect this job log. Triage: ignore, patch, or open an Argus issue."
+        else
+          echo "tool_status=ok" >> "$GITHUB_OUTPUT"
         fi
 
-        exit $SCAN_EXIT
+        # Build the summary section (stitched into the check summary + PR comment).
+        # On a tool error, prepend an actionable banner + the error tail so every
+        # persona (comment / summary / console) has enough to triage.
+        {
+          if [ "${SCAN_EXIT}" -eq 2 ]; then
+            echo "> ⚠️ **Dockerfile linter errored (tool exit code 2) — result is incomplete.** Triage: ignore / patch / open an Argus issue."
+            echo ""
+            if [ -s dockerfile-lint-reports/output.log ]; then
+              echo '<details><summary>Error output (last 20 lines)</summary>'
+              echo ""
+              echo '```'
+              tail -n 20 dockerfile-lint-reports/output.log
+              echo '```'
+              echo ""
+              echo '</details>'
+              echo ""
+            fi
+          fi
+          if [ -f "dockerfile-lint-reports/argus-summary.md" ]; then
+            cat dockerfile-lint-reports/argus-summary.md
+          fi
+        } > scanner-summaries/dockerfile-lint.md
+
+        cat scanner-summaries/dockerfile-lint.md >> "$GITHUB_STEP_SUMMARY"
+
+        # Do NOT exit non-zero here: aborting would stop this composite from
+        # exporting tool_status/issue_count to the caller. The failure policy is
+        # applied in the "Enforce lint failure policy" step below.
 
     - name: Upload Dockerfile lint artifacts
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -132,6 +181,26 @@ runs:
         comment_marker: dockerfile-linter-comment-marker
         title: '📦 Dockerfile Linting Results'
         fallback_message: 'No Dockerfile linting results available'
+
+    - name: Enforce lint failure policy
+      if: always()
+      shell: bash
+      env:
+        FAIL_ON_ISSUES: ${{ inputs.fail_on_issues }}
+        FAIL_ON_TOOL_ERROR: ${{ inputs.fail_on_tool_error }}
+        SCAN_EXIT: ${{ steps.scan.outputs.scan_exit }}
+        TOOL_STATUS: ${{ steps.scan.outputs.tool_status }}
+      run: |
+        # Findings gate (documented fail_on_issues contract): argus exit 1.
+        if [ "$FAIL_ON_ISSUES" = "true" ] && [ "$SCAN_EXIT" = "1" ]; then
+          echo "::error title=Dockerfile lint findings::Linting issues found and fail_on_issues is enabled."
+          exit 1
+        fi
+        # Tool-error gate (opt-in; distinct from findings): argus exit 2.
+        if [ "$FAIL_ON_TOOL_ERROR" = "true" ] && [ "$TOOL_STATUS" = "error" ]; then
+          echo "::error title=Dockerfile linter error::hadolint errored and fail_on_tool_error is enabled."
+          exit 1
+        fi
 
 branding:
   icon: 'box'

--- a/.github/actions/linter-javascript/README.md
+++ b/.github/actions/linter-javascript/README.md
@@ -23,6 +23,7 @@ This action validates JavaScript files for syntax errors and code quality issues
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
 | `fail_on_issues` | Fail the job if issues are found | No | `false` |
+| `fail_on_tool_error` | Fail the job when the linter tool itself errors (a crash — argus exit code 2), independent of `fail_on_issues`. Tool errors are always surfaced in the job log, status table, and PR comment; this only makes them block. | No | `false` |
 | `paths` | Paths to search for JavaScript files (space-separated) | No | `.` |
 | `node_version` | Node.js version to use | No | `20` |
 
@@ -31,6 +32,7 @@ This action validates JavaScript files for syntax errors and code quality issues
 | Output | Description |
 |--------|-------------|
 | `issues_count` | Total number of issues found |
+| `tool_status` | Whether the linter tool ran cleanly: `ok`, or `error` when the tool itself crashed (argus exit code 2). |
 | `syntax_issues` | Number of syntax errors |
 | `jshint_issues` | Number of JSHint code quality issues |
 

--- a/.github/actions/linter-javascript/action.yml
+++ b/.github/actions/linter-javascript/action.yml
@@ -31,11 +31,22 @@ inputs:
     description: 'Whether to post PR comments'
     required: false
     default: 'false'
+  fail_on_tool_error:
+    description: |
+      Fail the job when jshint itself errors (a tool crash — argus exit code 2),
+      independent of fail_on_issues. Default false: a tool error is always surfaced
+      in the job log, the status table, and the PR comment, but only blocks the job
+      when this is set to true.
+    required: false
+    default: 'false'
 
 outputs:
   issues_count:
     description: 'Total number of linting issues found'
     value: ${{ steps.scan.outputs.issue_count }}
+  tool_status:
+    description: 'Whether jshint ran cleanly: "ok", or "error" when the tool itself crashed (argus exit code 2).'
+    value: ${{ steps.scan.outputs.tool_status }}
 
 runs:
   using: 'composite'
@@ -78,7 +89,10 @@ runs:
           SEVERITY="info"
         fi
 
-        SCAN_EXIT=0
+        # argus scan exit codes: 0 = clean, 1 = findings over threshold,
+        # 2 = tool error (jshint/argus itself crashed). Capture combined
+        # output so a crash can be echoed into the console AND the summary.
+        set +e
         python -m argus scan lint-javascript \
           --path "${SCAN_PATH}" \
           --severity-threshold "${SEVERITY}" \
@@ -86,18 +100,53 @@ runs:
           --output-dir ./javascript-lint-reports \
           --output-vars ./javascript-lint-reports/counts.env \
           --no-timestamp \
-          || SCAN_EXIT=$?
+          2>&1 | tee javascript-lint-reports/output.log
+        SCAN_EXIT=${PIPESTATUS[0]}
+        set -e
 
-        # Forward counts to GitHub Actions outputs
+        # Forward counts + a machine-readable exit code to job outputs.
         [ -f javascript-lint-reports/counts.env ] && cat javascript-lint-reports/counts.env >> "$GITHUB_OUTPUT"
+        echo "scan_exit=${SCAN_EXIT}" >> "$GITHUB_OUTPUT"
 
-        # Copy markdown summary for PR comment and step summary
-        if [ -f "javascript-lint-reports/argus-summary.md" ]; then
-          cp javascript-lint-reports/argus-summary.md scanner-summaries/javascript-lint.md
-          cat javascript-lint-reports/argus-summary.md >> "$GITHUB_STEP_SUMMARY"
+        # Distinguish a tool error (exit 2) from findings (exit 1). A tool error
+        # means the result is untrustworthy, so surface it in the job log now; it
+        # is also carried up via the tool_status output (status table) and the
+        # summary banner below (PR comment).
+        if [ "${SCAN_EXIT}" -eq 2 ]; then
+          echo "tool_status=error" >> "$GITHUB_OUTPUT"
+          echo "::error title=JavaScript linter error::jshint (argus lint-javascript) exited with a tool error (code 2). The JavaScript lint result is incomplete — inspect this job log. Triage: ignore, patch, or open an Argus issue."
+        else
+          echo "tool_status=ok" >> "$GITHUB_OUTPUT"
         fi
 
-        exit $SCAN_EXIT
+        # Build the summary section (stitched into the check summary + PR comment).
+        # On a tool error, prepend an actionable banner + the error tail so every
+        # persona (comment / summary / console) has enough to triage.
+        {
+          if [ "${SCAN_EXIT}" -eq 2 ]; then
+            echo "> ⚠️ **JavaScript linter errored (tool exit code 2) — result is incomplete.** Triage: ignore / patch / open an Argus issue."
+            echo ""
+            if [ -s javascript-lint-reports/output.log ]; then
+              echo '<details><summary>Error output (last 20 lines)</summary>'
+              echo ""
+              echo '```'
+              tail -n 20 javascript-lint-reports/output.log
+              echo '```'
+              echo ""
+              echo '</details>'
+              echo ""
+            fi
+          fi
+          if [ -f "javascript-lint-reports/argus-summary.md" ]; then
+            cat javascript-lint-reports/argus-summary.md
+          fi
+        } > scanner-summaries/javascript-lint.md
+
+        cat scanner-summaries/javascript-lint.md >> "$GITHUB_STEP_SUMMARY"
+
+        # Do NOT exit non-zero here: aborting would stop this composite from
+        # exporting tool_status/issue_count to the caller. The failure policy is
+        # applied in the "Enforce lint failure policy" step below.
 
     - name: Upload JavaScript lint artifacts
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -124,6 +173,26 @@ runs:
         comment_marker: javascript-linter-comment-marker
         title: '📜 JavaScript Linting Results'
         fallback_message: 'No JavaScript linting results available'
+
+    - name: Enforce lint failure policy
+      if: always()
+      shell: bash
+      env:
+        FAIL_ON_ISSUES: ${{ inputs.fail_on_issues }}
+        FAIL_ON_TOOL_ERROR: ${{ inputs.fail_on_tool_error }}
+        SCAN_EXIT: ${{ steps.scan.outputs.scan_exit }}
+        TOOL_STATUS: ${{ steps.scan.outputs.tool_status }}
+      run: |
+        # Findings gate (documented fail_on_issues contract): argus exit 1.
+        if [ "$FAIL_ON_ISSUES" = "true" ] && [ "$SCAN_EXIT" = "1" ]; then
+          echo "::error title=JavaScript lint findings::Linting issues found and fail_on_issues is enabled."
+          exit 1
+        fi
+        # Tool-error gate (opt-in; distinct from findings): argus exit 2.
+        if [ "$FAIL_ON_TOOL_ERROR" = "true" ] && [ "$TOOL_STATUS" = "error" ]; then
+          echo "::error title=JavaScript linter error::jshint errored and fail_on_tool_error is enabled."
+          exit 1
+        fi
 
 branding:
   icon: 'code'

--- a/.github/actions/linter-json/README.md
+++ b/.github/actions/linter-json/README.md
@@ -23,6 +23,7 @@ This action checks JSON syntax across your repository. It uploads results as art
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
 | `fail_on_issues` | Fail the job if issues are found | No | `false` |
+| `fail_on_tool_error` | Fail the job when the linter tool itself errors (a crash — argus exit code 2), independent of `fail_on_issues`. Tool errors are always surfaced in the job log, status table, and PR comment; this only makes them block. | No | `false` |
 | `paths` | Paths to search for JSON files (space-separated) | No | `.` |
 | `node_version` | Node.js version to use | No | `20` |
 
@@ -31,6 +32,7 @@ This action checks JSON syntax across your repository. It uploads results as art
 | Output | Description |
 |--------|-------------|
 | `issues_count` | Number of validation issues found |
+| `tool_status` | Whether the linter tool ran cleanly: `ok`, or `error` when the tool itself crashed (argus exit code 2). |
 
 ## Artifacts
 

--- a/.github/actions/linter-json/action.yml
+++ b/.github/actions/linter-json/action.yml
@@ -31,11 +31,22 @@ inputs:
     description: 'Whether to post PR comments'
     required: false
     default: 'false'
+  fail_on_tool_error:
+    description: |
+      Fail the job when jsonlint itself errors (a tool crash — argus exit code 2),
+      independent of fail_on_issues. Default false: a tool error is always surfaced
+      in the job log, the status table, and the PR comment, but only blocks the job
+      when this is set to true.
+    required: false
+    default: 'false'
 
 outputs:
   issues_count:
     description: 'Number of validation issues found'
     value: ${{ steps.scan.outputs.issue_count }}
+  tool_status:
+    description: 'Whether jsonlint ran cleanly: "ok", or "error" when the tool itself crashed (argus exit code 2).'
+    value: ${{ steps.scan.outputs.tool_status }}
 
 runs:
   using: 'composite'
@@ -78,7 +89,10 @@ runs:
           SEVERITY="info"
         fi
 
-        SCAN_EXIT=0
+        # argus scan exit codes: 0 = clean, 1 = findings over threshold,
+        # 2 = tool error (jsonlint/argus itself crashed). Capture combined
+        # output so a crash can be echoed into the console AND the summary.
+        set +e
         python -m argus scan lint-json \
           --path "${SCAN_PATH}" \
           --severity-threshold "${SEVERITY}" \
@@ -86,18 +100,53 @@ runs:
           --output-dir ./json-lint-reports \
           --output-vars ./json-lint-reports/counts.env \
           --no-timestamp \
-          || SCAN_EXIT=$?
+          2>&1 | tee json-lint-reports/output.log
+        SCAN_EXIT=${PIPESTATUS[0]}
+        set -e
 
-        # Forward counts to GitHub Actions outputs
+        # Forward counts + a machine-readable exit code to job outputs.
         [ -f json-lint-reports/counts.env ] && cat json-lint-reports/counts.env >> "$GITHUB_OUTPUT"
+        echo "scan_exit=${SCAN_EXIT}" >> "$GITHUB_OUTPUT"
 
-        # Copy markdown summary for PR comment and step summary
-        if [ -f "json-lint-reports/argus-summary.md" ]; then
-          cp json-lint-reports/argus-summary.md scanner-summaries/json-lint.md
-          cat json-lint-reports/argus-summary.md >> "$GITHUB_STEP_SUMMARY"
+        # Distinguish a tool error (exit 2) from findings (exit 1). A tool error
+        # means the result is untrustworthy, so surface it in the job log now; it
+        # is also carried up via the tool_status output (status table) and the
+        # summary banner below (PR comment).
+        if [ "${SCAN_EXIT}" -eq 2 ]; then
+          echo "tool_status=error" >> "$GITHUB_OUTPUT"
+          echo "::error title=JSON linter error::jsonlint (argus lint-json) exited with a tool error (code 2). The JSON lint result is incomplete — inspect this job log. Triage: ignore, patch, or open an Argus issue."
+        else
+          echo "tool_status=ok" >> "$GITHUB_OUTPUT"
         fi
 
-        exit $SCAN_EXIT
+        # Build the summary section (stitched into the check summary + PR comment).
+        # On a tool error, prepend an actionable banner + the error tail so every
+        # persona (comment / summary / console) has enough to triage.
+        {
+          if [ "${SCAN_EXIT}" -eq 2 ]; then
+            echo "> ⚠️ **JSON linter errored (tool exit code 2) — result is incomplete.** Triage: ignore / patch / open an Argus issue."
+            echo ""
+            if [ -s json-lint-reports/output.log ]; then
+              echo '<details><summary>Error output (last 20 lines)</summary>'
+              echo ""
+              echo '```'
+              tail -n 20 json-lint-reports/output.log
+              echo '```'
+              echo ""
+              echo '</details>'
+              echo ""
+            fi
+          fi
+          if [ -f "json-lint-reports/argus-summary.md" ]; then
+            cat json-lint-reports/argus-summary.md
+          fi
+        } > scanner-summaries/json-lint.md
+
+        cat scanner-summaries/json-lint.md >> "$GITHUB_STEP_SUMMARY"
+
+        # Do NOT exit non-zero here: aborting would stop this composite from
+        # exporting tool_status/issue_count to the caller. The failure policy is
+        # applied in the "Enforce lint failure policy" step below.
 
     - name: Upload JSON lint artifacts
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -124,6 +173,26 @@ runs:
         comment_marker: json-linter-comment-marker
         title: '📋 JSON Linting Results'
         fallback_message: 'No JSON linting results available'
+
+    - name: Enforce lint failure policy
+      if: always()
+      shell: bash
+      env:
+        FAIL_ON_ISSUES: ${{ inputs.fail_on_issues }}
+        FAIL_ON_TOOL_ERROR: ${{ inputs.fail_on_tool_error }}
+        SCAN_EXIT: ${{ steps.scan.outputs.scan_exit }}
+        TOOL_STATUS: ${{ steps.scan.outputs.tool_status }}
+      run: |
+        # Findings gate (documented fail_on_issues contract): argus exit 1.
+        if [ "$FAIL_ON_ISSUES" = "true" ] && [ "$SCAN_EXIT" = "1" ]; then
+          echo "::error title=JSON lint findings::Linting issues found and fail_on_issues is enabled."
+          exit 1
+        fi
+        # Tool-error gate (opt-in; distinct from findings): argus exit 2.
+        if [ "$FAIL_ON_TOOL_ERROR" = "true" ] && [ "$TOOL_STATUS" = "error" ]; then
+          echo "::error title=JSON linter error::jsonlint errored and fail_on_tool_error is enabled."
+          exit 1
+        fi
 
 branding:
   icon: 'file-text'

--- a/.github/actions/linter-python/README.md
+++ b/.github/actions/linter-python/README.md
@@ -24,6 +24,7 @@ This action checks Python code for style violations (flake8) and security issues
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
 | `fail_on_issues` | Fail the job if issues are found | No | `false` |
+| `fail_on_tool_error` | Fail the job when the linter tool itself errors (a crash — argus exit code 2), independent of `fail_on_issues`. Tool errors are always surfaced in the job log, status table, and PR comment; this only makes them block. | No | `false` |
 | `paths` | Paths to lint (space-separated) | No | `.` |
 | `python_version` | Python version to use | No | `3.12` |
 | `max_line_length` | Maximum line length for flake8 | No | `120` |
@@ -34,6 +35,7 @@ This action checks Python code for style violations (flake8) and security issues
 | Output | Description |
 |--------|-------------|
 | `issues_count` | Total number of issues found |
+| `tool_status` | Whether the linter tool ran cleanly: `ok`, or `error` when the tool itself crashed (argus exit code 2). |
 | `flake8_issues` | Number of flake8 style issues |
 | `bandit_issues` | Number of bandit security issues |
 

--- a/.github/actions/linter-python/action.yml
+++ b/.github/actions/linter-python/action.yml
@@ -40,11 +40,22 @@ inputs:
     description: 'Whether to post PR comments'
     required: false
     default: 'false'
+  fail_on_tool_error:
+    description: |
+      Fail the job when flake8 itself errors (a tool crash — argus exit code 2),
+      independent of fail_on_issues. Default false: a tool error is always surfaced
+      in the job log, the status table, and the PR comment, but only blocks the job
+      when this is set to true.
+    required: false
+    default: 'false'
 
 outputs:
   issues_count:
     description: 'Total number of linting issues found'
     value: ${{ steps.scan.outputs.issue_count }}
+  tool_status:
+    description: 'Whether flake8 ran cleanly: "ok", or "error" when the tool itself crashed (argus exit code 2).'
+    value: ${{ steps.scan.outputs.tool_status }}
 
 runs:
   using: 'composite'
@@ -87,7 +98,10 @@ runs:
           SEVERITY="info"
         fi
 
-        SCAN_EXIT=0
+        # argus scan exit codes: 0 = clean, 1 = findings over threshold,
+        # 2 = tool error (flake8/argus itself crashed). Capture combined
+        # output so a crash can be echoed into the console AND the summary.
+        set +e
         python -m argus scan lint-python \
           --path "${SCAN_PATH}" \
           --severity-threshold "${SEVERITY}" \
@@ -95,18 +109,53 @@ runs:
           --output-dir ./python-lint-reports \
           --output-vars ./python-lint-reports/counts.env \
           --no-timestamp \
-          || SCAN_EXIT=$?
+          2>&1 | tee python-lint-reports/output.log
+        SCAN_EXIT=${PIPESTATUS[0]}
+        set -e
 
-        # Forward counts to GitHub Actions outputs
+        # Forward counts + a machine-readable exit code to job outputs.
         [ -f python-lint-reports/counts.env ] && cat python-lint-reports/counts.env >> "$GITHUB_OUTPUT"
+        echo "scan_exit=${SCAN_EXIT}" >> "$GITHUB_OUTPUT"
 
-        # Copy markdown summary for PR comment and step summary
-        if [ -f "python-lint-reports/argus-summary.md" ]; then
-          cp python-lint-reports/argus-summary.md scanner-summaries/python-lint.md
-          cat python-lint-reports/argus-summary.md >> "$GITHUB_STEP_SUMMARY"
+        # Distinguish a tool error (exit 2) from findings (exit 1). A tool error
+        # means the result is untrustworthy, so surface it in the job log now; it
+        # is also carried up via the tool_status output (status table) and the
+        # summary banner below (PR comment).
+        if [ "${SCAN_EXIT}" -eq 2 ]; then
+          echo "tool_status=error" >> "$GITHUB_OUTPUT"
+          echo "::error title=Python linter error::flake8 (argus lint-python) exited with a tool error (code 2). The Python lint result is incomplete — inspect this job log. Triage: ignore, patch, or open an Argus issue."
+        else
+          echo "tool_status=ok" >> "$GITHUB_OUTPUT"
         fi
 
-        exit $SCAN_EXIT
+        # Build the summary section (stitched into the check summary + PR comment).
+        # On a tool error, prepend an actionable banner + the error tail so every
+        # persona (comment / summary / console) has enough to triage.
+        {
+          if [ "${SCAN_EXIT}" -eq 2 ]; then
+            echo "> ⚠️ **Python linter errored (tool exit code 2) — result is incomplete.** Triage: ignore / patch / open an Argus issue."
+            echo ""
+            if [ -s python-lint-reports/output.log ]; then
+              echo '<details><summary>Error output (last 20 lines)</summary>'
+              echo ""
+              echo '```'
+              tail -n 20 python-lint-reports/output.log
+              echo '```'
+              echo ""
+              echo '</details>'
+              echo ""
+            fi
+          fi
+          if [ -f "python-lint-reports/argus-summary.md" ]; then
+            cat python-lint-reports/argus-summary.md
+          fi
+        } > scanner-summaries/python-lint.md
+
+        cat scanner-summaries/python-lint.md >> "$GITHUB_STEP_SUMMARY"
+
+        # Do NOT exit non-zero here: aborting would stop this composite from
+        # exporting tool_status/issue_count to the caller. The failure policy is
+        # applied in the "Enforce lint failure policy" step below.
 
     - name: Upload Python lint artifacts
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -133,6 +182,26 @@ runs:
         comment_marker: python-linter-comment-marker
         title: '🐍 Python Code Quality Results'
         fallback_message: 'No Python linting results available'
+
+    - name: Enforce lint failure policy
+      if: always()
+      shell: bash
+      env:
+        FAIL_ON_ISSUES: ${{ inputs.fail_on_issues }}
+        FAIL_ON_TOOL_ERROR: ${{ inputs.fail_on_tool_error }}
+        SCAN_EXIT: ${{ steps.scan.outputs.scan_exit }}
+        TOOL_STATUS: ${{ steps.scan.outputs.tool_status }}
+      run: |
+        # Findings gate (documented fail_on_issues contract): argus exit 1.
+        if [ "$FAIL_ON_ISSUES" = "true" ] && [ "$SCAN_EXIT" = "1" ]; then
+          echo "::error title=Python lint findings::Linting issues found and fail_on_issues is enabled."
+          exit 1
+        fi
+        # Tool-error gate (opt-in; distinct from findings): argus exit 2.
+        if [ "$FAIL_ON_TOOL_ERROR" = "true" ] && [ "$TOOL_STATUS" = "error" ]; then
+          echo "::error title=Python linter error::flake8 errored and fail_on_tool_error is enabled."
+          exit 1
+        fi
 
 branding:
   icon: 'code'

--- a/.github/actions/linter-terraform/README.md
+++ b/.github/actions/linter-terraform/README.md
@@ -24,6 +24,7 @@ This action validates Terraform files using `terraform fmt`, `terraform validate
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
 | `fail_on_issues` | Fail the job if issues are found | No | `false` |
+| `fail_on_tool_error` | Fail the job when the linter tool itself errors (a crash — argus exit code 2), independent of `fail_on_issues`. Tool errors are always surfaced in the job log, status table, and PR comment; this only makes them block. | No | `false` |
 | `paths` | Paths to search for Terraform files (space-separated) | No | `.` |
 | `terraform_version` | Terraform version to use | No | `latest` |
 | `run_tflint` | Run TFLint in addition to fmt/validate | No | `true` |
@@ -33,6 +34,7 @@ This action validates Terraform files using `terraform fmt`, `terraform validate
 | Output | Description |
 |--------|-------------|
 | `issues_count` | Total number of linting issues found |
+| `tool_status` | Whether the linter tool ran cleanly: `ok`, or `error` when the tool itself crashed (argus exit code 2). |
 | `fmt_issues` | Number of formatting issues |
 | `validate_issues` | Number of validation issues |
 | `tflint_issues` | Number of TFLint issues |

--- a/.github/actions/linter-terraform/action.yml
+++ b/.github/actions/linter-terraform/action.yml
@@ -40,11 +40,22 @@ inputs:
     description: 'Whether to post PR comments'
     required: false
     default: 'false'
+  fail_on_tool_error:
+    description: |
+      Fail the job when terraform itself errors (a tool crash — argus exit code 2),
+      independent of fail_on_issues. Default false: a tool error is always surfaced
+      in the job log, the status table, and the PR comment, but only blocks the job
+      when this is set to true.
+    required: false
+    default: 'false'
 
 outputs:
   issues_count:
     description: 'Total number of linting issues found'
     value: ${{ steps.scan.outputs.issue_count }}
+  tool_status:
+    description: 'Whether terraform ran cleanly: "ok", or "error" when the tool itself crashed (argus exit code 2).'
+    value: ${{ steps.scan.outputs.tool_status }}
 
 runs:
   using: 'composite'
@@ -87,7 +98,10 @@ runs:
           SEVERITY="info"
         fi
 
-        SCAN_EXIT=0
+        # argus scan exit codes: 0 = clean, 1 = findings over threshold,
+        # 2 = tool error (terraform/argus itself crashed). Capture combined
+        # output so a crash can be echoed into the console AND the summary.
+        set +e
         python -m argus scan lint-terraform \
           --path "${SCAN_PATH}" \
           --severity-threshold "${SEVERITY}" \
@@ -95,18 +109,53 @@ runs:
           --output-dir ./terraform-lint-reports \
           --output-vars ./terraform-lint-reports/counts.env \
           --no-timestamp \
-          || SCAN_EXIT=$?
+          2>&1 | tee terraform-lint-reports/output.log
+        SCAN_EXIT=${PIPESTATUS[0]}
+        set -e
 
-        # Forward counts to GitHub Actions outputs
+        # Forward counts + a machine-readable exit code to job outputs.
         [ -f terraform-lint-reports/counts.env ] && cat terraform-lint-reports/counts.env >> "$GITHUB_OUTPUT"
+        echo "scan_exit=${SCAN_EXIT}" >> "$GITHUB_OUTPUT"
 
-        # Copy markdown summary for PR comment and step summary
-        if [ -f "terraform-lint-reports/argus-summary.md" ]; then
-          cp terraform-lint-reports/argus-summary.md scanner-summaries/terraform-lint.md
-          cat terraform-lint-reports/argus-summary.md >> "$GITHUB_STEP_SUMMARY"
+        # Distinguish a tool error (exit 2) from findings (exit 1). A tool error
+        # means the result is untrustworthy, so surface it in the job log now; it
+        # is also carried up via the tool_status output (status table) and the
+        # summary banner below (PR comment).
+        if [ "${SCAN_EXIT}" -eq 2 ]; then
+          echo "tool_status=error" >> "$GITHUB_OUTPUT"
+          echo "::error title=Terraform linter error::terraform (argus lint-terraform) exited with a tool error (code 2). The Terraform lint result is incomplete — inspect this job log. Triage: ignore, patch, or open an Argus issue."
+        else
+          echo "tool_status=ok" >> "$GITHUB_OUTPUT"
         fi
 
-        exit $SCAN_EXIT
+        # Build the summary section (stitched into the check summary + PR comment).
+        # On a tool error, prepend an actionable banner + the error tail so every
+        # persona (comment / summary / console) has enough to triage.
+        {
+          if [ "${SCAN_EXIT}" -eq 2 ]; then
+            echo "> ⚠️ **Terraform linter errored (tool exit code 2) — result is incomplete.** Triage: ignore / patch / open an Argus issue."
+            echo ""
+            if [ -s terraform-lint-reports/output.log ]; then
+              echo '<details><summary>Error output (last 20 lines)</summary>'
+              echo ""
+              echo '```'
+              tail -n 20 terraform-lint-reports/output.log
+              echo '```'
+              echo ""
+              echo '</details>'
+              echo ""
+            fi
+          fi
+          if [ -f "terraform-lint-reports/argus-summary.md" ]; then
+            cat terraform-lint-reports/argus-summary.md
+          fi
+        } > scanner-summaries/terraform-lint.md
+
+        cat scanner-summaries/terraform-lint.md >> "$GITHUB_STEP_SUMMARY"
+
+        # Do NOT exit non-zero here: aborting would stop this composite from
+        # exporting tool_status/issue_count to the caller. The failure policy is
+        # applied in the "Enforce lint failure policy" step below.
 
     - name: Upload Terraform lint artifacts
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -133,6 +182,26 @@ runs:
         comment_marker: terraform-linter-comment-marker
         title: '🏗️ Terraform Linting Results'
         fallback_message: 'No Terraform linting results available'
+
+    - name: Enforce lint failure policy
+      if: always()
+      shell: bash
+      env:
+        FAIL_ON_ISSUES: ${{ inputs.fail_on_issues }}
+        FAIL_ON_TOOL_ERROR: ${{ inputs.fail_on_tool_error }}
+        SCAN_EXIT: ${{ steps.scan.outputs.scan_exit }}
+        TOOL_STATUS: ${{ steps.scan.outputs.tool_status }}
+      run: |
+        # Findings gate (documented fail_on_issues contract): argus exit 1.
+        if [ "$FAIL_ON_ISSUES" = "true" ] && [ "$SCAN_EXIT" = "1" ]; then
+          echo "::error title=Terraform lint findings::Linting issues found and fail_on_issues is enabled."
+          exit 1
+        fi
+        # Tool-error gate (opt-in; distinct from findings): argus exit 2.
+        if [ "$FAIL_ON_TOOL_ERROR" = "true" ] && [ "$TOOL_STATUS" = "error" ]; then
+          echo "::error title=Terraform linter error::terraform errored and fail_on_tool_error is enabled."
+          exit 1
+        fi
 
 branding:
   icon: 'layers'

--- a/.github/actions/linter-yaml/README.md
+++ b/.github/actions/linter-yaml/README.md
@@ -24,6 +24,7 @@ This action checks YAML syntax and style. It uploads results as artifacts that c
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
 | `fail_on_issues` | Fail the job if issues are found | No | `false` |
+| `fail_on_tool_error` | Fail the job when the linter tool itself errors (a crash — argus exit code 2), independent of `fail_on_issues`. Tool errors are always surfaced in the job log, status table, and PR comment; this only makes them block. | No | `false` |
 | `config_file` | Path to yamllint configuration file | No | `''` |
 | `paths` | Paths to lint (space-separated) | No | `.` |
 | `python_version` | Python version to use for yamllint | No | `3.12` |
@@ -33,6 +34,7 @@ This action checks YAML syntax and style. It uploads results as artifacts that c
 | Output | Description |
 |--------|-------------|
 | `issues_count` | Number of linting issues found |
+| `tool_status` | Whether the linter tool ran cleanly: `ok`, or `error` when the tool itself crashed (argus exit code 2). |
 
 ## Artifacts
 

--- a/.github/actions/linter-yaml/action.yml
+++ b/.github/actions/linter-yaml/action.yml
@@ -36,11 +36,22 @@ inputs:
     description: 'Whether to post PR comments'
     required: false
     default: 'false'
+  fail_on_tool_error:
+    description: |
+      Fail the job when yamllint itself errors (a tool crash — argus exit code 2),
+      independent of fail_on_issues. Default false: a tool error is always surfaced
+      in the job log, the status table, and the PR comment, but only blocks the job
+      when this is set to true.
+    required: false
+    default: 'false'
 
 outputs:
   issues_count:
     description: 'Number of linting issues found'
     value: ${{ steps.scan.outputs.issue_count }}
+  tool_status:
+    description: 'Whether yamllint ran cleanly: "ok", or "error" when the tool itself crashed (argus exit code 2).'
+    value: ${{ steps.scan.outputs.tool_status }}
 
 runs:
   using: 'composite'
@@ -83,7 +94,10 @@ runs:
           SEVERITY="info"
         fi
 
-        SCAN_EXIT=0
+        # argus scan exit codes: 0 = clean, 1 = findings over threshold,
+        # 2 = tool error (yamllint/argus itself crashed). Capture combined
+        # output so a crash can be echoed into the console AND the summary.
+        set +e
         python -m argus scan lint-yaml \
           --path "${SCAN_PATH}" \
           --severity-threshold "${SEVERITY}" \
@@ -91,18 +105,53 @@ runs:
           --output-dir ./yaml-lint-reports \
           --output-vars ./yaml-lint-reports/counts.env \
           --no-timestamp \
-          || SCAN_EXIT=$?
+          2>&1 | tee yaml-lint-reports/output.log
+        SCAN_EXIT=${PIPESTATUS[0]}
+        set -e
 
-        # Forward counts to GitHub Actions outputs
+        # Forward counts + a machine-readable exit code to job outputs.
         [ -f yaml-lint-reports/counts.env ] && cat yaml-lint-reports/counts.env >> "$GITHUB_OUTPUT"
+        echo "scan_exit=${SCAN_EXIT}" >> "$GITHUB_OUTPUT"
 
-        # Copy markdown summary for PR comment and step summary
-        if [ -f "yaml-lint-reports/argus-summary.md" ]; then
-          cp yaml-lint-reports/argus-summary.md scanner-summaries/yaml-lint.md
-          cat yaml-lint-reports/argus-summary.md >> "$GITHUB_STEP_SUMMARY"
+        # Distinguish a tool error (exit 2) from findings (exit 1). A tool error
+        # means the result is untrustworthy, so surface it in the job log now; it
+        # is also carried up via the tool_status output (status table) and the
+        # summary banner below (PR comment).
+        if [ "${SCAN_EXIT}" -eq 2 ]; then
+          echo "tool_status=error" >> "$GITHUB_OUTPUT"
+          echo "::error title=YAML linter error::yamllint (argus lint-yaml) exited with a tool error (code 2). The YAML lint result is incomplete — inspect this job log. Triage: ignore, patch, or open an Argus issue."
+        else
+          echo "tool_status=ok" >> "$GITHUB_OUTPUT"
         fi
 
-        exit $SCAN_EXIT
+        # Build the summary section (stitched into the check summary + PR comment).
+        # On a tool error, prepend an actionable banner + the error tail so every
+        # persona (comment / summary / console) has enough to triage.
+        {
+          if [ "${SCAN_EXIT}" -eq 2 ]; then
+            echo "> ⚠️ **YAML linter errored (tool exit code 2) — result is incomplete.** Triage: ignore / patch / open an Argus issue."
+            echo ""
+            if [ -s yaml-lint-reports/output.log ]; then
+              echo '<details><summary>Error output (last 20 lines)</summary>'
+              echo ""
+              echo '```'
+              tail -n 20 yaml-lint-reports/output.log
+              echo '```'
+              echo ""
+              echo '</details>'
+              echo ""
+            fi
+          fi
+          if [ -f "yaml-lint-reports/argus-summary.md" ]; then
+            cat yaml-lint-reports/argus-summary.md
+          fi
+        } > scanner-summaries/yaml-lint.md
+
+        cat scanner-summaries/yaml-lint.md >> "$GITHUB_STEP_SUMMARY"
+
+        # Do NOT exit non-zero here: aborting would stop this composite from
+        # exporting tool_status/issue_count to the caller. The failure policy is
+        # applied in the "Enforce lint failure policy" step below.
 
     - name: Upload YAML lint artifacts
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -129,6 +178,26 @@ runs:
         comment_marker: yaml-linter-comment-marker
         title: '📄 YAML Linting Results'
         fallback_message: 'No YAML linting results available'
+
+    - name: Enforce lint failure policy
+      if: always()
+      shell: bash
+      env:
+        FAIL_ON_ISSUES: ${{ inputs.fail_on_issues }}
+        FAIL_ON_TOOL_ERROR: ${{ inputs.fail_on_tool_error }}
+        SCAN_EXIT: ${{ steps.scan.outputs.scan_exit }}
+        TOOL_STATUS: ${{ steps.scan.outputs.tool_status }}
+      run: |
+        # Findings gate (documented fail_on_issues contract): argus exit 1.
+        if [ "$FAIL_ON_ISSUES" = "true" ] && [ "$SCAN_EXIT" = "1" ]; then
+          echo "::error title=YAML lint findings::Linting issues found and fail_on_issues is enabled."
+          exit 1
+        fi
+        # Tool-error gate (opt-in; distinct from findings): argus exit 2.
+        if [ "$FAIL_ON_TOOL_ERROR" = "true" ] && [ "$TOOL_STATUS" = "error" ]; then
+          echo "::error title=YAML linter error::yamllint errored and fail_on_tool_error is enabled."
+          exit 1
+        fi
 
 branding:
   icon: 'file-text'

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -28,6 +28,15 @@ on:
         required: false
         type: boolean
         default: false
+      fail_on_tool_error:
+        description: |
+          Fail the workflow when a linter tool itself errors (a crash — argus exit
+          code 2), independent of fail_on_issues. Default false: a tool error is
+          always surfaced in the job log, the status table, and the PR comment, but
+          only blocks the pipeline when this is true.
+        required: false
+        type: boolean
+        default: false
       post_pr_comment:
         description: 'Post linting summary as PR comment'
         required: false
@@ -53,6 +62,7 @@ jobs:
     continue-on-error: true
     outputs:
       yaml_issues: ${{ steps.lint.outputs.issues_count }}
+      yaml_tool_status: ${{ steps.lint.outputs.tool_status }}
 
     steps:
       - name: Checkout repository
@@ -70,6 +80,7 @@ jobs:
     continue-on-error: true
     outputs:
       json_issues: ${{ steps.lint.outputs.issues_count }}
+      json_tool_status: ${{ steps.lint.outputs.tool_status }}
 
     steps:
       - name: Checkout repository
@@ -87,6 +98,7 @@ jobs:
     continue-on-error: true
     outputs:
       python_issues: ${{ steps.lint.outputs.issues_count }}
+      python_tool_status: ${{ steps.lint.outputs.tool_status }}
 
     steps:
       - name: Checkout repository
@@ -104,6 +116,7 @@ jobs:
     continue-on-error: true
     outputs:
       js_issues: ${{ steps.lint.outputs.issues_count }}
+      js_tool_status: ${{ steps.lint.outputs.tool_status }}
 
     steps:
       - name: Checkout repository
@@ -121,6 +134,7 @@ jobs:
     continue-on-error: true
     outputs:
       docker_issues: ${{ steps.lint.outputs.issues_count }}
+      docker_tool_status: ${{ steps.lint.outputs.tool_status }}
 
     steps:
       - name: Checkout repository
@@ -138,6 +152,7 @@ jobs:
     continue-on-error: true
     outputs:
       terraform_issues: ${{ steps.lint.outputs.issues_count }}
+      terraform_tool_status: ${{ steps.lint.outputs.tool_status }}
 
     steps:
       - name: Checkout repository
@@ -192,22 +207,24 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           post_pr_comment: ${{ inputs.post_pr_comment }}
-          # Render the per-linter pass/fail table so a skipped/failed linter is
-          # visible instead of the report reading "clean". The workflow's fail
-          # contract stays governed solely by fail_on_issues below, so
-          # fail_on_scanner_failure is left off here. (Hard-failing on a crashed
-          # linter is limited by the lint jobs' continue-on-error — which also
-          # absorbs linters' non-zero-on-findings exit — and is tracked as a
-          # follow-up in #325.)
-          fail_on_scanner_failure: false
+          # Drive the per-linter status table from each linter's tool_status
+          # output (ok|error), NOT needs.*.result. The lint jobs use
+          # continue-on-error, which can mask a job's result; tool_status is
+          # written by the linter action from the argus exit code (2 = tool
+          # error, distinct from 1 = findings) and always propagates. A tool
+          # error → "failure" in the table, so a crashed linter is visible in the
+          # check summary and PR comment instead of the report reading "clean".
+          # Whether a tool error BLOCKS is governed by fail_on_tool_error;
+          # findings remain governed solely by fail_on_issues below.
+          fail_on_scanner_failure: ${{ inputs.fail_on_tool_error }}
           scan_statuses: |
             {
-              "yaml":       "${{ needs.yaml-lint.result }}",
-              "json":       "${{ needs.json-lint.result }}",
-              "python":     "${{ needs.python-lint.result }}",
-              "javascript": "${{ needs.javascript-lint.result }}",
-              "dockerfile": "${{ needs.dockerfile-lint.result }}",
-              "terraform":  "${{ needs.terraform-lint.result }}"
+              "yaml":       "${{ needs.yaml-lint.outputs.yaml_tool_status == 'error' && 'failure' || 'success' }}",
+              "json":       "${{ needs.json-lint.outputs.json_tool_status == 'error' && 'failure' || 'success' }}",
+              "python":     "${{ needs.python-lint.outputs.python_tool_status == 'error' && 'failure' || 'success' }}",
+              "javascript": "${{ needs.javascript-lint.outputs.js_tool_status == 'error' && 'failure' || 'success' }}",
+              "dockerfile": "${{ needs.dockerfile-lint.outputs.docker_tool_status == 'error' && 'failure' || 'success' }}",
+              "terraform":  "${{ needs.terraform-lint.outputs.terraform_tool_status == 'error' && 'failure' || 'success' }}"
             }
 
       - name: Fail if issues found

--- a/tests/unit/test_linter_tool_error_signal.py
+++ b/tests/unit/test_linter_tool_error_signal.py
@@ -1,0 +1,82 @@
+"""Contract test for the linter tool-error signal (issue #325).
+
+A linter that *crashes* (the underlying tool errored — argus exit code 2) is a
+different signal from a linter that merely *found issues* (exit code 1). Each
+linter action must surface a tool error distinctly so it reaches every persona:
+the job console (``::error::`` annotation), the check/status summary, and the PR
+comment. The mechanism:
+
+* each ``linter-*`` action exposes a ``tool_status`` output ("ok"/"error"),
+  derived from the argus exit code, plus an opt-in ``fail_on_tool_error`` input;
+* the scan step no longer aborts with ``exit $SCAN_EXIT`` (that would stop the
+  composite exporting ``tool_status``); an "Enforce lint failure policy" step
+  applies the findings / tool-error gates instead;
+* ``linting.yml`` drives the summary status table from each linter's
+  ``tool_status`` (reliable) rather than ``needs.*.result`` (masked by
+  ``continue-on-error``), and wires the block decision to ``fail_on_tool_error``.
+
+This test locks the contract so a future edit can't silently drop the signal.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+ACTIONS = ROOT / ".github" / "actions"
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+LINTERS = ["yaml", "json", "python", "javascript", "dockerfile", "terraform"]
+
+
+def _action(linter: str) -> pathlib.Path:
+    return ACTIONS / f"linter-{linter}" / "action.yml"
+
+
+def test_linter_actions_expose_tool_status_output_and_gate_input():
+    for linter in LINTERS:
+        path = _action(linter)
+        assert path.is_file(), f"missing linter action: {path}"
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        outputs = data.get("outputs") or {}
+        inputs = data.get("inputs") or {}
+        assert "tool_status" in outputs, f"{linter}: missing tool_status output"
+        assert "issues_count" in outputs, f"{linter}: missing issues_count output"
+        assert "fail_on_tool_error" in inputs, f"{linter}: missing fail_on_tool_error input"
+
+
+def test_linter_actions_do_not_abort_before_exporting_outputs():
+    # `exit $SCAN_EXIT` in the scan step would stop the composite from exporting
+    # tool_status. The failure policy must live in a dedicated enforce step.
+    for linter in LINTERS:
+        text = _action(linter).read_text(encoding="utf-8")
+        assert "exit $SCAN_EXIT" not in text, (
+            f"{linter}: scan step still aborts with `exit $SCAN_EXIT`; tool_status "
+            "would not propagate to the caller"
+        )
+        assert "Enforce lint failure policy" in text, (
+            f"{linter}: missing the 'Enforce lint failure policy' step"
+        )
+        assert "tool_status=error" in text and "tool_status=ok" in text, (
+            f"{linter}: scan step must emit both tool_status=ok and tool_status=error"
+        )
+        assert "::error" in text, f"{linter}: missing a ::error:: annotation on tool error"
+
+
+def test_linting_workflow_drives_table_from_tool_status():
+    text = (WORKFLOWS / "linting.yml").read_text(encoding="utf-8")
+    data = yaml.safe_load(text)
+    inputs = (data.get(True) or data.get("on") or {}).get("workflow_call", {}).get("inputs", {})
+    assert "fail_on_tool_error" in inputs, "linting.yml missing fail_on_tool_error input"
+    # The status table must key off tool_status, not the maskable needs.*.result.
+    assert "_tool_status == 'error'" in text, (
+        "linting.yml scan_statuses should derive from each linter's tool_status output"
+    )
+    assert "fail_on_scanner_failure: ${{ inputs.fail_on_tool_error }}" in text, (
+        "linting.yml must gate the summary hard-fail on fail_on_tool_error"
+    )
+    # Every linter's tool_status must be threaded into scan_statuses.
+    for key in ("yaml", "json", "python", "javascript", "dockerfile", "terraform"):
+        assert f'"{key}":' in text, f"linting.yml scan_statuses missing linter '{key}'"


### PR DESCRIPTION
## Description
A linter that **crashes** (the underlying tool errored) is a fundamentally different signal from a linter that merely **found issues** — but the linter actions collapsed both into a single `exit $SCAN_EXIT` + `issues_count`, and `linting.yml` drove its status table from `needs.*.result`, which job-level `continue-on-error` can mask. Net effect (#325): a crashed linter could read "clean." This separates the two and surfaces a tool error at **all three levels** a reviewer might look at — job console, check/status summary, and PR comment — each with enough detail to decide *ignore / patch / open an Argus issue*.

## Changes Made
- [ ] Added new scanner/workflow
- [x] Modified existing scanner/workflow
- [x] Updated documentation
- [x] Fixed bug
- [x] Other (contract test)

### Details
The argus CLI already distinguishes the two conditions by exit code — `0` clean, `1` findings over threshold, `2` tool error — so the fix builds on that contract.

**Linter actions** (`yaml`, `json`, `python`, `javascript`, `dockerfile`, `terraform`):
- New `tool_status` output (`ok`|`error`) derived from the exit code; findings (exit 1) are **not** a tool error.
- On a tool error: a `::error::` annotation (job console) **and** an actionable banner + `<details>` error tail prepended into the summary section (PR comment + step summary).
- The scan step no longer aborts with `exit $SCAN_EXIT` (that stopped the composite exporting `tool_status`); a new **"Enforce lint failure policy"** step applies the findings gate (`fail_on_issues`, unchanged) and an opt-in tool-error gate (new `fail_on_tool_error` input).

**`linting.yml`:**
- New `fail_on_tool_error` input, **default `false`** — a tool error is always *surfaced* everywhere, but only *blocks* on opt-in (per the agreed behavior).
- Each linter's `tool_status` is exposed as a job output; the summary status table is now driven by `tool_status` (reliable) instead of `needs.*.result` (maskable by `continue-on-error`), and the summary hard-fail is gated on `fail_on_tool_error`.

This completes the piece that #335's code comment explicitly deferred back to #325.

**Not changed:** the security scanners — they return the same `0/1/2` exit codes, so the identical pattern applies; tracked as a follow-up rather than ballooning this PR.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results
- New `tests/unit/test_linter_tool_error_signal.py` (3 tests) locks the contract: every linter action exposes `tool_status` + `fail_on_tool_error`, no longer aborts before exporting outputs, has the enforce step, and `linting.yml` drives the table from `tool_status` gated on `fail_on_tool_error`. Passes.
- All 6 `linter-*/action.yml` parse; actionlint + yamllint (pre-commit) green.

## Security Considerations
- [x] No security impact
- [ ] Security enhancement

### Security Details
Improves signal fidelity — a crashed linter can no longer masquerade as a clean run. No change to what is scanned. Shell interpolation uses `env:`-quoted controlled values (booleans / exit codes), not untrusted input.

## AI Context Updates (.ai/)
- [x] N/A - No .ai/ updates needed

`.ai/` documents linters at the SDK level (`argus/linters/*.py` registry); this change is to the composite-action interface + the linting workflow, which `.ai/` does not enumerate.

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (linter README Inputs/Outputs tables)
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Closes #325