### PR TITLE
fix(ci): reusable-workflow lows — sbom default, container image gate, summary naming (closes #332)

### DIFF
--- a/.github/actions/scanner-clamav/action.yml
+++ b/.github/actions/scanner-clamav/action.yml
@@ -83,8 +83,17 @@ runs:
       env:
         FAIL_ON_SEVERITY: ${{ inputs.fail_on_severity }}
         SCAN_PATH: ${{ inputs.scan_path }}
+        JOB_ID: ${{ inputs.job_id }}
       run: |
         mkdir -p clamav-reports scanner-summaries
+
+        # Unique internal summary filename per invocation so that multiple
+        # invocations feeding one security-summary (merge-multiple) don't
+        # clobber identically named files. Key on job_id (same identifier the
+        # caller uses to keep the artifact name unique).
+        SAFE_ID=$(printf '%s' "${JOB_ID}" | tr -c 'A-Za-z0-9._-' '_')
+        SUMMARY_FILE="scanner-summaries/clamav-${SAFE_ID}.md"
+        echo "summary_file=${SUMMARY_FILE}" >> "$GITHUB_OUTPUT"
 
         # SDK auto-discovers argus.yml if present; works without one too
         SCAN_EXIT=0
@@ -128,7 +137,7 @@ runs:
 
         # Copy markdown summary for PR comment artifact and step summary
         if [ -f "clamav-reports/argus-summary.md" ]; then
-          cp clamav-reports/argus-summary.md scanner-summaries/clamav.md
+          cp clamav-reports/argus-summary.md "${SUMMARY_FILE}"
           cat clamav-reports/argus-summary.md >> "$GITHUB_STEP_SUMMARY"
         fi
 
@@ -154,7 +163,7 @@ runs:
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: scanner-summary-clamav-${{ inputs.job_id }}
-        path: scanner-summaries/clamav.md
+        path: ${{ steps.scan.outputs.summary_file }}
         retention-days: 7
       continue-on-error: true
 
@@ -162,7 +171,7 @@ runs:
       if: github.event_name == 'pull_request' && inputs.post_pr_comment == 'true'
       uses: huntridge-labs/argus/.github/actions/comment-pr@1.8.1
       with:
-        summary_file: scanner-summaries/clamav.md
+        summary_file: ${{ steps.scan.outputs.summary_file }}
         comment_marker: clamav-scanner-comment-marker
         title: '🛡️ ClamAV Malware Scan Results'
         fallback_message: 'No ClamAV results available'

--- a/.github/actions/scanner-dependency-review/action.yml
+++ b/.github/actions/scanner-dependency-review/action.yml
@@ -202,6 +202,7 @@ runs:
       continue-on-error: true
 
     - name: Generate scanner summary
+      id: generate-summary
       if: always()
       shell: bash
       run: |
@@ -213,8 +214,16 @@ runs:
           SKIPPED="true"
         fi
 
+        # Unique internal summary filename per invocation so that multiple
+        # invocations feeding one security-summary (merge-multiple) don't
+        # clobber identically named files. Key on job_id (same identifier the
+        # caller uses to keep the artifact name unique).
+        SAFE_ID=$(printf '%s' "${JOB_ID}" | tr -c 'A-Za-z0-9._-' '_')
+        SUMMARY_FILE="scanner-summaries/dependency-review-${SAFE_ID}.md"
+        echo "summary_file=${SUMMARY_FILE}" >> "$GITHUB_OUTPUT"
+
         python3 "$SCRIPT_DIR/scripts/generate_summary.py" \
-          --output-file "scanner-summaries/dependency-review.md" \
+          --output-file "${SUMMARY_FILE}" \
           --is-pr-comment "true" \
           --skipped "$SKIPPED" \
           --critical "${STEPS_PARSE_RESULTS_OUTPUTS_CRITICAL_COUNT}" \
@@ -242,6 +251,7 @@ runs:
           --github-run-id "${{ github.run_id }}"
       continue-on-error: true
       env:
+        JOB_ID: ${{ inputs.job_id }}
         STEPS_CHECK_EVENT_OUTPUTS_IS_PR: ${{ steps.check-event.outputs.is_pr }}
         STEPS_PARSE_RESULTS_OUTPUTS_CRITICAL_COUNT: ${{ steps.parse-results.outputs.critical_count }}
         STEPS_PARSE_RESULTS_OUTPUTS_HIGH_COUNT: ${{ steps.parse-results.outputs.high_count }}
@@ -254,7 +264,7 @@ runs:
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: scanner-summary-dependency-review-${{ inputs.job_id }}
-        path: scanner-summaries/dependency-review.md
+        path: ${{ steps.generate-summary.outputs.summary_file }}
         retention-days: 7
       continue-on-error: true
 
@@ -262,7 +272,7 @@ runs:
       if: github.event_name == 'pull_request' && inputs.post_pr_comment == 'true'
       uses: huntridge-labs/argus/.github/actions/comment-pr@1.8.1
       with:
-        summary_file: scanner-summaries/dependency-review.md
+        summary_file: ${{ steps.generate-summary.outputs.summary_file }}
         comment_marker: dependency-review-comment-marker
         title: '🔗 Dependency Review Results'
         fallback_message: 'No dependency review results available'

--- a/.github/actions/scanner-osv/action.yml
+++ b/.github/actions/scanner-osv/action.yml
@@ -114,8 +114,17 @@ runs:
       env:
         SCAN_PATH: ${{ inputs.scan_path }}
         FAIL_ON_SEVERITY: ${{ inputs.fail_on_severity }}
+        JOB_ID: ${{ inputs.job_id }}
       run: |
         mkdir -p osv-reports scanner-summaries
+
+        # Unique internal summary filename per invocation so that multiple
+        # invocations feeding one security-summary (merge-multiple) don't
+        # clobber identically named files. Key on job_id (same identifier the
+        # caller uses to keep the artifact name unique).
+        SAFE_ID=$(printf '%s' "${JOB_ID}" | tr -c 'A-Za-z0-9._-' '_')
+        SUMMARY_FILE="scanner-summaries/osv-${SAFE_ID}.md"
+        echo "summary_file=${SUMMARY_FILE}" >> "$GITHUB_OUTPUT"
 
         # SDK auto-discovers argus.yml if present; works without one too
         SCAN_EXIT=0
@@ -143,7 +152,7 @@ runs:
 
         # Copy markdown summary for PR comment artifact
         if [ -f "osv-reports/argus-summary.md" ]; then
-          cp osv-reports/argus-summary.md scanner-summaries/osv.md
+          cp osv-reports/argus-summary.md "${SUMMARY_FILE}"
           cat osv-reports/argus-summary.md >> "$GITHUB_STEP_SUMMARY"
         fi
 
@@ -171,7 +180,7 @@ runs:
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: scanner-summary-osv-${{ inputs.job_id }}
-        path: scanner-summaries/osv.md
+        path: ${{ steps.scan.outputs.summary_file }}
         retention-days: 7
       continue-on-error: true
 
@@ -179,7 +188,7 @@ runs:
       if: github.event_name == 'pull_request' && inputs.post_pr_comment == 'true'
       uses: huntridge-labs/argus/.github/actions/comment-pr@1.8.1
       with:
-        summary_file: scanner-summaries/osv.md
+        summary_file: ${{ steps.scan.outputs.summary_file }}
         comment_marker: osv-scanner-comment-marker
         title: '📦 OSV Dependency Scan Results'
         fallback_message: 'No OSV scan results available'

--- a/.github/actions/scanner-supply-chain/action.yml
+++ b/.github/actions/scanner-supply-chain/action.yml
@@ -113,8 +113,17 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github_token }}
         SCAN_PATH: ${{ inputs.scan_path }}
         FAIL_ON_SEVERITY: ${{ inputs.fail_on_severity }}
