### PR TITLE
feat(mcp): migrate the MCP server to the mcp 2.x SDK

### DIFF
--- a/.ai/errors.yaml
+++ b/.ai/errors.yaml
@@ -774,16 +774,35 @@ errors:
 
       '
     solution:
+      status: 'RESOLVED — argus/mcp.py now builds its server with
+        mcp.server.MCPServer and the dependency floor is ``mcp>=2.0``, so the
+        <2.0 ceiling and the Dependabot mcp hold described below no longer
+        exist in the tree. Retained as the worked example for the next time an
+        upstream major deletes a module out from under a pinned-by-floor dep.
+
+        '
       steps:
       - 'Add a forward ceiling in BOTH places the dep is declared: ``mcp>=1.10,<2.0`` in requirements.txt and in the [mcp] extra in pyproject.toml. A ceiling in only one leaves the other resolving 2.x.'
-      - 'Add a Dependabot ``ignore`` for mcp ``version-update:semver-major`` (pip ecosystem) so the major is not re-proposed inside the pip-all group every week.'
+      - 'Add a Dependabot ``ignore`` for the major (pip ecosystem) so it is not re-proposed inside the pip-all group every week. The ceiling is the guard; the ignore only reduces noise.'
       - 'Do NOT revert the commit CI blamed — it is a forward constraint fix, and the failing commit is unrelated.'
+      - 'Then migrate deliberately in a separate PR rather than leaving the ceiling indefinitely: the 1.x line went maintenance-only (security fixes) at the 2.0 release, so a permanent cap parks the MCP server on an unsupported branch.'
       note: 'Confirm the bound is right before trusting it — inspect the wheels
         rather than the changelog: download both and diff the namelist for the
-        module that disappeared. 1.29.0 is the newest release that still ships
-        mcp/server/fastmcp/. Negative control: ``pip install mcp==2.0.0`` then
-        run the file — collection errors with 0 items; reinstall the range and
-        all 86 tests in argus/tests/test_mcp.py pass.
+        module that disappeared. 1.29.0 was the newest release that still
+        shipped mcp/server/fastmcp/. Negative control: ``pip install
+        mcp==2.0.0`` then run the file — collection errors with 0 items;
+        reinstall the capped range and all 86 tests in
+        argus/tests/test_mcp.py pass.
+
+        '
+      migration_notes: 'The 2.x port was mechanical: MCPServer keeps
+        ``.tool()``, ``.resource(uri)`` and ``.prompt()`` with compatible
+        signatures, and accepts ``name``/``instructions`` positionally as
+        before. Two things did change — ``version`` became a real
+        constructor parameter (1.x needed a write to the private
+        ``_mcp_server`` attribute), and that private attribute was renamed
+        to ``_lowlevel_server``, so any 1.x code reaching into it breaks on
+        2.x regardless of the import path.
 
         '
       reference: requirements.txt + pyproject.toml ([project.optional-dependencies] mcp) + .github/dependabot.yml

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,19 +30,6 @@ updates:
         patterns:
           - "*"
 
-    # Hold mcp at 1.x. mcp 2.0.0 (2026-07-28) deleted the
-    # mcp.server.fastmcp package outright; argus/mcp.py builds its server
-    # through ``from mcp.server.fastmcp import FastMCP``, so 2.x turns
-    # collection of argus/tests/test_mcp.py into a hard error and aborts
-    # the whole suite with exit code 2. The requirements.txt / pyproject
-    # ceiling (<2.0) is the actual guard — this ignore just stops the
-    # major from being re-proposed inside the pip-all group every week.
-    # Re-enable once argus/mcp.py is ported to the 2.x server API
-    # (mcp.server.apps / mcp.server.context).
-    ignore:
-      - dependency-name: "mcp"
-        update-types: ["version-update:semver-major"]
-
     commit-message:
       prefix: "chore(deps)"
 

--- a/argus/mcp.py
+++ b/argus/mcp.py
@@ -11,7 +11,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 
 from argus import __version__ as _ARGUS_VERSION
 
@@ -21,8 +21,9 @@ from argus import __version__ as _ARGUS_VERSION
 # older snapshots can miss recent changes or new disclosures.
 DEFAULT_FRESH_THRESHOLD_SECONDS = 86400
 
