### PR TITLE
fix(build-containers): surface Grype findings in the container PR comment

### DIFF
--- a/.ai/errors.yaml
+++ b/.ai/errors.yaml
@@ -247,6 +247,26 @@ scn_detector_errors:
       \ image. Local-image scans (built from a Dockerfile) are\nunaffected \u2014 they\
       \ read the daemon over the mounted socket.\n"
   reference: "argus/container/scanner.py::_docker_login_mount_args"
+- pattern: "No vulnerabilities detected by Grype|PR comment shows 0 Grype findings"
+  category: container-scanning
+  context: "The build-containers.yml PR comment reports 0 Grype findings for an image
+    while that image's own scan annotations report vulnerabilities at/above the
+    severity cutoff (e.g. \"failed minimum severity level\").\n"
+  root_cause: "The workflow's report step parsed Trivy JSON only and built a
+    ContainerScanResult with combined_findings=trivy_findings and no grype_findings.
+    Since grype_findings defaults to [], ContainerMarkdownReporter renders
+    \"No vulnerabilities detected by Grype\" for every image regardless of Grype's
+    actual result, and the combined severity counts drop every Grype-only CVE. Grype
+    ran in a separate anchore/scan-action step whose findings were never captured.\n"
+  solution:
+    steps:
+    - "Render the per-image summary via scripts/ci/render_container_summary.py, which
+      calls the SDK's scan_image() (trivy + grype, deduped by CVE) so both scanners'
+      findings populate the section, the combined counts, and the SARIF."
+    note: "Dogfood scan_image() — the same entrypoint argus scan container /
+      ContainerEngine.run use — rather than re-parsing one tool's output in CI.
+      Any per-image CI report must populate BOTH trivy_findings and grype_findings.\n"
+  reference: "scripts/ci/render_container_summary.py and .github/workflows/build-containers.yml (scan job)"
 errors:
   RESOURCE_NOT_ACCESSIBLE_BY_INTEGRATION:
     category: permissions

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -160,87 +160,35 @@ jobs:
           pip install --quiet pyyaml
           echo "PYTHONPATH=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
 
-      # Scan with ALL severities — perception is protection
-      - name: Scan with Trivy (SARIF)
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-        with:
-          image-ref: "ghcr.io/huntridge-labs/argus/${{ matrix.image }}:${{ github.sha }}"
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-
-      - name: Upload Trivy SARIF
-        if: always()
-        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
-        with:
-          sarif_file: trivy-results.sarif
-          category: "container-${{ matrix.image }}"
-        continue-on-error: true
-
-      - name: Scan with Grype
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7
-        with:
-          image: "ghcr.io/huntridge-labs/argus/${{ matrix.image }}:${{ github.sha }}"
-          fail-build: false
-          severity-cutoff: critical
-
-      - name: Scan with Trivy (JSON)
-        if: always()
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-        with:
-          image-ref: "ghcr.io/huntridge-labs/argus/${{ matrix.image }}:${{ github.sha }}"
-          format: 'json'
-          output: 'trivy-results.json'
-
-      # Use argus container scanner parser + container markdown reporter
-      - name: Generate report with Argus
-        if: always()
+      # Scan the built image with the Argus SDK (Trivy + Grype, deduped by
+      # CVE) and render this container's PR-comment section + a combined
+      # SARIF. This dogfoods scan_image() — the same entrypoint
+      # `argus scan container` / ContainerEngine.run use — so BOTH tools'
+      # findings reach the report and the Security tab.
+      #
+      # The previous inline report parsed Trivy JSON only and left
+      # grype_findings=[], so the container markdown reporter rendered
+      # "No vulnerabilities detected by Grype" for every image regardless
+      # of what Grype found (a false negative), and the combined counts
+      # dropped every Grype-only CVE. See scripts/ci/render_container_summary.py.
+      - name: Scan image & render summary (Argus SDK)
         run: |
-          mkdir -p scanner-summaries
-          python3 << 'PYEOF'
-          import sys, os
-          sys.path.insert(0, os.environ.get("PYTHONPATH", "."))
-
-          from pathlib import Path
-          from argus.scanners.container import ContainerScanner
-          from argus.container.scanner import ContainerScanResult, ContainerScanSummary
-          from argus.reporters.container_markdown import ContainerMarkdownReporter
-
-          image_name = os.environ["IMAGE_NAME"]
-          image_tag = os.environ.get("IMAGE_TAG", "latest")
-          image_ref = f"ghcr.io/huntridge-labs/argus/{image_name}:{image_tag}"
-
-          trivy_json = Path("trivy-results.json")
-          scanner = ContainerScanner()
-          trivy_findings = scanner.parse_trivy_results(trivy_json) if trivy_json.exists() else []
-
-          result = ContainerScanResult(
-              name=image_name,
-              image_ref=image_ref,
-              trivy_findings=trivy_findings,
-              combined_findings=trivy_findings,
-          )
-
-          # Write just this container's detail section (not the full report)
-          reporter = ContainerMarkdownReporter()
-          reporter.report_single(result, "scanner-summaries")
-
-          # Also write a JSON summary for the combine step
-          import json
-          json.dump({
-              "name": image_name,
-              "image_ref": image_ref,
-              "critical": result.critical_count,
-              "high": result.high_count,
-              "medium": result.medium_count,
-              "low": result.low_count,
-              "total": result.total_count,
-              "unique": result.unique_count,
-              "build_success": result.build_success,
-          }, open(f"scanner-summaries/{image_name}.json", "w"))
-          PYEOF
+          python -m scripts.ci.render_container_summary \
+            --image-name "$IMAGE_NAME" \
+            --image-ref "ghcr.io/huntridge-labs/argus/${IMAGE_NAME}:${IMAGE_TAG}" \
+            --out-dir scanner-summaries \
+            --sarif-dir sarif-out
         env:
           IMAGE_NAME: ${{ matrix.image }}
           IMAGE_TAG: ${{ github.sha }}
+
+      - name: Upload SARIF to GitHub Security
+        if: always() && github.actor != 'nektos/act' && hashFiles('sarif-out/argus-results.sarif') != ''
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+        with:
+          sarif_file: sarif-out/argus-results.sarif
+          category: "container-${{ matrix.image }}"
+        continue-on-error: true
 
       - name: Upload scan artifacts
         if: always()

--- a/scripts/ci/render_container_summary.py
+++ b/scripts/ci/render_container_summary.py
@@ -1,0 +1,180 @@
+"""Scan one built container image with the Argus SDK and emit the
+per-image PR-comment artifacts (markdown section + flat JSON counts) plus
+a combined SARIF for the GitHub Security tab.
+
+Why this exists
+---------------
+``build-containers.yml`` used to build its PR comment from an inline
+heredoc that parsed **only** Trivy's JSON output and constructed a
+``ContainerScanResult`` with ``combined_findings=trivy_findings`` and no
+``grype_findings``. Because ``ContainerScanResult.grype_findings``
+defaults to ``[]``, the container markdown reporter rendered
+"✅ No vulnerabilities detected by Grype" for *every* image regardless of
+what Grype actually found — a false negative — while the separate
+``anchore/scan-action`` step still emitted its "failed minimum severity
+level" annotation. The Trivy-only ``combined_findings`` also under-counted
+the summary table by dropping every Grype-only CVE.
+
+This script dogfoods the SDK's own :func:`argus.container.scan_image` —
+the exact entrypoint ``ContainerEngine.run`` uses — so both Trivy and
+Grype run and are deduplicated by CVE via
+:func:`argus.container.deduplicate_findings`. The rendered section,
+severity counts, and SARIF therefore all reflect the union of both
+scanners.
+
+Usage
+-----
+    python -m scripts.ci.render_container_summary \
+        --image-name cli \
+        --image-ref ghcr.io/huntridge-labs/argus/cli:<sha> \
+        --out-dir scanner-summaries \
+        --sarif-dir sarif-out
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+from argus.container import ContainerTarget, scan_image
+from argus.container.scanner import ContainerScanResult
+from argus.reporters import get_reporter
+from argus.reporters.container_markdown import ContainerMarkdownReporter
+
+# Sub-scanners the PR comment reports on. Deliberately CVE-only
+# (Trivy + Grype) to match the two subsections the container markdown
+# reporter renders; the attack-surface sub-scanners (exposure, services)
+# and SBOM generation aren't part of this image-vuln summary.
+_SCANNERS: tuple[str, ...] = ("trivy", "grype")
+
+
+def build_count_summary(result: ContainerScanResult) -> dict:
+    """Build the flat per-image counts dict the combine step consumes.
+
+    Keys mirror what ``build-containers.yml``'s combine step reads back
+    (``name``, ``image_ref``, ``critical``/``high``/``medium``/``low``,
+    ``build_success``); ``total``/``unique`` are included for parity with
+    the SDK's own ``container-scan.json``. Counts derive from
+    ``combined_findings``, so Grype-only CVEs are included — the exact
+    gap this script closes.
+    """
+    return {
+        "name": result.name,
+        "image_ref": result.image_ref,
+        "build_success": result.build_success,
+        "critical": result.critical_count,
+        "high": result.high_count,
+        "medium": result.medium_count,
+        "low": result.low_count,
+        "total": result.total_count,
+        "unique": result.unique_count,
+    }
+
+
+def write_pr_comment_artifacts(result: ContainerScanResult, out_dir: Path) -> None:
+    """Write the per-image markdown section and flat JSON counts.
+
+    The markdown section is produced by the SDK's own
+    ``ContainerMarkdownReporter.report_single`` (bare ``<details>`` block,
+    no outer wrapper) so the downstream combine step can concatenate it
+    unchanged.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    ContainerMarkdownReporter().report_single(result, out_dir)
+    (out_dir / f"{result.name}.json").write_text(
+        json.dumps(build_count_summary(result), indent=2),
+        encoding="utf-8",
+    )
+
+
+def write_sarif(result: ContainerScanResult, sarif_dir: Path) -> Path:
+    """Write a combined (Trivy + Grype) SARIF for the GitHub Security tab.
+
+    Wraps the deduplicated findings in a canonical ``ScanSummary`` and
+    hands it to the standard SARIF reporter — the same shape the CLI's
+    container-scan path emits. Uploading this (rather than a Trivy-only
+    SARIF) means Grype-only CVEs also reach the Security tab.
+    """
+    from argus.core.models import ScanContext, ScanResult, ScanSummary
+
+    sarif_dir.mkdir(parents=True, exist_ok=True)
+    canonical = ScanSummary(
+        results=[
+            ScanResult(
+                scanner=f"container/{result.name}",
+                findings=list(result.combined_findings),
+                metadata={"image_ref": result.image_ref},
+            )
+        ],
+        scan_context=ScanContext.capture(),
+    )
+    return get_reporter("sarif").report(canonical, sarif_dir)
+
+
+def run(
+    image_name: str,
+    image_ref: str,
+    out_dir: Path,
+    sarif_dir: Path | None = None,
+) -> ContainerScanResult:
+    """Scan ``image_ref`` via the SDK and write the CI artifacts.
+
+    The image is already built and ``docker load``-ed into the local
+    daemon by an earlier job, so the target carries no Dockerfile —
+    ``scan_image`` detects it as a local image and scans it through the
+    docker-daemon source.
+    """
+    target = ContainerTarget(name=image_name, image_ref=image_ref)
+    result = scan_image(target, scanners=_SCANNERS, sbom=False)
+
+    write_pr_comment_artifacts(result, out_dir)
+    if sarif_dir is not None:
+        write_sarif(result, sarif_dir)
+
+    if result.scanner_errors:
+        # Surface (don't swallow) sub-scanner failures — a Grype crash
+        # must not masquerade as "0 findings" the way the old Trivy-only
+        # path did. Non-zero exit lets the workflow decide how to gate.
+        for tool, err in result.scanner_errors.items():
+            print(f"::warning::{tool} sub-scanner error for {image_name}: {err}", file=sys.stderr)
+
+    return result
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Scan a built container image with the Argus SDK and "
+        "render PR-comment + SARIF artifacts.",
+    )
+    parser.add_argument("--image-name", required=True, help="Short image name (matrix key).")
+    parser.add_argument("--image-ref", required=True, help="Full image reference to scan.")
+    parser.add_argument(
+        "--out-dir",
+        default="scanner-summaries",
+        help="Directory for the per-image markdown section + JSON counts.",
+    )
+    parser.add_argument(
+        "--sarif-dir",
+        default=None,
+        help="Directory for the combined SARIF (omit to skip SARIF output).",
+    )
+    args = parser.parse_args(argv)
+
+    result = run(
+        image_name=args.image_name,
+        image_ref=args.image_ref,
+        out_dir=Path(args.out_dir),
+        sarif_dir=Path(args.sarif_dir) if args.sarif_dir else None,
+    )
+
+    # A sub-scanner failure means the summary is incomplete — exit
+    # non-zero so the caller can gate rather than silently trusting a
+    # partial result.
+    return 1 if result.scanner_errors else 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/unit/test_render_container_summary.py
+++ b/tests/unit/test_render_container_summary.py
@@ -1,0 +1,212 @@
+"""Tests for ``scripts/ci/render_container_summary.py``.
+
+Regression lock for the PR-comment false negative: the old inline heredoc
+in ``build-containers.yml`` parsed only Trivy output, so Grype findings
+were dropped and the container markdown reporter rendered
+"No vulnerabilities detected by Grype" for every image. These tests prove
+the SDK-backed replacement surfaces Grype findings — including a
+Grype-only CVE that Trivy never reported — in the per-image section, the
+severity counts, and the combined SARIF.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+from argus.container.scanner import ContainerScanResult, deduplicate_findings
+from argus.core.models import Finding, Severity
+
+from scripts.ci import render_container_summary as rcs
+
+
+# --------------------------------------------------------------------- #
+# Fixtures                                                              #
+# --------------------------------------------------------------------- #
+
+
+def _cve(cve: str, severity: Severity, tool: str, pkg: str = "openssl") -> Finding:
+    return Finding(
+        id=cve,
+        severity=severity,
+        title=f"{cve} in {pkg}",
+        cve=cve,
+        scanner="container",
+        metadata={"tool": tool, "package": pkg, "installed_version": "1.0"},
+    )
+
+
+def _result_with_grype_only_critical() -> ContainerScanResult:
+    """A result where Grype finds a CRITICAL that Trivy never reported.
+
+    This is the exact scenario the bug hid: Trivy sees a single medium,
+    Grype sees a distinct critical. The deduped ``combined_findings`` must
+    contain both.
+    """
+    trivy = [_cve("CVE-2024-0001", Severity.MEDIUM, "trivy")]
+    grype = [_cve("CVE-2024-9999", Severity.CRITICAL, "grype")]
+    return ContainerScanResult(
+        name="cli",
+        image_ref="ghcr.io/huntridge-labs/argus/cli:testsha",
+        trivy_findings=trivy,
+        grype_findings=grype,
+        combined_findings=deduplicate_findings(trivy, grype),
+    )
+
+
+# --------------------------------------------------------------------- #
+# build_count_summary                                                   #
+# --------------------------------------------------------------------- #
+
+
+def test_count_summary_includes_grype_only_cve():
+    result = _result_with_grype_only_critical()
+    summary = rcs.build_count_summary(result)
+
+    # The Grype-only critical must be counted — the old Trivy-only path
+    # reported critical=0 here.
+    assert summary["critical"] == 1
+    assert summary["medium"] == 1
+    assert summary["total"] == 2
+    assert summary["name"] == "cli"
+    assert summary["image_ref"].endswith("cli:testsha")
+    assert summary["build_success"] is True
+
+
+def test_count_summary_keys_match_combine_step():
+    """The combine step reads these exact keys back — lock the contract."""
+    summary = rcs.build_count_summary(_result_with_grype_only_critical())
+    for key in ("name", "image_ref", "build_success", "critical", "high", "medium", "low"):
+        assert key in summary
+
+
+# --------------------------------------------------------------------- #
+# write_pr_comment_artifacts                                            #
+# --------------------------------------------------------------------- #
+
+
+def test_section_surfaces_grype_findings(tmp_path: Path):
+    rcs.write_pr_comment_artifacts(_result_with_grype_only_critical(), tmp_path)
+
+    md = (tmp_path / "cli.md").read_text(encoding="utf-8")
+
+    # The Grype subsection must show the real finding, NOT the false
+    # "no vulnerabilities" line that the bug produced.
+    assert "CVE-2024-9999" in md
+    assert "No vulnerabilities detected by Grype" not in md
+    # Trivy's finding is still present.
+    assert "CVE-2024-0001" in md
+
+
+def test_json_counts_written(tmp_path: Path):
+    rcs.write_pr_comment_artifacts(_result_with_grype_only_critical(), tmp_path)
+
+    data = json.loads((tmp_path / "cli.json").read_text(encoding="utf-8"))
+    assert data["critical"] == 1
+    assert data["total"] == 2
+
+
+def test_clean_image_reports_no_grype_findings_truthfully(tmp_path: Path):
+    """When Grype genuinely finds nothing, the honest line is fine."""
+    clean = ContainerScanResult(
+        name="cli",
+        image_ref="ghcr.io/huntridge-labs/argus/cli:testsha",
+        trivy_findings=[],
+        grype_findings=[],
+        combined_findings=[],
+    )
+    rcs.write_pr_comment_artifacts(clean, tmp_path)
+    md = (tmp_path / "cli.md").read_text(encoding="utf-8")
+    assert "No vulnerabilities detected by Grype" in md
+
+
+# --------------------------------------------------------------------- #
+# write_sarif                                                           #
+# --------------------------------------------------------------------- #
+
+
+def test_sarif_includes_grype_only_cve(tmp_path: Path):
+    path = rcs.write_sarif(_result_with_grype_only_critical(), tmp_path)
+    assert path.exists()
+    sarif = json.loads(path.read_text(encoding="utf-8"))
+    assert sarif["version"] == "2.1.0"
+    # The Grype-only critical must reach the Security tab too.
+    assert "CVE-2024-9999" in json.dumps(sarif)
+
+
+# --------------------------------------------------------------------- #
+# run / main (scan_image monkeypatched — no Docker in unit tests)       #
+# --------------------------------------------------------------------- #
+
+
+def test_run_uses_scan_image_and_writes_all_artifacts(tmp_path: Path, monkeypatch):
+    captured = {}
+
+    def fake_scan_image(target, scanners, sbom):
+        captured["target"] = target
+        captured["scanners"] = scanners
+        captured["sbom"] = sbom
+        return _result_with_grype_only_critical()
+
+    monkeypatch.setattr(rcs, "scan_image", fake_scan_image)
+
+    out_dir = tmp_path / "summaries"
+    sarif_dir = tmp_path / "sarif"
+    result = rcs.run(
+        image_name="cli",
+        image_ref="ghcr.io/huntridge-labs/argus/cli:testsha",
+        out_dir=out_dir,
+        sarif_dir=sarif_dir,
+    )
+
+    # Dogfoods the SDK's scan_image with the CVE-only sub-scanner set.
+    assert captured["scanners"] == ("trivy", "grype")
+    assert captured["sbom"] is False
+    assert captured["target"].image_ref.endswith("cli:testsha")
+    assert captured["target"].dockerfile is None
+
+    assert (out_dir / "cli.md").exists()
+    assert (out_dir / "cli.json").exists()
+    assert (sarif_dir / "argus-results.sarif").exists()
+    assert result.critical_count == 1
+
+
+def test_run_without_sarif_dir_skips_sarif(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(
+        rcs, "scan_image",
+        lambda target, scanners, sbom: _result_with_grype_only_critical(),
+    )
+    out_dir = tmp_path / "summaries"
+    rcs.run("cli", "ref:tag", out_dir, sarif_dir=None)
+    assert (out_dir / "cli.md").exists()
+    assert not (tmp_path / "sarif").exists()
+
+
+def test_main_exit_zero_on_clean_run(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(
+        rcs, "scan_image",
+        lambda target, scanners, sbom: _result_with_grype_only_critical(),
+    )
+    rc = rcs.main([
+        "--image-name", "cli",
+        "--image-ref", "ghcr.io/huntridge-labs/argus/cli:testsha",
+        "--out-dir", str(tmp_path / "out"),
+    ])
+    assert rc == 0
+
+
+def test_main_exit_nonzero_on_scanner_error(tmp_path: Path, monkeypatch):
+    def scan_with_error(target, scanners, sbom):
+        r = _result_with_grype_only_critical()
+        r.scanner_errors = {"grype": "grype produced 0-byte output"}
+        return r
+
+    monkeypatch.setattr(rcs, "scan_image", scan_with_error)
+    rc = rcs.main([
+        "--image-name", "cli",
+        "--image-ref", "ref:tag",
+        "--out-dir", str(tmp_path / "out"),
+    ])
+    # A sub-scanner failure must not be reported as a clean pass.
+    assert rc == 1


### PR DESCRIPTION
## Description
The container-scan PR comment reported "No vulnerabilities detected by Grype" for every image regardless of what Grype actually found — a false negative in a security tool. Root cause: the `scan` job in `build-containers.yml` built its report from an inline step that parsed **Trivy JSON only** and constructed a `ContainerScanResult` with no `grype_findings`. Because `grype_findings` defaults to `[]`, the container markdown reporter rendered the "no findings" line for Grype on every image, while the separate `anchore/scan-action` step still emitted its "failed minimum severity level" annotation. The Trivy-only `combined_findings` also under-counted the summary table (dropping Grype-only CVEs), and only the Trivy SARIF reached the Security tab.

## Changes Made
- [ ] Added new scanner/workflow
- [x] Modified existing scanner/workflow
- [ ] Updated documentation
- [x] Fixed bug
- [x] Other: added a tested CI helper script; documented the pattern in `.ai/errors.yaml`

### Details
- **Affected:** `.github/workflows/build-containers.yml` (the per-image `scan` job).
- **Fix:** Replaced the `Trivy (SARIF)` / `anchore/scan-action` (Grype) / `Trivy (JSON)` / inline-Python steps with `scripts/ci/render_container_summary.py`, which dogfoods the SDK's `scan_image()` — the same entrypoint `argus scan container` and `ContainerEngine.run` use — so both Trivy and Grype run and are deduplicated by CVE via `deduplicate_findings()`.
- Both scanners now populate the per-image markdown section, the combined severity counts, and a combined SARIF.
- A Trivy/Grype sub-scanner crash now fails the job (non-zero exit) instead of masquerading as "0 findings".
- **No breaking changes** — the combine step's artifact contract (`<image>.md` + `<image>.json`) is unchanged.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results
`tests/unit/test_render_container_summary.py` — 10 tests, all passing. Regression lock: a Grype-only CRITICAL must appear in the per-image section, the counts, and the SARIF, and must **not** produce "No vulnerabilities detected by Grype". `ruff`, `yamllint`, and `actionlint` verified clean on the changed files.

## Security Considerations
- [ ] No security impact
- [x] Security enhancement
- [ ] Potential security implications (explain below)

### Security Details
Fixes a false negative in the container vulnerability report — Grype findings were silently dropped from the PR comment and the combined severity counts. Also routes the combined Trivy+Grype SARIF to the GitHub Security tab (previously Trivy-only), so Grype-only CVEs surface there too.

## AI Context Updates (.ai/)
- [ ] `.ai/architecture.yaml` updated (if components/structure changed)
- [ ] `.ai/workflows.yaml` updated (if commands/tasks changed)
- [ ] `.ai/decisions.yaml` updated (if design decision made)
- [x] `.ai/errors.yaml` updated (documented the Grype-dropped-from-PR-comment pattern)
- [ ] N/A - No .ai/ updates needed

## Checklist
- [x] Code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
N/A — reported via internal triage.

---
> **Heads-up:** two CI gates (`check-cli-docs`, `check-architecture-sync`) fail on `main` independently of this PR — both report `argus console` / `license` / `report-pdf` missing from `docs/cli-reference.md` and `.ai/context.yaml`. Left out of this PR to keep it focused; can regenerate those separately.