### PR TITLE
fix(examples): harden example workflows against shell injection and add non-root USER

### DIFF
--- a/examples/github-enterprise/container-scanning.yml
+++ b/examples/github-enterprise/container-scanning.yml
@@ -56,13 +56,19 @@ jobs:
 
       - name: Determine image to scan
         id: image
+        # Route the untrusted workflow_dispatch input through env so it is never
+        # interpolated into the shell command; reference the quoted variables
+        # instead (avoids yaml.github-actions.security.run-shell-injection).
+        env:
+          IMAGE_REF: ${{ github.event.inputs.image_ref }}
+          DEFAULT_IMAGE: ${{ env.DEFAULT_IMAGE }}
         run: |
-          if [ -n "${{ github.event.inputs.image_ref }}" ]; then
-            IMAGE="${{ github.event.inputs.image_ref }}"
+          if [ -n "$IMAGE_REF" ]; then
+            IMAGE="$IMAGE_REF"
           else
-            IMAGE="${{ env.DEFAULT_IMAGE }}"
+            IMAGE="$DEFAULT_IMAGE"
           fi
-          echo "image=$IMAGE" >> $GITHUB_OUTPUT
+          echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
           echo "Scanning image: $IMAGE"
 
       # Authenticate to registry if needed (example for GHCR)

--- a/examples/plugins/hello-plugin/Dockerfile
+++ b/examples/plugins/hello-plugin/Dockerfile
@@ -12,5 +12,10 @@ FROM python:3.14-alpine
 
 COPY plugin.py /plugin.py
 
+# Run as the non-root "nobody" user. Matches the sandbox's runtime
+# --user 65534:65534 and satisfies dockerfile.security.missing-user-entrypoint
+# (defense-in-depth: the image itself never defaults to root).
+USER 65534:65534
+
 # Emits an argus.plugin.v1 findings document on stdout.
 ENTRYPOINT ["python3", "/plugin.py"]

--- a/examples/workflows/actions-scanner-zap-from-config.yml
+++ b/examples/workflows/actions-scanner-zap-from-config.yml
@@ -56,13 +56,21 @@ jobs:
           config_file: ${{ inputs.config_file || 'examples/configs/zap-config.example.yml' }}
 
       - name: Display parsed config
+        # Route inputs/outputs through env so untrusted values are never
+        # interpolated into the shell command; reference the quoted variables
+        # instead (avoids yaml.github-actions.security.run-shell-injection).
+        env:
+          CONFIG_FILE: ${{ inputs.config_file }}
+          SCAN_COUNT: ${{ steps.parse.outputs.total_scan_count }}
+          POST_PR_COMMENT: ${{ steps.parse.outputs.post_pr_comment }}
+          MATRIX_JSON: ${{ steps.parse.outputs.matrix }}
         run: |
-          echo "📋 Config file: ${{ inputs.config_file }}"
-          echo "📊 Scan count: ${{ steps.parse.outputs.total_scan_count }}"
-          echo "💬 PR comment: ${{ steps.parse.outputs.post_pr_comment }}"
+          echo "📋 Config file: $CONFIG_FILE"
+          echo "📊 Scan count: $SCAN_COUNT"
+          echo "💬 PR comment: $POST_PR_COMMENT"
           echo ""
           echo "🔍 Matrix JSON:"
-          echo '${{ steps.parse.outputs.matrix }}' | jq '.'
+          echo "$MATRIX_JSON" | jq '.'
 
   zap-scan:
     name: ZAP ${{ matrix.name }}
@@ -107,5 +115,9 @@ jobs:
 
       - name: Check for critical findings
         if: steps.summary.outputs.total_critical > 0 || steps.summary.outputs.total_high > 0
+        # Same pattern as above: keep step outputs out of the shell command line.
+        env:
+          TOTAL_CRITICAL: ${{ steps.summary.outputs.total_critical }}
+          TOTAL_HIGH: ${{ steps.summary.outputs.total_high }}
         run: |