+        JOB_ID: ${{ inputs.job_id }}
       run: |
         mkdir -p supply-chain-reports scanner-summaries
+
+        # Unique internal summary filename per invocation so that multiple
+        # invocations feeding one security-summary (merge-multiple) don't
+        # clobber identically named files. Key on job_id (same identifier the
+        # caller uses to keep the artifact name unique).
+        SAFE_ID=$(printf '%s' "${JOB_ID}" | tr -c 'A-Za-z0-9._-' '_')
+        SUMMARY_FILE="scanner-summaries/supply-chain-${SAFE_ID}.md"
+        echo "summary_file=${SUMMARY_FILE}" >> "$GITHUB_OUTPUT"
 
         # SDK auto-discovers argus.yml if present; works without one too
         SCAN_EXIT=0
@@ -152,7 +161,7 @@ runs:
 
         # Copy markdown summary for PR comment artifact
         if [ -f "supply-chain-reports/argus-summary.md" ]; then
-          cp supply-chain-reports/argus-summary.md scanner-summaries/supply-chain.md
+          cp supply-chain-reports/argus-summary.md "${SUMMARY_FILE}"
           cat supply-chain-reports/argus-summary.md >> "$GITHUB_STEP_SUMMARY"
         fi
 
@@ -180,7 +189,7 @@ runs:
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: scanner-summary-supply-chain-${{ inputs.job_id }}
-        path: scanner-summaries/supply-chain.md
+        path: ${{ steps.scan.outputs.summary_file }}
         retention-days: 7
       continue-on-error: true
 
