### PR TITLE
feat(osv): emit upstream fixed_version in finding metadata

### DIFF
--- a/argus/scanners/osv.py
+++ b/argus/scanners/osv.py
@@ -154,8 +154,25 @@ class OsvScanner:
                 "package_version": pkg_version,
                 "ecosystem": pkg_ecosystem,
                 "aliases": vuln.get("aliases", []),
+                "fixed_version": self._extract_fixed_version(vuln),
             },
         )
+
+    def _extract_fixed_version(self, vuln: dict) -> str | None:
+        """The upstream-fixed version for this vuln, if OSV reports one.
+
+        OSV records fixes as ``affected[].ranges[].events[]`` entries carrying a
+        ``fixed`` key. Return the first fixed version found; ``None`` means no
+        upstream fix is published yet — consumers use this to avoid grading an
+        unpatchable-upstream CVE like negligence (fix-aware grading).
+        """
+        for affected in vuln.get("affected", []):
+            for rng in affected.get("ranges", []):
+                for event in rng.get("events", []):
+                    fixed = event.get("fixed")
+                    if fixed:
+                        return str(fixed)
+        return None
 
     def _extract_severity(self, vuln: dict) -> Severity:
         """Extract severity from database_specific or affected blocks."""

--- a/argus/tests/scanners/test_osv.py
+++ b/argus/tests/scanners/test_osv.py
@@ -11,6 +11,29 @@ _LOCAL = ScanPaths(workspace=".", output="/tmp/out.json")
 _CONTAINER = ScanPaths(workspace="/workspace", output="/output/results.json")
 
 
+class TestOsvFixedVersion:
+    """_extract_fixed_version pulls the upstream fix (if any) for fix-aware grading."""
+
+    def test_extracts_fixed_version_from_ranges(self):
+        vuln = {"affected": [{"ranges": [{"events": [{"introduced": "0"}, {"fixed": "2.0.1"}]}]}]}
+        assert OsvScanner()._extract_fixed_version(vuln) == "2.0.1"
+
+    def test_no_fix_event_returns_none(self):
+        vuln = {"affected": [{"ranges": [{"events": [{"introduced": "0"}]}]}]}
+        assert OsvScanner()._extract_fixed_version(vuln) is None
+
+    def test_missing_affected_returns_none(self):
+        assert OsvScanner()._extract_fixed_version({}) is None
+
+    def test_fixed_version_rides_in_finding_metadata(self, fixtures_dir):
+        findings = OsvScanner().parse_results(
+            fixtures_dir / "osv" / "results-with-findings.json"
+        )
+        # Every parsed finding carries the key (value may be None when unfixed),
+        # so the cloud ingest can read it uniformly.
+        assert all("fixed_version" in f.metadata for f in findings)
+
+
 class TestOsvParseResults:
     """Test OsvScanner.parse_results with fixture data."""
 


### PR DESCRIPTION
## Description
The OSV scanner now records the upstream **fixed version** for each vulnerability in the finding metadata, so downstream consumers can do *fix-aware grading* — distinguishing a vuln you can patch from one still awaiting an upstream release.

## Changes Made
- [x] Modified existing scanner/workflow
- [x] Unit tests added

### Details
- `OsvScanner._extract_fixed_version()` walks OSV's `affected[].ranges[].events[].fixed` and returns the first fixed version (`None` when upstream hasn't published a fix).
- Added to the finding `metadata` as `fixed_version`. The container scanner already emits this; OSV now matches, so dependency findings carry it uniformly.
- No CLI/parser/behavior change — purely additive metadata.

## Testing
- [x] Unit tests added/updated
- 22 passed (`argus/tests/scanners/test_osv.py`), incl. extraction from ranges, no-fix → None, missing affected → None, and metadata presence.

## Security Considerations
- [x] Security enhancement
More accurate fix-availability data lets consumers avoid grading unpatchable-upstream CVEs like negligence (you can only be as secure as the OSS you provision).

## AI Context Updates (.ai/)
- Not needed — a scanner metadata field, no structural/command/decision change.