-          echo "::warning::Found security findings - Critical: ${{ steps.summary.outputs.total_critical }}, High: ${{ steps.summary.outputs.total_high }}"
+          echo "::warning::Found security findings - Critical: $TOTAL_CRITICAL, High: $TOTAL_HIGH"


### PR DESCRIPTION
## Description
Argus's own opengrep SAST flags **3 HIGH** findings in the `examples/` tree. These are reference/template files users copy, so shipping the anti-pattern trains users to write insecure workflows. This PR removes the anti-patterns while preserving each file's existing behavior, step ids, outputs, comments, and style.

## Changes Made
- [ ] Added new scanner/workflow
- [x] Modified existing scanner/workflow
- [ ] Updated documentation
- [x] Fixed bug
- [ ] Other (please specify)

### Details
Which workflows/scanners are affected? Three example templates under `examples/` (no SDK, scanner, or action runtime code changed):

- **`examples/github-enterprise/container-scanning.yml`** — the "Determine image to scan" step interpolated the untrusted `github.event.inputs.image_ref` (and `DEFAULT_IMAGE`) directly into the shell. Rule `yaml.github-actions.security.run-shell-injection`. Now routed through step `env:` and referenced as quoted `"$IMAGE_REF"` / `"$DEFAULT_IMAGE"`. The step id (`image`) and its `image=` output are unchanged.
- **`examples/workflows/actions-scanner-zap-from-config.yml`** — the "Display parsed config" step interpolated `inputs.config_file` and `steps.parse.outputs.*` into `echo`. Same rule. Moved to step `env:` and referenced as quoted vars. The later "Check for critical findings" step (`steps.summary.outputs.*`, not flagged by the rule) is hardened the same way so the example is uniformly copy-safe.
- **`examples/plugins/hello-plugin/Dockerfile`** — no `USER` before `ENTRYPOINT`. Rule `dockerfile.security.missing-user-entrypoint`. Added `USER 65534:65534`, matching the plugin sandbox's documented runtime contract (`--user 65534:65534`) as defense-in-depth.

No breaking changes: all step behavior, ids, and outputs are preserved.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results
- Each edited YAML parses: `python3 -c "import yaml; yaml.safe_load(open('<file>'))"` → OK for both workflows.
- SAST verified with `semgrep` (opengrep's upstream, identical rule ids) using the exact two rules:
  - **Baseline (`origin/main`)** reproduced all 3 findings:
    - `run-shell-injection` — `container-scanning.yml:59`
    - `run-shell-injection` — `actions-scanner-zap-from-config.yml:59`
    - `missing-user-entrypoint` — `hello-plugin/Dockerfile:16`
  - **After the fix**, scanning the entire `examples/` tree with the same rules reports **0 findings** and nothing new.
- `opengrep` itself has no installable distribution for this environment (Python 3.14 / macOS), so `semgrep` — which opengrep forks and shares rule ids with — was used to validate.

## Security Considerations
- [ ] No security impact
- [x] Security enhancement
- [ ] Potential security implications (explain below)

### Security Details
Removes shell-injection anti-patterns from two example workflows (untrusted `${{ ... }}` context expressions interpolated into `run:` blocks) and adds a non-root `USER` to the example plugin image. These are reference templates; exploitability in the examples themselves is bounded by dispatch/caller permissions, but the point is not to teach users the unsafe pattern.

## AI Context Updates (.ai/)
- [ ] `.ai/architecture.yaml` updated (if components/structure changed)
- [ ] `.ai/workflows.yaml` updated (if commands/tasks changed)
- [ ] `.ai/decisions.yaml` updated (if design decision made)
- [ ] `.ai/errors.yaml` updated (if common error addressed)
- [x] N/A - No .ai/ updates needed

Only example templates changed — no components, commands, decisions, or error patterns affected.

## Checklist
- [x] Code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Closes #355
