### PR TITLE
fix(deps): cap mcp below 2.0 to unbreak the test suite

### DIFF
--- a/.ai/errors.yaml
+++ b/.ai/errors.yaml
@@ -752,3 +752,39 @@ errors:
         '
       reference: package.json + .github/dependabot.yml + .github/workflows/release-preview.yml + scripts/release-it-process-changelog.js
     symptom: empty changelog|release preview shows only version header|no Maintenance/Dependencies section|chore(deps) commits missing from changelog
+  MODULENOTFOUNDERROR__NO_MODULE_NAMED__MCP_SERVER_FASTMCP__WHOLE_SUITE_ABORTS_EXIT_CODE_2:
+    category: development
+    context: 'Unit Tests and Release (dry-run) both red on main with no code
+      change that touches Python dependencies. Collection of
+      argus/tests/test_mcp.py errors out, pytest reports "collected 0 items /
+      1 error", and the run exits 2 before any result is reported.
+
+      '
+    root_cause: 'mcp 2.0.0 (released 2026-07-28) deleted the
+
+      mcp.server.fastmcp package outright — the 1.29.0 wheel ships 19
+      mcp/server/fastmcp/* entries, the 2.0.0 wheel ships zero, replaced by a
+      restructured surface (mcp/server/apps.py, context.py, extension.py).
+      requirements.txt and pyproject.toml both declared an open-ended
+      ``mcp>=1.10``, so CI resolved the new major at install time and
+      ``from mcp.server.fastmcp import FastMCP`` in argus/mcp.py:14 raised
+      ImportError at collection. Nothing in the repo changed; the break
+      arrived from PyPI. It surfaced on the first main run in a week, which
+      makes it look like whichever commit happened to trigger that run.
+
+      '
+    solution:
+      steps:
+      - 'Add a forward ceiling in BOTH places the dep is declared: ``mcp>=1.10,<2.0`` in requirements.txt and in the [mcp] extra in pyproject.toml. A ceiling in only one leaves the other resolving 2.x.'
+      - 'Add a Dependabot ``ignore`` for mcp ``version-update:semver-major`` (pip ecosystem) so the major is not re-proposed inside the pip-all group every week.'
+      - 'Do NOT revert the commit CI blamed — it is a forward constraint fix, and the failing commit is unrelated.'
+      note: 'Confirm the bound is right before trusting it — inspect the wheels
+        rather than the changelog: download both and diff the namelist for the
+        module that disappeared. 1.29.0 is the newest release that still ships
+        mcp/server/fastmcp/. Negative control: ``pip install mcp==2.0.0`` then
+        run the file — collection errors with 0 items; reinstall the range and
+        all 86 tests in argus/tests/test_mcp.py pass.
+
+        '
+      reference: requirements.txt + pyproject.toml ([project.optional-dependencies] mcp) + .github/dependabot.yml
+    symptom: No module named 'mcp.server.fastmcp'|collected 0 items / 1 error|ERROR collecting argus/tests/test_mcp.py

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,19 @@ updates:
         patterns:
           - "*"
 
+    # Hold mcp at 1.x. mcp 2.0.0 (2026-07-28) deleted the
+    # mcp.server.fastmcp package outright; argus/mcp.py builds its server
+    # through ``from mcp.server.fastmcp import FastMCP``, so 2.x turns
+    # collection of argus/tests/test_mcp.py into a hard error and aborts
+    # the whole suite with exit code 2. The requirements.txt / pyproject
+    # ceiling (<2.0) is the actual guard — this ignore just stops the
+    # major from being re-proposed inside the pip-all group every week.
+    # Re-enable once argus/mcp.py is ported to the 2.x server API
+    # (mcp.server.apps / mcp.server.context).
+    ignore:
+      - dependency-name: "mcp"
+        update-types: ["version-update:semver-major"]
+
     commit-message:
       prefix: "chore(deps)"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,8 +73,14 @@ ai = [
 ]
 # Shell tab completion
 completion = ["argcomplete>=3.5"]
-# MCP server for AI assistant integration
-mcp = ["mcp>=1.10"]
+# MCP server for AI assistant integration.
+# Cap below 2.0: that release (2026-07-28) deleted the mcp.server.fastmcp
+# package outright. argus/mcp.py builds its server through
+# ``from mcp.server.fastmcp import FastMCP``, which 2.x replaced with a
+# restructured surface (mcp.server.apps / mcp.server.context). 1.29.0 is
+# the newest release that still ships mcp/server/fastmcp/. Lift the
+# ceiling once argus/mcp.py is ported to the 2.x API.
+mcp = ["mcp>=1.10,<2.0"]
 # Terminal interface for `argus view --interface=terminal`.
 # Floor bumped to 8.0 — the mouse-first interactivity work (clickable
 # Footer hints, click-to-sort headers, hover tooltips, right-click

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,13 @@ python-slugify>=8.0.4
 requests>=2.32.3
 
 # MCP server (optional at runtime, required for full test coverage)
-mcp>=1.10
+# Cap below 2.0: that release (2026-07-28) deleted the mcp.server.fastmcp
+# package outright, so `from mcp.server.fastmcp import FastMCP` in
+# argus/mcp.py raises ModuleNotFoundError and collection of
+# argus/tests/test_mcp.py aborts the whole run with exit code 2. 1.29.0
+# still ships mcp/server/fastmcp/. Lift the ceiling once argus/mcp.py is
+# ported to the 2.x server API (mcp.server.apps / mcp.server.context).
+mcp>=1.10,<2.0
 
 # Optional: AI fallback for SCN Detector (not required for rule-based classification)
 # Install with: pip install "anthropic>=0.45"


### PR DESCRIPTION
## Description
`mcp` 2.0.0 landed on PyPI on 2026-07-28 and deleted the `mcp.server.fastmcp` package outright. Both dependency declarations used an open-ended `mcp>=1.10`, so CI resolved the new major at install time and `argus/mcp.py:14` failed to import. This caps the constraint below 2.0.

No commit in this repo caused the break. It arrived from PyPI and surfaced on the first `main` run in a week, which made it look like whichever commit happened to trigger that run.

## Changes Made
- [ ] Added new scanner/workflow
- [ ] Modified existing scanner/workflow
- [x] Updated documentation
- [x] Fixed bug
- [ ] Other (please specify)

### Details
**Which workflows/scanners are affected?** Unit Tests and Release (dry-run) were both red on `main`. Neither could get past test collection.

**What the failure looked like:**
```
E   ModuleNotFoundError: No module named 'mcp.server.fastmcp'
collected 0 items / 1 error
##[error]Process completed with exit code 2
```

**Root cause.** Comparing the published wheels: `mcp` 1.29.0 ships 19 `mcp/server/fastmcp/*` entries, `mcp` 2.0.0 ships zero. 2.x replaces it with a restructured surface (`mcp/server/apps.py`, `context.py`, `extension.py`). `argus/mcp.py` builds its server through `from mcp.server.fastmcp import FastMCP`, so the import raises at collection and pytest aborts the entire suite before reporting a single result.

**What changed:**
- `requirements.txt` → `mcp>=1.10,<2.0`
- `pyproject.toml` `[mcp]` extra → `mcp>=1.10,<2.0`
- `.github/dependabot.yml` → ignore `mcp` `version-update:semver-major` for the pip ecosystem
- `.ai/errors.yaml` → new error entry documenting the pattern

Both declarations needed the ceiling. Capping only one leaves the other resolving 2.x. The Dependabot ignore is not the guard, the version ceiling is; the ignore just stops the major being re-proposed inside the weekly `pip-all` group. This mirrors the existing `conventional-changelog-conventionalcommits` hold in the npm ecosystem.

**Any breaking changes?** No. 1.29.0 is the newest release that still ships `mcp/server/fastmcp/`, so the MCP server keeps working exactly as before.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results
Constraint resolves as intended and the import works:
```
resolved mcp == 1.29.0
fastmcp import OK -> <class 'mcp.server.fastmcp.server.FastMCP'>
```

The previously-aborting file:
```
argus/tests/test_mcp.py ..............................................
86 passed in 0.35s
```

Full suite:
```
3979 passed, 141 skipped, 27 deselected, 28 warnings in 41.63s
Required test coverage of 80% reached. Total coverage: 85.51%
```

Negative control, to confirm causality rather than assume it. Forcing the new major reproduces the exact CI failure:
```
$ pip install mcp==2.0.0 && pytest argus/tests/test_mcp.py
collected 0 items / 1 error
ERROR collecting argus/tests/test_mcp.py
```
Reinstalling the capped range returns all 86 to green.

> The one deselected test is `TestDockerPull::test_pull_small_image`, which times out pulling `hello-world` from Docker Hub. Unrelated flake, already seen on #360.

## Security Considerations
- [ ] No security impact
- [x] Security enhancement
- [ ] Potential security implications (explain below)

### Security Details
Replacing an open-ended `>=` range with a bounded one removes a path where an unreviewed upstream major enters the build automatically. This is the pattern the repo already documents for the npm hold, and it matches the supply-chain policy note at the top of `dependabot.yml`.

Worth a follow-up: `pyyaml`, `requests`, `python-slugify`, `pytest` and `pytest-cov` still carry open-ended `>=` floors with no ceiling.

## AI Context Updates (.ai/)
- [ ] `.ai/architecture.yaml` updated (if components/structure changed)
- [ ] `.ai/workflows.yaml` updated (if commands/tasks changed)
- [ ] `.ai/decisions.yaml` updated (if design decision made)
- [x] `.ai/errors.yaml` updated (if common error addressed)
- [ ] N/A - No .ai/ updates needed

Added `MODULENOTFOUNDERROR__NO_MODULE_NAMED__MCP_SERVER_FASTMCP__WHOLE_SUITE_ABORTS_EXIT_CODE_2`, including the "do not revert the commit CI blamed" note, since the blamed commit is unrelated to the cause.

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
None.

## Follow-up
Porting `argus/mcp.py` and `argus/tests/test_mcp.py` to the 2.x server API (`mcp.server.apps` / `mcp.server.context`) is deliberately out of scope here. This PR is the minimal change that gets `main` green. The 2.0 migration is a real rewrite of the server construction path and deserves its own PR and its own review.