@@ -188,7 +197,7 @@ runs:
       if: github.event_name == 'pull_request' && inputs.post_pr_comment == 'true'
       uses: huntridge-labs/argus/.github/actions/comment-pr@1.8.1
       with:
-        summary_file: scanner-summaries/supply-chain.md
+        summary_file: ${{ steps.scan.outputs.summary_file }}
         comment_marker: supply-chain-scanner-comment-marker
         title: '🔗 Supply Chain Security Scan Results'
         fallback_message: '⚠️ Supply chain scan summary generation failed. Check action logs.'

--- a/.github/actions/scanner-syft/action.yml
+++ b/.github/actions/scanner-syft/action.yml
@@ -328,8 +328,11 @@ runs:
           echo "" >> "$output"
         }
 
-        # Generate PR comment artifact
-        generate_summary "scanner-summaries/syft.md" "true"
+        # Generate PR comment artifact. Filename is suffixed with the unique
+        # per-invocation prefix (same identifier the artifact name uses) so
+        # multiple invocations feeding one security-summary (merge-multiple)
+        # don't clobber identically named files.
+        generate_summary "scanner-summaries/syft-${PREFIX}.md" "true"
 
         # Generate job summary
         generate_summary "$GITHUB_STEP_SUMMARY" "false"
@@ -340,7 +343,7 @@ runs:
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: scanner-summary-syft-${{ steps.setup.outputs.prefix }}
-        path: scanner-summaries/syft.md
+        path: scanner-summaries/syft-${{ steps.setup.outputs.prefix }}.md
         retention-days: 7
       continue-on-error: true
 
@@ -348,7 +351,7 @@ runs:
       if: github.event_name == 'pull_request' && inputs.post_pr_comment == 'true'
       uses: huntridge-labs/argus/.github/actions/comment-pr@1.8.1
       with:
-        summary_file: scanner-summaries/syft.md
+        summary_file: scanner-summaries/syft-${{ steps.setup.outputs.prefix }}.md
         comment_marker: syft-scanner-comment-marker
         title: '📦 Syft SBOM Results'
         fallback_message: 'No Syft SBOM results available'

--- a/.github/actions/scanner-zap-summary/README.md
+++ b/.github/actions/scanner-zap-summary/README.md
@@ -22,7 +22,7 @@ Composite action to aggregate and summarize results from multiple ZAP DAST scans
 |-------|-------------|----------|---------|
 | `artifact_pattern` | Pattern to match ZAP report artifacts | No | `zap-reports-*` |
 | `summary_pattern` | Pattern to match scanner summary artifacts | No | `scanner-summary-zap-*` |
-| `output_name` | Name for the combined summary artifact | No | `zap-combined-summary` |
+| `output_name` | Name for the combined summary artifact (defaults to a `scanner-summary-*` name so a top-level `security-summary` aggregator collects it) | No | `scanner-summary-zap-combined` |
 | `retention_days` | Days to retain the summary artifact | No | `30` |
 | `write_step_summary` | Write summary to GITHUB_STEP_SUMMARY | No | `true` |
 | `post_pr_comment` | Post results as PR comment | No | `true` |

--- a/.github/actions/scanner-zap-summary/action.yml
+++ b/.github/actions/scanner-zap-summary/action.yml
@@ -12,9 +12,12 @@ inputs:
     required: false
     default: 'scanner-summary-zap-*'
   output_name:
