### PR TITLE
chore(deps): update the four scanners past the 7-day age gate

### DIFF
--- a/argus/containers.py
+++ b/argus/containers.py
@@ -28,7 +28,7 @@ from pathlib import Path
 OFFICIAL_IMAGES = {
     "trivy": "aquasec/trivy:0.72.0@sha256:cffe3f5161a47a6823fbd23d985795b3ed72a4c806da4c4df16266c02accdd6f",
     "grype": "anchore/grype:v0.116.0@sha256:fd4ab4d1042b522c896e73bdf09ab8bf384fa417df99d6dd0d6e1008c7e7c821",
-    "syft": "anchore/syft:v1.49.0@sha256:13b53ebabe3d215268c90cf8fb9b875f0183908245f376fd4b3a2cb69d21d484",
+    "syft": "anchore/syft:v1.50.0@sha256:1288ea4c8b38767b4e620c1e312c8cb26b6e887a99b4f07ab6cd19fc6f225026",
     "gitleaks": "zricethezav/gitleaks:v8.30.1@sha256:c00b6bd0aeb3071cbcb79009cb16a60dd9e0a7c60e2be9ab65d25e6bc8abbb7f",
     "clamav": "clamav/clamav:1.5.3@sha256:d06c1d6a451d616e1dd79b42f44c8c8c291bba9cf4e75ebc4d0e43c1c6dd87bb",
     "checkov": "bridgecrew/checkov:3.3.8@sha256:c64ffb6d6fc8087c896341a2c697770a04a1cf558db04fa7b8129d8ca6bce336",

--- a/argus/containers.py
+++ b/argus/containers.py
@@ -57,7 +57,7 @@ OFFICIAL_IMAGES = {
     # lint-terraform docker fallbacks. terraform fmt/validate run via
     # the official Hashicorp image; tflint via its official image.
     "terraform": "hashicorp/terraform:1.15.8@sha256:7ae513256f7ce67879e218ae8593d6fbe216ec9e123abe6c94e4e10704857963",
-    "tflint": "ghcr.io/terraform-linters/tflint:v0.55.1@sha256:4136a6ec3d6659551f2b8f63be8bd413c8c1d842506a5597a26bf4e8bc1eac16",
+    "tflint": "ghcr.io/terraform-linters/tflint:v0.64.0@sha256:1c595f42d794c32c45a6ea8b58655fd66433d4ca3b1bc631c574a48d120bd19f",
     # lint-javascript via eslint. pipelinecomponents/eslint is the most
     # widely-used multi-arch eslint image. The upstream tags by commit
     # SHA + ``:latest`` + ``:edge``, not semver, so the ``:latest`` tag

--- a/argus/containers.py
+++ b/argus/containers.py
@@ -38,7 +38,7 @@ OFFICIAL_IMAGES = {
     # that protects us between Renovate-driven bumps — same pattern as
     # the eslint entry.
     "kics": "checkmarx/kics:latest@sha256:3e5a268eb8adda2e5a483c9359ddfc4cd520ab856a7076dc0b1d8784a37e2602",
-    "osv-scanner": "ghcr.io/google/osv-scanner:v2.3.6@sha256:2e07e642463100474fc5e214b66e6beccbd6bfa63dd3fbf047b3f755e78a6cfe",
+    "osv-scanner": "ghcr.io/google/osv-scanner:v2.4.0@sha256:5116601dedc01c1c580eb92371883ec052fc4c13c3fbc109d621a63ac416d475",
     "zap": "ghcr.io/zaproxy/zaproxy:2.17.0@sha256:8d387b1a63e3425beef4846e39719f5af2a787753af2d8b6558c6257d7a577a2",
     # promptfoo LLM red-team / eval. Opt-in scanner; requires provider
     # API keys + network at scan time. Pinned to an immutable version tag

--- a/argus/containers.py
+++ b/argus/containers.py
@@ -44,7 +44,7 @@ OFFICIAL_IMAGES = {
     # API keys + network at scan time. Pinned to an immutable version tag
     # + digest (Renovate-managed), like every other image here — the
     # publisher's ``:latest`` is mutable and silently drifts.
-    "promptfoo": "ghcr.io/promptfoo/promptfoo:0.121.14@sha256:4348f35b8382f2564f23746ddc3160637cfb9242ea8541304ac1ec6641597840",
+    "promptfoo": "ghcr.io/promptfoo/promptfoo:0.121.19@sha256:50d3a796710e4db7a5ede90bf27dc28146ef022a7ebb83914c5105608396fd96",
     "hadolint": "hadolint/hadolint:v2.14.0@sha256:27086352fd5e1907ea2b934eb1023f217c5ae087992eb59fde121dce9c9ff21e",
     # lint-shell via shellcheck. The koalaman/shellcheck-alpine image is
     # the official multi-arch distribution (~3 MB). shellcheck is GPL-3.0

--- a/scripts/release-it-process-changelog.js
+++ b/scripts/release-it-process-changelog.js
@@ -11,29 +11,55 @@
 const fs = require('fs');
 const path = require('path');
 
-// Security scanner patterns to detect in commit messages
+// Security scanner patterns to detect in commit messages.
+//
+// Matched as case-insensitive substrings against the whole changelog line, so
+// every tool we actually ship needs an entry here or its bump lands under the
+// generic "Dependencies" heading instead of "Security Tools". Keep this list in
+// step with OFFICIAL_IMAGES in argus/containers.py and the ARG *_VERSION pins in
+// docker/Dockerfile.* — the audit on 2026-08-04 found ten shipped tools missing.
 const securityScannerPatterns = [
-  'bridgecrewio/checkov-action',
-  'checkov-action',
-  'checkov',
+  // SAST
   'aquasecurity/trivy-action',
   'trivy-action',
   'trivy',
+  'bandit',
+  'opengrep',
+  'semgrep',
+  'gosec',
+  'github/codeql-action',
+  'codeql-action',
+  'codeql',
+  // IaC / config
+  'bridgecrewio/checkov-action',
+  'checkov-action',
+  'checkov',
+  'checkmarx',
+  'kics',
+  'tflint',
+  'hadolint',
+  // Dependencies / SBOM
   'anchore/sbom-action',
   'sbom-action',
   'syft',
   'anchore/scan-action',
   'grype',
-  'clamav',
+  'osv-scanner',
+  'osv',
+  // Secrets / malware
   'gitleaks/gitleaks-action',
   'gitleaks-action',
   'gitleaks',
-  'bandit',
-  'opengrep',
-  'semgrep',
-  'github/codeql-action',
-  'codeql-action',
-  'codeql'
+  'clamav',
+  // Supply chain
+  'zizmor',
+  'actionlint',
+  // DAST / AI
+  'zaproxy',
+  'zap',
+  'promptfoo',
+  // Shell
+  'shellcheck'
 ];
 
 function isSecurityScanner(commitText) {


### PR DESCRIPTION
## Description

Updates every scanner that is **actually eligible** under our 7-day minimum release age. That is **4 tools**, not the 8 I first reported and not 2.

Two corrections to my earlier count, both found by the checker in the companion PR:

- **syft** is eligible. I computed its age against midnight rather than the current time and got 6 days; it is 7.
- **promptfoo** is eligible at `0.121.19`. I had compared only against `latest` (`0.122.0`, published today, too new) and missed that an older, adoptable release existed.

Release dates against 2026-08-04:

| Tool | Pinned | Latest | Published | Age | Eligible |
|---|---|---|---|---|---|
| osv-scanner | v2.3.6 | **v2.4.0** | 2026-06-18 | 47d | ✅ adopted |
| promptfoo | 0.121.14 | **0.121.19** | 2026-07-14 | 21d | ✅ adopted |
| tflint | v0.55.1 | **v0.64.0** | 2026-07-17 | 18d | ✅ adopted |
| syft | v1.49.0 | **v1.50.0** | 2026-07-28 | 7d | ✅ adopted |
| grype | v0.116.0 | v0.116.1 | 2026-07-28 | 6d | ❌ one day short |
| hadolint | v2.14.0 | v2.15.1 | 2026-07-31 | 3d | ❌ |
| checkov | 3.3.8 | 3.3.9 | 2026-08-02 | 1d | ❌ |
| trivy | 0.72.0 | 0.73.0 | 2026-08-03 | 1d | ❌ |
| promptfoo | (see above) | 0.122.0 | 2026-08-04 | 0d | ❌ |

The age gate is doing its job on the bottom four. **The four in this PR are ones it was not holding** — osv-scanner unproposed for six weeks, tflint for two, promptfoo for three — which is the actual defect. The companion PR addresses that.

The held versions become eligible between 2026-08-05 and 2026-08-10.

## Changes Made
- [ ] Added new scanner/workflow
- [x] Modified existing scanner/workflow
- [ ] Updated documentation
- [x] Fixed bug
- [ ] Other (please specify)

### Details

One commit per tool, so each gets its own changelog line:

1. `chore(deps): update osv-scanner to v2.4.0`
2. `chore(deps): update tflint to v0.64.0`
3. `chore(deps): update syft to v1.50.0`
4. `chore(deps): update promptfoo to 0.121.19`
5. `fix(release): file every shipped scanner under Security Tools`

**On that last commit.** The changelog post-processor sorts `deps`-scoped commits into "Security Tools" vs "Dependencies" by substring-matching the commit line against a hardcoded list. That list covered 10 tools and missed 10 we ship: `osv-scanner`, `tflint`, `hadolint`, `kics`, `gosec`, `shellcheck`, `zizmor`, `actionlint`, `zap`, `promptfoo`.

Three of the four updates here are affected (`osv-scanner`, `tflint`, `promptfoo`). Without the fix they file as generic Dependencies, and every past bump of those ten tools has been misfiled the same way — so the changelog has been understating security-tool movement for a while.

For the record, the automation chain is: `chore` maps to a **Maintenance** section (`.release-it.json` preset types), then the post-processor requires the **scope to contain `deps`**, then a **scanner name anywhere in the line** promotes it to Security Tools. Type, scope, and tool name all have to be right.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results

Digests resolved from the official tags and pinned, then verified:

```
python -m scripts.ci.check_container_images   →  All images resolve (21/21)
```

Changelog categorization, against a synthetic Maintenance section:

```
Before (main's script):   ### Dependencies      ← both scanner bumps misfiled
After  (this branch):     ### Security Tools    ← osv-scanner, tflint
                          ### Dependencies      ← release-it
                          ### Maintenance       ← non-deps commit
```

So the fix is confirmed in both directions, and non-scanner deps and non-deps commits still sort correctly.

## Security Considerations
- [ ] No security impact
- [x] Security enhancement
- [ ] Potential security implications (explain below)

### Security Details

Four scanners move to current detection content, and the 7-day age gate was respected rather than worked around: `grype v0.116.1` is one day short and was left alone even though it would have been convenient to sweep in.

All four digests were resolved from the vendors' own official tags (`ghcr.io/google/osv-scanner`, `ghcr.io/terraform-linters/tflint`, `anchore/syft`, `ghcr.io/promptfoo/promptfoo`) rather than from a third-party mirror.

**Fixed here after all:** `docker/Dockerfile.cli` shipped `SYFT_VERSION=1.50.0` while `argus/containers.py` pinned `syft v1.49.0`, so a scan got a different syft depending on whether it ran via the CLI image or the container fallback. That split was introduced today by #375, which bumped the Dockerfile ARG but not the `containers.py` pin. Since syft v1.50.0 does clear the 7-day gate, the syft commit closes the split rather than leaving it open. The companion PR adds a CI gate so the two locations cannot silently disagree again.

## AI Context Updates (.ai/)

- [ ] `.ai/architecture.yaml` updated (if components/structure changed)
- [ ] `.ai/workflows.yaml` updated (if commands/tasks changed)
- [ ] `.ai/decisions.yaml` updated (if design decision made)
- [ ] `.ai/errors.yaml` updated (if common error addressed)
- [x] N/A - No .ai/ updates needed

Version pins only; no component, command, or behaviour change.

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues

Paired with the Renovate hardening PR. Renovate's Dependency Dashboard is #200.
