### PR TITLE
feat(vex): apply OpenVEX to the CLI container's bundled-Go criticals

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -177,7 +177,8 @@ jobs:
             --image-name "$IMAGE_NAME" \
             --image-ref "ghcr.io/huntridge-labs/argus/${IMAGE_NAME}:${IMAGE_TAG}" \
             --out-dir scanner-summaries \
-            --sarif-dir sarif-out
+            --sarif-dir sarif-out \
+            --vex .vex/argus-cli.openvex.json
         env:
           IMAGE_NAME: ${{ matrix.image }}
           IMAGE_TAG: ${{ github.sha }}

--- a/.vex/README.md
+++ b/.vex/README.md
@@ -1,0 +1,69 @@
+# CLI container VEX — evidence & justification (DRAFT — needs sign-off)
+
+Scope: the CLI container's CRITICAL findings that are **not attributable to
+Argus's own code** — every one lives in a vendored Go dependency inside a
+**bundled third-party security-tool binary**, not in the Argus Python package.
+Evidence below is from the GitHub code-scanning alerts for category
+`container-cli` (SARIF emitted by the container scan), which carry per-finding
+binary attribution (`location.path`).
+
+## Binary attribution (evidence)
+
+| Vulnerable component | Bundled binary | Source |
+|---|---|---|
+| `golang.org/x/crypto@v0.35.0` (CVE-2025-47913 / -47914 / -58181 + Grype GHSA/GO aliases) | `usr/local/bin/gitleaks` | code-scanning alert `location.path` |
+| `stdlib@go1.24.11` (CVE-2025-68121 / GO-2026-4337) | `usr/local/bin/gitleaks` | code-scanning alert `location.path` |
+| `stdlib@go1.26.1` (highs) | `usr/local/bin/actionlint` | " |
+| `stdlib@go1.26.3` (highs) | `usr/local/bin/grype`, `usr/local/bin/syft` | " |
+
+The 12 CRITICALs collapse to two root causes, both in **gitleaks** (an old
+build — `zricethezav/gitleaks:v8.30.1`, compiled with Go 1.24.11 and vendoring
+`x/crypto` v0.35.0):
+
+1. **`golang.org/x/crypto` v0.35.0** — the `x/crypto/ssh` advisory cluster
+   (Grype rates CRITICAL; Trivy rates the same CVEs HIGH).
+2. **Go stdlib 1.24.11** — CVE-2025-68121.
+
+## Justification: `not_affected` / `vulnerable_code_not_in_execute_path`
+
+Argus invokes gitleaks as a **one-shot, offline secret scanner over the
+already-checked-out local working tree**. It does not open a network listener,
+serve requests, or initiate SSH connections. The `x/crypto/ssh` handshake code
+(the affected path for the x/crypto cluster) and the stdlib path for
+CVE-2025-68121 are therefore never reached in Argus's usage.
+
+⚠️ **Per-CVE reachability must be confirmed before this is treated as final.**
+Each `x/crypto` CVE's specific affected function should be checked against
+gitleaks' actual call graph (gitleaks *can* clone remote repos, which would
+exercise SSH — Argus's pipeline scans the local checkout, so it does not, but
+that is a usage assumption worth pinning). This draft encodes the assumption;
+sign-off = confirming it holds for your invocation.
+
+## ⭐ Recommended first: fix, don't suppress
+
+These are **fixable by bumping the bundled tool**, which is better than a VEX:
+
+- Bump **gitleaks** in `docker/Dockerfile.cli` / `argus/containers.py` to a
+  release built against Go ≥ 1.24.13 and `x/crypto` ≥ 0.52.0 — that clears the
+  x/crypto cluster **and** CVE-2025-68121 outright (10 of the 12 criticals).
+- Bump **actionlint** / confirm **grype**/**syft** are on current builds for
+  the stdlib highs.
+
+VEX should cover only the residue that has **no** rebuilt upstream release yet.
+If a gitleaks bump clears these, this document is unnecessary.
+
+## How to apply (once signed off)
+
+Commit as `.vex/argus-cli.openvex.json` and point the scan at it:
+
+```yaml
+# argus.yml
+containers:
+  vex: .vex/argus-cli.openvex.json          # container-lifecycle scan
+scanners:
+  grype: { vex: .vex/argus-cli.openvex.json }   # source/SBOM scans (PR #365)
+  trivy: { vex: .vex/argus-cli.openvex.json }
+```
+
+Both Trivy and Grype resolve CVE↔GHSA↔GO aliases, but statements are included
+under all three ID schemes for belt-and-suspenders matching.

--- a/.vex/argus-cli.openvex.json
+++ b/.vex/argus-cli.openvex.json
@@ -1,0 +1,115 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://huntridge-labs.github.io/argus/vex/argus-cli-go-bundled",
+  "author": "Huntridge Labs Security",
+  "role": "Document Creator",
+  "timestamp": "2026-07-20T00:00:00Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {"name": "CVE-2025-47913"},
+      "products": [{"@id": "pkg:golang/golang.org/x/crypto@v0.35.0"}],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "golang.org/x/crypto is vendored into the bundled gitleaks binary (usr/local/bin/gitleaks). The affected code is in golang.org/x/crypto/ssh; Argus invokes gitleaks only as an offline scanner over the already-checked-out local working tree, so no SSH client/server handshake is performed and the vulnerable path is never reached."
+    },
+    {
+      "vulnerability": {"name": "CVE-2025-47914"},
+      "products": [{"@id": "pkg:golang/golang.org/x/crypto@v0.35.0"}],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "x/crypto vendored into gitleaks; golang.org/x/crypto/ssh path is not exercised by gitleaks scanning a local repo. Awaiting an upstream gitleaks release built against x/crypto >= 0.52.0."
+    },
+    {
+      "vulnerability": {"name": "CVE-2025-58181"},
+      "products": [{"@id": "pkg:golang/golang.org/x/crypto@v0.35.0"}],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "x/crypto vendored into gitleaks; golang.org/x/crypto/ssh path is not exercised by gitleaks scanning a local repo. Awaiting an upstream gitleaks release built against x/crypto >= 0.52.0."
+    },
+    {
+      "vulnerability": {"name": "GHSA-x527-x647-q7gg"},
+      "products": [{"@id": "pkg:golang/golang.org/x/crypto@v0.35.0"}],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Grype advisory alias for the x/crypto/ssh cluster above; same binary (gitleaks), same non-reachable path."
+    },
+    {
+      "vulnerability": {"name": "GHSA-vgwf-h737-ff37"},
+      "products": [{"@id": "pkg:golang/golang.org/x/crypto@v0.35.0"}],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Grype advisory alias for the x/crypto/ssh cluster above; same binary (gitleaks), same non-reachable path."
+    },
+    {
+      "vulnerability": {"name": "GHSA-rm3j-f69w-wqmq"},
+      "products": [{"@id": "pkg:golang/golang.org/x/crypto@v0.35.0"}],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Grype advisory alias for the x/crypto/ssh cluster above; same binary (gitleaks), same non-reachable path."
+    },
+    {
+      "vulnerability": {"name": "GHSA-jppx-rxg9-jmrx"},
+      "products": [{"@id": "pkg:golang/golang.org/x/crypto@v0.35.0"}],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Grype advisory alias for the x/crypto/ssh cluster above; same binary (gitleaks), same non-reachable path."
+    },
+    {
+      "vulnerability": {"name": "GHSA-f5wc-c3c7-36mc"},
+      "products": [{"@id": "pkg:golang/golang.org/x/crypto@v0.35.0"}],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Grype advisory alias for the x/crypto/ssh cluster above; same binary (gitleaks), same non-reachable path."
+    },
+    {
+      "vulnerability": {"name": "GHSA-89gr-r52h-f8rx"},
+      "products": [{"@id": "pkg:golang/golang.org/x/crypto@v0.35.0"}],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Grype advisory alias for the x/crypto/ssh cluster above; same binary (gitleaks), same non-reachable path."
+    },
+    {
+      "vulnerability": {"name": "GHSA-5cgq-3rg8-m6cv"},
+      "products": [{"@id": "pkg:golang/golang.org/x/crypto@v0.35.0"}],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Grype advisory alias for the x/crypto/ssh cluster above; same binary (gitleaks), same non-reachable path."
+    },
+    {
+      "vulnerability": {"name": "GO-2026-5005"},
+      "products": [{"@id": "pkg:golang/golang.org/x/crypto@v0.35.0"}],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Go vuln DB alias for the x/crypto/ssh cluster above; same binary (gitleaks), same non-reachable path."
+    },
+    {
+      "vulnerability": {"name": "GO-2026-5019"},
+      "products": [{"@id": "pkg:golang/golang.org/x/crypto@v0.35.0"}],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Go vuln DB alias for the x/crypto/ssh cluster above; same binary (gitleaks), same non-reachable path."
+    },
+    {
+      "vulnerability": {"name": "GO-2026-5020"},
+      "products": [{"@id": "pkg:golang/golang.org/x/crypto@v0.35.0"}],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Go vuln DB alias for the x/crypto/ssh cluster above; same binary (gitleaks), same non-reachable path."
+    },
+    {
+      "vulnerability": {"name": "CVE-2025-68121"},
+      "products": [{"@id": "pkg:golang/stdlib@go1.24.11"}],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Go standard library baked into the gitleaks binary (built with Go 1.24.11). gitleaks runs as a one-shot offline secret scanner over the local working tree — it opens no network listener and serves no requests — so the affected stdlib path is not reached. Fixed in Go 1.24.13+/1.25.7+; awaiting an upstream gitleaks rebuild."
+    },
+    {
+      "vulnerability": {"name": "GO-2026-4337"},
+      "products": [{"@id": "pkg:golang/stdlib@go1.24.11"}],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Go vuln DB alias of CVE-2025-68121 (same stdlib vuln in the gitleaks binary); same non-reachable rationale."
+    }
+  ]
+}

--- a/argus.yml
+++ b/argus.yml
@@ -63,6 +63,10 @@ scanners:
 # build-containers workflow can read this same list rather than
 # hard-coding a parallel matrix — single source of truth.
 containers:
+  # OpenVEX document: drops not_affected / fixed findings (with justification)
+  # from the trivy + grype container scans. Covers the CLI image's Go criticals
+  # that live in bundled third-party binaries (see .vex/README.md).
+  vex: .vex/argus-cli.openvex.json
   images:
     # Build-then-scan entries: dockerfile: + name: pin the build tag.
     # Under schema option A, image: is for *remote pulls only* — these

--- a/argus/core/schema.py
+++ b/argus/core/schema.py
@@ -116,7 +116,7 @@ _EXECUTION_KEYS = {
 }
 
 # Top-level containers block keys
-_CONTAINERS_KEYS = {"images", "discover", "search_paths", "scanners"}
+_CONTAINERS_KEYS = {"images", "discover", "search_paths", "scanners", "vex"}
 
 # Per-image entry keys (under containers.images[*])
 _CONTAINER_IMAGE_KEYS = {"image", "dockerfile", "context", "name", "cleanup"}

--- a/scripts/ci/render_container_summary.py
+++ b/scripts/ci/render_container_summary.py
@@ -119,16 +119,19 @@ def run(
     image_ref: str,
     out_dir: Path,
     sarif_dir: Path | None = None,
+    vex: list[str] | None = None,
 ) -> ContainerScanResult:
     """Scan ``image_ref`` via the SDK and write the CI artifacts.
 
     The image is already built and ``docker load``-ed into the local
-    daemon by an earlier job, so the target carries no Dockerfile —
+    daemon by an earlier job, so the target carries no Dockerfile;
     ``scan_image`` detects it as a local image and scans it through the
-    docker-daemon source.
+    docker-daemon source. ``vex`` (OpenVEX document paths) is forwarded to
+    trivy and grype so not_affected / fixed findings are filtered.
     """
     target = ContainerTarget(name=image_name, image_ref=image_ref)
-    result = scan_image(target, scanners=_SCANNERS, sbom=False)
+    config = {"vex": vex} if vex else None
+    result = scan_image(target, scanners=_SCANNERS, sbom=False, config=config)
 
     write_pr_comment_artifacts(result, out_dir)
     if sarif_dir is not None:
@@ -161,6 +164,14 @@ def main(argv: Sequence[str] | None = None) -> int:
         default=None,
         help="Directory for the combined SARIF (omit to skip SARIF output).",
     )
+    parser.add_argument(
+        "--vex",
+        action="append",
+        dest="vex",
+        default=None,
+        metavar="PATH",
+        help="OpenVEX document to apply (repeatable); forwarded to trivy + grype.",
+    )
     args = parser.parse_args(argv)
 
     result = run(
@@ -168,6 +179,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         image_ref=args.image_ref,
         out_dir=Path(args.out_dir),
         sarif_dir=Path(args.sarif_dir) if args.sarif_dir else None,
+        vex=args.vex,
     )
 
     # A sub-scanner failure means the summary is incomplete — exit

--- a/tests/unit/test_render_container_summary.py
+++ b/tests/unit/test_render_container_summary.py
@@ -143,10 +143,11 @@ def test_sarif_includes_grype_only_cve(tmp_path: Path):
 def test_run_uses_scan_image_and_writes_all_artifacts(tmp_path: Path, monkeypatch):
     captured = {}
 
-    def fake_scan_image(target, scanners, sbom):
+    def fake_scan_image(target, scanners, sbom, config=None):
         captured["target"] = target
         captured["scanners"] = scanners
         captured["sbom"] = sbom
+        captured["config"] = config
         return _result_with_grype_only_critical()
 
     monkeypatch.setattr(rcs, "scan_image", fake_scan_image)
@@ -163,6 +164,7 @@ def test_run_uses_scan_image_and_writes_all_artifacts(tmp_path: Path, monkeypatc
     # Dogfoods the SDK's scan_image with the CVE-only sub-scanner set.
     assert captured["scanners"] == ("trivy", "grype")
     assert captured["sbom"] is False
+    assert captured["config"] is None  # no --vex passed
     assert captured["target"].image_ref.endswith("cli:testsha")
     assert captured["target"].dockerfile is None
 
@@ -175,7 +177,7 @@ def test_run_uses_scan_image_and_writes_all_artifacts(tmp_path: Path, monkeypatc
 def test_run_without_sarif_dir_skips_sarif(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(
         rcs, "scan_image",
-        lambda target, scanners, sbom: _result_with_grype_only_critical(),
+        lambda target, scanners, sbom, config=None: _result_with_grype_only_critical(),
     )
     out_dir = tmp_path / "summaries"
     rcs.run("cli", "ref:tag", out_dir, sarif_dir=None)
@@ -186,7 +188,7 @@ def test_run_without_sarif_dir_skips_sarif(tmp_path: Path, monkeypatch):
 def test_main_exit_zero_on_clean_run(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(
         rcs, "scan_image",
-        lambda target, scanners, sbom: _result_with_grype_only_critical(),
+        lambda target, scanners, sbom, config=None: _result_with_grype_only_critical(),
     )
     rc = rcs.main([
         "--image-name", "cli",
@@ -197,7 +199,7 @@ def test_main_exit_zero_on_clean_run(tmp_path: Path, monkeypatch):
 
 
 def test_main_exit_nonzero_on_scanner_error(tmp_path: Path, monkeypatch):
-    def scan_with_error(target, scanners, sbom):
+    def scan_with_error(target, scanners, sbom, config=None):
         r = _result_with_grype_only_critical()
         r.scanner_errors = {"grype": "grype produced 0-byte output"}
         return r
@@ -210,3 +212,38 @@ def test_main_exit_nonzero_on_scanner_error(tmp_path: Path, monkeypatch):
     ])
     # A sub-scanner failure must not be reported as a clean pass.
     assert rc == 1
+
+
+def test_run_threads_vex_into_scan_image_config(tmp_path: Path, monkeypatch):
+    captured = {}
+
+    def fake_scan_image(target, scanners, sbom, config=None):
+        captured["config"] = config
+        return _result_with_grype_only_critical()
+
+    monkeypatch.setattr(rcs, "scan_image", fake_scan_image)
+    rcs.run(
+        image_name="cli",
+        image_ref="ref:tag",
+        out_dir=tmp_path / "out",
+        vex=[".vex/argus-cli.openvex.json"],
+    )
+    assert captured["config"] == {"vex": [".vex/argus-cli.openvex.json"]}
+
+
+def test_main_forwards_vex_flag(tmp_path: Path, monkeypatch):
+    captured = {}
+
+    def fake_scan_image(target, scanners, sbom, config=None):
+        captured["config"] = config
+        return _result_with_grype_only_critical()
+
+    monkeypatch.setattr(rcs, "scan_image", fake_scan_image)
+    rcs.main([
+        "--image-name", "cli",
+        "--image-ref", "ref:tag",
+        "--out-dir", str(tmp_path / "out"),
+        "--vex", "a.json",
+        "--vex", "b.json",
+    ])
+    assert captured["config"] == {"vex": ["a.json", "b.json"]}


### PR DESCRIPTION
## Description
Adds `.vex/argus-cli.openvex.json` and wires it into the container scan so the CLI image's Go **CRITICALs** are filtered at the source with an auditable justification, instead of surfacing as unactionable noise in the PR comment.

These criticals are **not attributable to Argus's own code**. Code-scanning attribution (`location.path`) puts every one inside a bundled third-party Go binary — `golang.org/x/crypto v0.35.0` and Go `stdlib 1.24.11`, both in the **`gitleaks`** binary. The VEX marks them `not_affected` / `vulnerable_code_not_in_execute_path`: Argus runs gitleaks as a one-shot offline scanner over the local checkout, so the `x/crypto/ssh` handshake and the affected stdlib path are never reached. Full evidence + per-group reasoning is in **`.vex/README.md`**.

Built on the now-merged VEX work: #362 (surface Grype) → #364 (container `--vex`) → #365 (shared capability + grype/trivy).

## Changes Made
- [ ] Added new scanner/workflow
- [x] Modified existing scanner/workflow
- [x] Updated documentation
- [ ] Fixed bug
- [x] Other: version-controlled VEX document + wiring

### Details
- `.vex/argus-cli.openvex.json` — 15 OpenVEX statements (CVE **and** GHSA/GO aliases so both trivy and grype match).
- `argus.yml`: `containers.vex` points at it (the `argus scan container` path).
- `scripts/ci/render_container_summary.py`: new `--vex` passthrough into `scan_image(config=…)` so the build-containers PR-comment scan applies it.
- `.github/workflows/build-containers.yml`: passes `--vex .vex/argus-cli.openvex.json` to the render step.
- `argus/core/schema.py`: `vex` added to the allowed `containers.*` keys so `argus validate` accepts it (verified clean; the JSON schema already allows extra keys).

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed

### Test Results
`tests/unit/test_render_container_summary.py` updated for the new `scan_image(config=…)` call + `--vex` threading (config carries `{"vex": [...]}`; absent when no flag). 77 tests across render + validate-deep + container-discovery green; `argus validate --config argus.yml` clean; ruff/yaml clean. **This PR self-verifies**: its own build-containers run applies the VEX, so the CLI image's critical count should drop in the container-scan PR comment — the check that the statements actually match.

## Security Considerations
- [x] Security enhancement (auditable, justification-bearing suppression of non-attributable findings)

### Security Details
Suppression is data-driven and version-controlled (status + justification + reason + evidence), not an opaque per-tool ignore. Statements are ID-scoped, so a *future* x/crypto or stdlib CVE still surfaces.

## AI Context Updates (.ai/)
- [x] N/A — no registry/CLI/component change (config key `vex` was already added to `.ai/architecture.yaml` in #365)

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (`.vex/README.md`)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

---
> **Please review the justifications before merging** — this is a security assertion. Two honest caveats (also in `.vex/README.md`):
> 1. **Fix-first**: most of these are fixable by bumping the bundled **gitleaks** to a build on Go ≥1.24.13 + x/crypto ≥0.52.0 — the better long-term remedy. This VEX is the interim.
> 2. The `not_affected` claims rest on the **offline-usage assumption** (Argus never runs gitleaks over SSH / as a server). Confirm that holds for your invocation.