-mcp = FastMCP(
+mcp = MCPServer(
     "argus",
+    version=_ARGUS_VERSION,
     instructions="""
 Argus Security Scanner — comprehensive security scanning for your codebase.
 
@@ -68,14 +69,13 @@ SCANNER CATEGORIES:
 """,
 )
 
-# FastMCP's constructor doesn't expose ``version`` directly, so reach
-# through to the wrapped lowlevel ``mcp.server.lowlevel.Server`` and
-# set it. Without this, the MCP initialize response advertises the
-# FastMCP library version (e.g. "1.27.1") as the server version
-# instead of the argus version — MCP clients using the version to
-# disambiguate compatible argus releases would get the wrong answer
-# (issue #168-O).
-mcp._mcp_server.version = _ARGUS_VERSION
+# The server version is passed to the constructor above. MCP clients read
+# it from the initialize response to disambiguate compatible argus
+# releases, so it must be the argus version and not the SDK's own
+# (issue #168-O). Under mcp 1.x this needed a write through to the private
+# ``_mcp_server`` attribute because FastMCP's constructor did not accept
+# ``version``; MCPServer takes it directly and exposes a read-only
+# ``.version`` property.
 
 
 # ---------------------------------------------------------------------------
@@ -1073,6 +1073,6 @@ async def setup_scanning() -> str:
 # ---------------------------------------------------------------------------
 
 
-def create_server() -> FastMCP:
+def create_server() -> MCPServer:
     """Create and return the Argus MCP server instance."""
     return mcp

--- a/argus/tests/test_mcp.py
+++ b/argus/tests/test_mcp.py
@@ -1214,15 +1214,29 @@ class TestPrompts:
 class TestCreateServer:
     """Tests for the create_server factory."""
 
-    def test_returns_fastmcp_instance(self):
-        from mcp.server.fastmcp import FastMCP
+    def test_returns_mcpserver_instance(self):
+        from mcp.server import MCPServer
 
         server = create_server()
-        assert isinstance(server, FastMCP)
+        assert isinstance(server, MCPServer)
 
     def test_server_name_is_argus(self):
         server = create_server()
         assert server.name == "argus"
+
+    def test_server_advertises_argus_version_not_sdk_version(self):
+        """The initialize response must carry the argus version (#168-O).
+
+        Under mcp 1.x this was set by writing to the private
+        ``_mcp_server`` attribute, which nothing asserted; MCPServer takes
+        ``version`` in its constructor and exposes it as a property, so the
+        behaviour is now pinned here. A regression would make MCP clients
+        read the SDK's version and mis-identify the argus release.
+        """
+        from argus import __version__ as argus_version
+
+        server = create_server()
+        assert server.version == argus_version
 
     def test_server_has_instructions(self):
         server = create_server()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,13 +74,13 @@ ai = [
 # Shell tab completion
 completion = ["argcomplete>=3.5"]
 # MCP server for AI assistant integration.
-# Cap below 2.0: that release (2026-07-28) deleted the mcp.server.fastmcp
-# package outright. argus/mcp.py builds its server through
-# ``from mcp.server.fastmcp import FastMCP``, which 2.x replaced with a
-# restructured surface (mcp.server.apps / mcp.server.context). 1.29.0 is
-# the newest release that still ships mcp/server/fastmcp/. Lift the
-# ceiling once argus/mcp.py is ported to the 2.x API.
-mcp = ["mcp>=1.10,<2.0"]
+# Floor at 2.0: argus/mcp.py builds its server with mcp.server.MCPServer,
+# the 2.x replacement for the removed mcp.server.fastmcp.FastMCP. 2.x
+# speaks the 2026-07-28 protocol revision and still serves 2025-era
+# clients from the same server object, so raising the floor costs no
+# client compatibility. The 1.x line is upstream maintenance-only
+# (security fixes) — see py.sdk.modelcontextprotocol.io/migration/.
+mcp = ["mcp>=2.0"]
 # Terminal interface for `argus view --interface=terminal`.
 # Floor bumped to 8.0 — the mouse-first interactivity work (clickable
 # Footer hints, click-to-sort headers, hover tooltips, right-click

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,13 +19,11 @@ python-slugify>=8.0.4
 requests>=2.32.3
 
 # MCP server (optional at runtime, required for full test coverage)
-# Cap below 2.0: that release (2026-07-28) deleted the mcp.server.fastmcp
-# package outright, so `from mcp.server.fastmcp import FastMCP` in
-# argus/mcp.py raises ModuleNotFoundError and collection of
-# argus/tests/test_mcp.py aborts the whole run with exit code 2. 1.29.0
-# still ships mcp/server/fastmcp/. Lift the ceiling once argus/mcp.py is
-# ported to the 2.x server API (mcp.server.apps / mcp.server.context).
-mcp>=1.10,<2.0
+# Floor at 2.0: argus/mcp.py builds its server with mcp.server.MCPServer,
+# the 2.x replacement for the removed mcp.server.fastmcp.FastMCP. The 1.x
+# line is upstream maintenance-only (security fixes), so there is no
+# reason to keep straddling both.
+mcp>=2.0
 
 # Optional: AI fallback for SCN Detector (not required for rule-based classification)
 # Install with: pip install "anthropic>=0.45"


### PR DESCRIPTION
## Description
Ports `argus/mcp.py` from `mcp.server.fastmcp.FastMCP` to `mcp.server.MCPServer` and raises the dependency floor to `mcp>=2.0`, lifting the `<2.0` ceiling added in e779206d.

This is the deliberate follow-up to that pin. The pin got `main` green; it was never meant to be permanent.

## Why 2.0 is better for us

**The headline reason is supportability, not features.** Upstream moved the 1.x line to maintenance mode at the 2.0 release — [security fixes only](https://github.com/modelcontextprotocol/python-sdk/releases/tag/v2.0.0), with 1.x parked on a `v1.x` branch. Keeping a permanent `<2.0` cap means the MCP server of a security scanner sits on an unsupported dependency branch indefinitely. That is precisely the finding Argus raises in other people's repositories, and it would be inconsistent to carry it in our own.

**The port is cheap right now and gets more expensive the longer we wait.** The v2 decorator API is unchanged. `MCPServer` keeps `.tool()`, `.resource(uri)` and `.prompt()` with compatible signatures and still accepts `name` / `instructions` positionally. The functional diff in `argus/mcp.py` is 4 lines. Every 1.x release we skip widens the eventual gap for no benefit.

**Two things concretely improve in our code:**

1. **A private-attribute dependency disappears.** `version` is a real constructor parameter in 2.x, so this goes away:
   ```python
   mcp._mcp_server.version = _ARGUS_VERSION   # before
   ```
   ```python
   mcp = MCPServer("argus", version=_ARGUS_VERSION, ...)   # after
   ```
   This mattered more than it looks. 2.x also **renamed** `_mcp_server` to `_lowlevel_server`, so that line was a latent `AttributeError` regardless of the import path. We were reaching into SDK internals to set something the SDK now supports properly.

2. **A previously untested behaviour is now pinned.** Nothing asserted that the server advertises the *argus* version rather than the SDK's (issue #168-O) — the old hack was invisible to the suite. Added `test_server_advertises_argus_version_not_sdk_version`.

**Optionality we gain but do not use yet:** resource subscriptions (SEP-2575), `CacheHint`, OpenTelemetry tracing on by default, extension APIs, and the hardened OAuth flows (RFC 9207 issuer validation). These become relevant if Argus ever exposes the MCP server over Streamable HTTP. Today it is stdio-only, so they are future headroom rather than present wins.

### What does NOT improve — stated plainly

I measured rather than assumed, and two of the things the release notes advertise do not benefit us today:

- **No protocol-version gain on stdio.** I ran the same handshake against both SDKs. `mcp` 1.29.0 and `mcp` 2.0.0 **both** negotiate `2025-11-25`. The advertised `2026-07-28` revision is handshake-free and HTTP-only (a self-contained POST with no `initialize`), so it does not apply to our stdio transport at all.
  ```
  mcp 1.29.0, client asks 2026-07-28 -> negotiated: 2025-11-25
  mcp 2.0.0,  client asks 2026-07-28 -> negotiated: 2025-11-25
  mcp 2.0.0,  client asks 2025-06-18 -> negotiated: 2025-06-18
  ```
  The third line is still worth having: it confirms older clients are served unchanged, so raising the floor costs no client compatibility.

- **The stdio hardening is defence-in-depth, not a bug fix.** v2 diverts stray stdout to stderr while serving. I checked whether we actually had exposure: of 82 non-test `subprocess` call sites, 81 capture their output, and the one that does not (`argus/viewers/terminal/mouse_actions.py:238`) is not on the MCP path. `cmd_mcp` already routes its own output to stderr deliberately. So this removes a class of future regression — it does not fix a live corruption bug, and I am not claiming it does.

**Known upstream gaps in 2.0**, for completeness: the tasks extension (SEP-2663) is not in this release, and client-side DPoP proof binding (SEP-1932) and the `jwt-bearer` grant are unimplemented. None are used by Argus.

## Changes Made
- [ ] Added new scanner/workflow
- [x] Modified existing scanner/workflow
- [x] Updated documentation
- [ ] Fixed bug
- [ ] Other (please specify)

### Details
**Which workflows/scanners are affected?** The MCP server surface only (`argus mcp`). No scanner, reporter, or CLI behaviour changes.

**What changed:**
- `argus/mcp.py` — `FastMCP` → `MCPServer`, `version=` passed to the constructor, private `_mcp_server` write removed, `create_server()` return type updated
- `argus/tests/test_mcp.py` — type assertion updated, new advertised-version test
- `requirements.txt` and `pyproject.toml` `[mcp]` extra — `mcp>=1.10,<2.0` → `mcp>=2.0`
- `.github/dependabot.yml` — removed the mcp major hold, which existed only to block the major now being adopted
- `.ai/errors.yaml` — marked the fastmcp entry `RESOLVED`, kept it as the worked example, and recorded the two real migration gotchas (`version` is now a constructor arg; `_mcp_server` was renamed)

**Any breaking changes?** None for Argus users. `docs/mcp.md` installs via the `[mcp]` extra rather than a pinned version, so no doc change was needed. Anyone pinning `mcp<2` in their own environment alongside `argus-security[mcp]` will now hit a resolver conflict; that is the intended consequence of adopting the major.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results
Full suite on `mcp` 2.0.0:
```
3980 passed, 141 skipped, 27 deselected, 28 warnings in 38.22s
Required test coverage of 80% reached. Total coverage: 85.51%
```

Every tool, resource and prompt still registers:
```
tools    : 9   (argus_scan, argus_list_scanners, argus_validate, argus_detect,
                argus_init, argus_classify, argus_explain_finding,
                argus_scan_summary, argus_security_review)
resources: 4   (argus://config, argus://results/latest,
                argus://config/schema, argus://architecture)
prompts  : 3   (security_review, fix_findings, setup_scanning)
```

End-to-end, driving a real JSON-RPC session over `argus mcp` on stdio rather than only calling the factory:
```
initialize -> serverInfo: {'name': 'argus', 'version': '1.10.0'}
protocolVersion: 2025-06-18
tools/list -> count: 9
```
`serverInfo.version` is the argus version, not the SDK's, which is the #168-O behaviour surviving the move to the supported constructor argument.

> The one deselected test is `TestDockerPull::test_pull_small_image`, which times out pulling `hello-world` from Docker Hub. Pre-existing flake, unrelated.

## Security Considerations
- [ ] No security impact
- [x] Security enhancement
- [ ] Potential security implications (explain below)

### Security Details
Moves the MCP server off a dependency branch that now receives security fixes only and onto the actively developed line. Also removes reliance on an SDK private attribute, which is a supply-chain-adjacent fragility: internal renames are not semver-protected, so code reaching past the public API can break or silently misbehave on any upstream release.

The 2.x line additionally hardens stdio handling and OAuth (RFC 9207 issuer validation, SEP-990 identity assertion). As noted above, the stdio piece is defence-in-depth for us rather than a fix, and the OAuth work only becomes relevant if the server is ever exposed beyond stdio.

## AI Context Updates (.ai/)
- [ ] `.ai/architecture.yaml` updated (if components/structure changed)
- [ ] `.ai/workflows.yaml` updated (if commands/tasks changed)
- [ ] `.ai/decisions.yaml` updated (if design decision made)
- [x] `.ai/errors.yaml` updated (if common error addressed)
- [ ] N/A - No .ai/ updates needed

The fastmcp error entry is marked `RESOLVED` rather than deleted: the diagnostic pattern (upstream major deletes a module under a floor-pinned dep; cap it, do not revert the blamed commit, then migrate deliberately) is worth keeping, and it now carries the migration gotchas.

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues
Follows e779206d. Preserves the behaviour from #168-O and adds the test it never had.
