### PR TITLE
test: cloud webhook check (do not merge)

### DIFF
--- a/docs/.cloud-webhook-test.md
+++ b/docs/.cloud-webhook-test.md
@@ -1,0 +1,5 @@
+<!-- Throwaway file to fire a pull_request webhook for validating Argus Cloud
+     PR reporting (sticky status comment + check run). Safe to delete; this PR
+     is not intended to merge. -->
+
+Cloud webhook connectivity test — delete this file / close the PR after verifying.


### PR DESCRIPTION
Throwaway PR to fire a `pull_request` event and validate Argus Cloud PR reporting (sticky status comment + "Argus scan" check) after the webhook-secret rotation. **Not intended to merge — will be closed.**