### PR TITLE
docs(mumps): sync tree-sitter tested-range comments with &lt;0.27 ceiling

### DIFF
--- a/argus/scanners/mumps/parser.py
+++ b/argus/scanners/mumps/parser.py
@@ -122,7 +122,7 @@ def _load_grammar(grammar: Path):
     ``Language(path, name)`` was replaced by ``Language(<pointer>)`` and the
     language now goes to the ``Parser`` constructor instead of
     ``set_language``. We support both so the ``[mumps]`` extra works across
-    the 0.20–0.25 range without forcing a binding version (#248). The
+    the 0.20–0.26 range without forcing a binding version (#248). The
     compiled grammar (ABI 14) is accepted by both.
     """
     from tree_sitter import Language, Parser

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,8 +100,8 @@ browser = [
 # ``scripts/build-mumps-grammar.sh`` (local) or the scanner-mumps container image
 # (which ships a prebuilt grammar). MumpsParser supports both the pre-0.22
 # Language(path, name) API and the >=0.22 Language(<pointer>) + Parser(lang)
-# API (#248), so the binding floats across the tested 0.20–0.25 range; the
-# <0.26 ceiling just bounds it to versions CI has exercised.
+# API (#248), so the binding floats across the tested 0.20–0.26 range; the
+# <0.27 ceiling just bounds it to versions CI has exercised.
 mumps = ["tree-sitter>=0.20,<0.27"]
 # All optional features
 all = ["argus-security[ai,completion,mcp,terminal,browser,mumps]"]


### PR DESCRIPTION
## Description
Follow-up to #346, which widened the `[mumps]` extra's tree-sitter ceiling to `<0.27` (permitting `tree-sitter 0.26.0`). Two explanatory comments still described the tested range as `0.20–0.25` and the ceiling as `<0.26`, so they no longer matched the actual constraint or the versions CI installs. This syncs the comment text. **Comment-only — no code or dependency-constraint change.**

## Changes Made
- [ ] Added new scanner/workflow
- [ ] Modified existing scanner/workflow
- [x] Updated documentation
- [ ] Fixed bug
- [x] Other (please specify): in-code comment/docstring accuracy fix

### Details
- **Affected:** MUMPS (`lint`/SAST) scanner support only — no workflows or scanners change behavior.
- **`pyproject.toml`** (comment above the `mumps` extra): `tested 0.20–0.25 range` → `0.20–0.26`; `<0.26 ceiling` → `<0.27`. The actual constraint (`tree-sitter>=0.20,<0.27`) was already updated by #346 and is untouched here.
- **`argus/scanners/mumps/parser.py`** (`_load_grammar` docstring): `the 0.20–0.25 range` → `0.20–0.26`.
- **No breaking changes.**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results
No behavioral surface — the diff is two comment lines. Verified the `git diff` touches only the comment/docstring text and leaves the `mumps = ["tree-sitter>=0.20,<0.27"]` constraint and all code unchanged. tree-sitter 0.26.0 compatibility itself was validated by #346's green unit-test matrix (Python 3.11–3.14, `[all]` extra installed + compiled grammar, MUMPS per-rule integration tests exercised against real 0.26.0 parse trees).

## Security Considerations
- [x] No security impact
- [ ] Security enhancement
- [ ] Potential security implications (explain below)

## AI Context Updates (.ai/)
- [x] N/A - No .ai/ updates needed

Comment-only accuracy fix; no structure, command, decision, or error-pattern change.

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Follow-up to #346. Closes # (n/a)