-    description: 'Name for the combined summary artifact'
+    description: |
+      Name for the combined summary artifact. Defaults to a
+      `scanner-summary-*` name so a top-level `security-summary` aggregator
+      (which collects `scanner-summary-*`) picks up the combined ZAP summary.
     required: false
-    default: 'zap-combined-summary'
+    default: 'scanner-summary-zap-combined'
   retention_days:
     description: 'Number of days to retain the summary artifact'
     required: false
@@ -79,6 +82,7 @@ runs:
       env:
         ARTIFACT_PATTERN: ${{ inputs.artifact_pattern }}
         SUMMARY_PATTERN: ${{ inputs.summary_pattern }}
+        UNIQUE_KEY: ${{ github.run_id }}-${{ github.job }}
       run: |
         # Reference Python scripts from scanner-zap action
         SCANNER_ZAP_SCRIPTS="${{ github.action_path }}/../scanner-zap/scripts"
@@ -96,9 +100,17 @@ runs:
         # Run the summary generator
         python3 "$GENERATOR"
 
+        # The generator writes a fixed internal filename (scanner-summaries/zap.md).
+        # Rename it to a per-invocation unique name so multiple combiner runs
+        # feeding one security-summary (merge-multiple) don't clobber identically
+        # named files. This action has no job_id input, so key on run_id + job.
+        SAFE_ID=$(printf '%s' "${UNIQUE_KEY}" | tr -c 'A-Za-z0-9._-' '_')
+        GENERATED_FILE="scanner-summaries/zap.md"
+        SUMMARY_FILE="scanner-summaries/zap-${SAFE_ID}.md"
+
         # Set outputs
-        SUMMARY_FILE="scanner-summaries/zap.md"
-        if [[ -f "$SUMMARY_FILE" ]]; then
+        if [[ -f "$GENERATED_FILE" ]]; then
+          mv "$GENERATED_FILE" "$SUMMARY_FILE"
           echo "summary_path=$SUMMARY_FILE" >> "$GITHUB_OUTPUT"
           echo "has_findings=true" >> "$GITHUB_OUTPUT"
         else
@@ -174,7 +186,7 @@ runs:
       if: github.event_name == 'pull_request' && inputs.post_pr_comment == 'true'
       uses: huntridge-labs/argus/.github/actions/comment-pr@1.8.1
       with:
-        summary_file: scanner-summaries/zap.md
+        summary_file: ${{ steps.generate.outputs.summary_path }}
         comment_marker: zap-scan-summary-comment
         title: '🕷️ ZAP DAST Scan Results'
         fallback_message: 'No ZAP scan results available'

--- a/.github/workflows/reusable-security-hardening.yml
+++ b/.github/workflows/reusable-security-hardening.yml
@@ -68,6 +68,15 @@ on:
         required: false
         default: '.'
         type: string
+      container_image_ref:
+        description: |
+          Container image to scan with the trivy-container / grype scanners
+          (e.g. ghcr.io/owner/app:tag). These scanners are opt-in (not part of
+          `all`); when they are selected but this is empty, their jobs are
+          skipped rather than scanning a placeholder image.
+        required: false
+        default: ''
+        type: string
       allow_failure:
         description: |
           Whether to allow the workflow to continue when any scanner fails or reports findings
@@ -323,7 +332,12 @@ jobs:
           case "$token" in
             '' ) ;;
             all|full)
-              local -a exclude=(sbom trivy-container grype zap dependency-review)
+              # sbom (Syft) generates a repo SBOM on every default run — it is in
+              # DEFAULT_SCANNERS and included here so `all` and DEFAULT_SCANNERS
+              # agree. The excluded scanners are opt-in/context-specific: the
+              # container scanners need an image (container_image_ref), zap needs
+              # a target URL, and dependency-review needs a pull_request event.
+              local -a exclude=(trivy-container grype zap dependency-review)
               for key in "${!RUN[@]}"; do
                 if [[ " ${exclude[*]} " != *" ${key} "* ]]; then
                   add_scanner "$key"
@@ -633,11 +647,11 @@ jobs:
   scanner-trivy-container:
     name: Trivy Container Scanner
     needs: scan-coordinator
-    if: needs.scan-coordinator.outputs.run_trivy_container == 'true'
+    if: needs.scan-coordinator.outputs.run_trivy_container == 'true' && inputs.container_image_ref != ''
     uses: huntridge-labs/argus/.github/workflows/scanner-trivy-container.yml@1.8.1
     with:
       allow_failure: ${{ inputs.allow_failure }}
