### PR TITLE
fix(bandit): honor skip_check and check from argus.yml

### DIFF
--- a/argus/core/config_options.py
+++ b/argus/core/config_options.py
@@ -117,6 +117,13 @@ BASE_OPTIONS: tuple[ConfigOption, ...] = (
 # the UI never offers a no-op key.
 
 _SCANNER_EXTRAS: dict[str, tuple[ConfigOption, ...]] = {
+    "bandit": (
+        ConfigOption("check", "Only these tests", "rule_ids", "Run only these bandit test IDs.", example="B201,B301"),
+        ConfigOption(
+            "skip_check", "Skip tests", "rule_ids",
+            "Bandit test IDs to ignore (e.g. B311).", ignore=True, example="B311,B404",
+        ),
+    ),
     "checkov": (
         ConfigOption("framework", "Framework", "string", "Limit to one framework.", example="terraform"),
         ConfigOption("check", "Only these checks", "rule_ids", "Run only these check IDs.", example="CKV_AWS_20"),

--- a/argus/scanners/bandit.py
+++ b/argus/scanners/bandit.py
@@ -65,6 +65,16 @@ class BanditScanner:
         exclude = config.get("exclude")
         if exclude:
             args.extend(["--exclude", exclude])
+        # config-reference.md documents `check` / `skip_check` for
+        # bandit and checkov alike; bandit spells them --tests / --skip
+        # (comma-separated test IDs). Issue #385: these were silently
+        # dropped, so a repo-committed skip policy never took effect.
+        check = config.get("check")
+        if check:
+            args.extend(["--tests", check])
+        skip_check = config.get("skip_check")
+        if skip_check:
+            args.extend(["--skip", skip_check])
         return args
 
     def is_available(self) -> bool:

--- a/argus/tests/scanners/test_bandit.py
+++ b/argus/tests/scanners/test_bandit.py
@@ -2,7 +2,6 @@
 
 import json
 
-import pytest
 
 from argus.core.models import Severity
 from argus.core.redact import REDACTED_PLACEHOLDER
@@ -55,6 +54,45 @@ class TestBanditScannerMeta:
         cmd = BanditScanner().install_command()
         assert cmd is not None
         assert "bandit" in cmd
+
+
+class TestBanditBuildArgs:
+    """Regression tests for issue #385: ``skip_check`` and ``check``
+    are documented in config-reference.md as applying to bandit (same
+    rows as checkov) but were never mapped to bandit's flags, so a
+    repo-committed ``argus.yml`` skip was silently ignored — the worst
+    failure mode for a policy gate.
+    """
+
+    def _args(self, config):
+        from argus.core.scanner_template import ScanPaths
+
+        paths = ScanPaths(workspace="/workspace", output="/tmp/out.json")
+        return BanditScanner().build_args(paths, config)
+
+    def test_skip_check_maps_to_skip_flag(self):
+        args = self._args({"skip_check": "B311,B105"})
+
+        assert "--skip" in args
+        assert args[args.index("--skip") + 1] == "B311,B105"
+
+    def test_check_maps_to_tests_flag(self):
+        args = self._args({"check": "B201,B301"})
+
+        assert "--tests" in args
+        assert args[args.index("--tests") + 1] == "B201,B301"
+
+    def test_no_selection_flags_without_config(self):
+        args = self._args({})
+
+        assert "--skip" not in args
+        assert "--tests" not in args
+
+    def test_selection_composes_with_exclude(self):
+        args = self._args({"skip_check": "B311", "exclude": "tests,docs"})
+
+        assert args[args.index("--skip") + 1] == "B311"
+        assert args[args.index("--exclude") + 1] == "tests,docs"
 
 
 class TestBanditRedaction:

--- a/argus/tests/test_config_options.py
+++ b/argus/tests/test_config_options.py
@@ -46,6 +46,18 @@ def test_checkov_exposes_skip_check_as_an_ignore_knob() -> None:
     assert "skip_check" in checkov["ignore_keys"]
 
 
+def test_bandit_exposes_skip_check_as_an_ignore_knob() -> None:
+    # Issue #385: bandit's skip_check/check were documented but never
+    # read, so the config surface (correctly) omitted them. Now that
+    # build_args maps them to --skip/--tests, the UI must offer both.
+    bandit = next(x for x in config_surface()["scanners"] if x["name"] == "bandit")
+    keys = {o["key"] for o in bandit["options"]}
+    assert "check" in keys
+    skip = next(o for o in bandit["options"] if o["key"] == "skip_check")
+    assert skip["kind"] == "rule_ids" and skip["ignore"] is True
+    assert "skip_check" in bandit["ignore_keys"]
+
+
 def test_container_and_zap_ignore_knobs() -> None:
     surface = {x["name"]: x for x in config_surface()["scanners"]}
     assert "expose_ignore_ports" in surface["container"]["ignore_keys"]

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -216,6 +216,7 @@ scanners:
     severity_threshold: high
     config_file: "pyproject.toml"
     exclude: "tests,docs"
+    skip_check: "B311,B404"
 ```
 
 **Container scanning with private registry:**


### PR DESCRIPTION
## Description
Fixes #385: bandit silently ignored `skip_check` and `check` from `argus.yml`. Both fields are documented in `docs/config-reference.md` as applying to bandit (same rows as checkov), but `BanditScanner.build_args` never read them — a repo-committed skip policy validated cleanly and then never took effect. Observed live on `huntridge-labs/sdp-demo` (16 B311 findings persisted after the config landed while checkov's `skip_check` resolved).

## Changes Made
- [ ] Added new scanner/workflow
- [x] Modified existing scanner/workflow
- [x] Updated documentation
- [x] Fixed bug
- [ ] Other (please specify)

### Details
- **Affected scanner**: bandit (local and container execution — both go through the same `build_args`).
- `argus/scanners/bandit.py`: map `check` → `--tests` and `skip_check` → `--skip` (bandit's native comma-separated test-ID flags), mirroring checkov's `--check`/`--skip-check` handling.
- `argus/core/config_options.py`: declare both knobs in `_SCANNER_EXTRAS["bandit"]` so the config surface (Console / Cloud config editor) offers them — the registry only lists keys a scanner actually reads, which is why bandit correctly had no entry before.
- `docs/config-reference.md`: added `skip_check` to the fully-configured bandit example. The option-table rows were already correct; the code now matches them.
- No breaking changes: configs that already carry `scanners.bandit.skip_check` (written against the docs) start working as documented.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results
- New `TestBanditBuildArgs` regression tests (skip_check → `--skip`, check → `--tests`, no flags without config, composes with `exclude`) — failed before the fix, pass after.
- New config-surface test asserting bandit exposes `skip_check` as an ignore knob.
- Full SDK suite: 3037 passed, 25 skipped locally (`argus/tests/`, excluding `test_mcp*.py` which fail collection on a local `mcp`-package version drift unrelated to this change).
- Verified flag spelling against real bandit 1.9.2: a `random.random()` sample file produces 1 B311 finding with no flags, 0 with `--skip B311`, 0 with `--tests B105`.

## Security Considerations
- [ ] No security impact
- [ ] Security enhancement
- [x] Potential security implications (explain below)

### Security Details
This change makes finding suppression work as documented. Suppression scope is unchanged from what the docs already promised (and what checkov already does): a repo-committed `argus.yml` can skip specific bandit test IDs. The prior behavior — a policy file that validates but silently doesn't apply — is the worse failure mode for a security gate, since operators believe a skip is active policy when it's a no-op.

## AI Context Updates (.ai/)
- [x] N/A - No .ai/ updates needed (no component/structure, command, or decision changes; behavior now matches existing docs)

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

### For New Scanners/Actions (if applicable)
N/A — no new scanner.

## Related Issues
Closes #385

## Screenshots/Logs (if applicable)
```
$ bandit -f json b311_demo.py | grep -c '"test_id": "B311"'   # 1
$ bandit -f json --skip B311 b311_demo.py | grep -c 'B311'    # 0
```
