### PR TITLE
fix(ci): cap coverage below 7.15.1 to unblock Python 3.14 CI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,14 @@
 # Floors bumped past known-CVE versions and stale-floor noise.
 pytest>=9.1.1
 pytest-cov>=7.1.0
+# coverage arrives transitively via pytest-cov. Cap below 7.15.1: that release
+# (2026-07-12) regressed HTML-report generation on Python 3.14 — its
+# find_soft_key_lines runs ast.parse() over every reported source file and
+# throws SyntaxError on the em-dash in the comment header of
+# argus/viewers/browser/templates/_findings_table.html.j2, crashing the run
+# with an INTERNALERROR after all tests pass. Lift the ceiling once coverage
+# ships a fix for the html reporter parsing non-Python source.
+coverage>=7.10.6,<7.15.1
 pyyaml>=6.0.2
 
 # Container name sanitization


### PR DESCRIPTION
## Description
Every PR's **Unit Tests (Python 3.14)** job started failing on 2026-07-13 (e.g. #348, #349) with an `INTERNALERROR` **after all tests pass**. Root cause is a third-party regression, not any code change:

- `coverage 7.15.1` (published 2026-07-12 20:55 UTC) changed HTML-report generation. Its `find_soft_key_lines` runs `ast.parse()` over every reported source file. It hits `argus/viewers/browser/templates/_findings_table.html.j2` — a Jinja template whose comment header contains an em-dash (`—`, U+2014) — and `ast.parse` raises `SyntaxError: invalid character '—' (U+2014)`, crashing the whole run.
- `coverage` arrives **transitively** via `pytest-cov>=7.1.0` with a `>=7.10.6` floor and **no upper bound**, so CI pulled the <8h-old 7.15.1. The last green `main` run (2026-07-12 20:47) predated the release by 8 minutes.

This pins `coverage>=7.10.6,<7.15.1` (resolves to 7.15.0, pre-regression) in `requirements.txt`.

Reproduced locally on Python 3.14: `python -c "import ast; ast.parse(open('argus/viewers/browser/templates/_findings_table.html.j2').read())"` throws the identical `SyntaxError` at the em-dash line, matching the CI traceback exactly.

## Changes Made
- [ ] Added new scanner/workflow
- [ ] Modified existing scanner/workflow
- [ ] Updated documentation
- [x] Fixed bug
- [x] Other (please specify): CI/test-toolchain dependency pin

### Details
- `requirements.txt`: add an explicit `coverage>=7.10.6,<7.15.1` line (with a comment explaining the regression and when to lift the ceiling).
- No source or scanner behavior changes. Affects the test/CI toolchain only.
- No breaking changes.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results
- Confirmed `coverage 7.15.1` is the trigger: `main` was green at 20:47 UTC on the prior coverage; #348 and #349 both fail identically at 06:39 the next morning on 7.15.1; the offending `.j2` has been in `main` since #298 and is unrelated to either dep bump.
- Reproduced the `ast.parse` `SyntaxError` locally on Python 3.14 (see Description).
- `<7.15.1` is satisfiable — 7.15.0 is on PyPI.
- CI on this PR is the authoritative green check.

## Security Considerations
- [x] No security impact
- [ ] Security enhancement
- [ ] Potential security implications (explain below)

Aligns with the project's "hold new releases" posture — this is the pip-side equivalent of the npm `minimum-release-age` guard that would have deferred a <24h-old release.

## AI Context Updates (.ai/)
- [x] N/A - No .ai/ updates needed

Toolchain pin; no structure, command, or behavior change.

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Unblocks CI for #348 and #349 (both fail on this regression, not on their own changes). They'll need their branches updated onto `main` after this merges to pick up the pin.