-      image_ref: 'nginx:latest'
+      image_ref: ${{ inputs.container_image_ref }}
       post_pr_comment: false
       enable_code_security: ${{ inputs.enable_code_security }}
       fail_on_severity: ${{ inputs.allow_failure == false && inputs.severity_threshold || 'none' }}
@@ -652,11 +666,11 @@ jobs:
   scanner-grype:
     name: Grype Scanner
     needs: scan-coordinator
-    if: needs.scan-coordinator.outputs.run_grype == 'true'
+    if: needs.scan-coordinator.outputs.run_grype == 'true' && inputs.container_image_ref != ''
     uses: huntridge-labs/argus/.github/workflows/scanner-grype.yml@1.8.1
     with:
       allow_failure: ${{ inputs.allow_failure }}
-      image_ref: 'nginx:latest'
+      image_ref: ${{ inputs.container_image_ref }}
       post_pr_comment: false
       enable_code_security: ${{ inputs.enable_code_security }}
       fail_on_severity: ${{ inputs.allow_failure == false && inputs.severity_threshold || 'none' }}


### PR DESCRIPTION
## Description
Rolls up the low-severity items from the reusable-workflow reliability audit (#332): sbom default consistency, hardcoded container image, summary-artifact naming collisions, and the zap-summary output name.

## Changes Made
- [ ] Added new scanner/workflow
- [x] Modified existing scanner/workflow
- [x] Updated documentation
- [x] Fixed bug
- [ ] Other

### Details
**L — `scanners: all` now includes `sbom`.** It was in `DEFAULT_SCANNERS` but excluded from `all` (the input default), so the Syft SBOM never ran out of the box despite being documented as a default. Argus is a supply-chain tool, so per the maintainer decision we generate a repo SBOM on every default run — the two lists now agree. The `sbom` job is already gated on `run_sbom`, in the `security-summary` `needs:` + `scan_statuses`, and scans the repo (no image needed).

**M — container image is no longer hardcoded.** The pipeline passed `image_ref: 'nginx:latest'` to trivy-container/grype, so a green result said nothing about the caller's images. New `container_image_ref` input (default empty); those opt-in jobs run only when the caller supplies an image (`&& inputs.container_image_ref != ''`) and skip otherwise.

**K — unique internal summary filenames.** Several composite summary actions wrote a fixed internal `.md` name under a per-invocation (job-id / prefix-suffixed) artifact name, so matrix re-runs collided under the aggregator's `merge-multiple` (only the last survived). Keyed each internal filename on the same unique id:
- `scanner-osv`, `scanner-clamav`, `scanner-supply-chain`, `scanner-dependency-review` → `job_id`
- `scanner-syft` → per-target `prefix`
- `scanner-zap-summary` (combiner, no job_id) → `run_id + job`

The three reusable **workflows** with the same pattern (`scanner-osv.yml` etc.) are intentionally **not** changed: they use a *fixed* artifact name, which blocks a second invocation at upload time, so the merge collision can't occur.

**N — zap-summary output name.** `scanner-zap-summary` emitted `zap-combined-summary`, which a top-level `security-summary` (collecting `scanner-summary-*`) would never pick up. Default renamed to `scanner-summary-zap-combined`.

**Breaking changes?** `sbom` now runs on default `all` pipelines (added Syft job). Container scanners now skip instead of scanning nginx when no image is supplied. Shell interpolation for the new filename keys uses `env:`-quoted, `tr`-sanitized values.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

### Test Results
- Existing `scanner-summary-*` contract test still passes.
- Simulated the resolve logic: `all` now selects `sbom` and still excludes trivy-container/grype/zap/dependency-review.
- All 6 composite actions + the orchestrator parse; actionlint + yamllint (pre-commit) green. Verified every renamed internal filename is consistently referenced (write / upload path / comment `summary_file`).

## Security Considerations
- [x] No security impact
- [ ] Security enhancement

### Security Details
A green container-scan result no longer misleadingly reflects a placeholder image. Filename keys are `env:`-passed and sanitized (`tr -c 'A-Za-z0-9._-' '_'`).

## AI Context Updates (.ai/)
- [x] N/A - No .ai/ updates needed

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (scanner-zap-summary README)
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Closes #332