### PR TITLE
fix(zap): refresh 2.17.0 image digest after upstream tag re-push

### DIFF
--- a/argus/containers.py
+++ b/argus/containers.py
@@ -39,7 +39,10 @@ OFFICIAL_IMAGES = {
     # the eslint entry.
     "kics": "checkmarx/kics:latest@sha256:3e5a268eb8adda2e5a483c9359ddfc4cd520ab856a7076dc0b1d8784a37e2602",
     "osv-scanner": "ghcr.io/google/osv-scanner:v2.4.0@sha256:5116601dedc01c1c580eb92371883ec052fc4c13c3fbc109d621a63ac416d475",
-    "zap": "ghcr.io/zaproxy/zaproxy:2.17.0@sha256:8d387b1a63e3425beef4846e39719f5af2a787753af2d8b6558c6257d7a577a2",
+    # Upstream re-pushed the 2.17.0 tag (2026-08); the old index digest
+    # no longer verifies against the registry. Pin refreshed to the
+    # tag's current index digest, verified via `docker manifest inspect`.
+    "zap": "ghcr.io/zaproxy/zaproxy:2.17.0@sha256:781a2bdaea47324e7bab583e2263f21d257b0aee61ed51521a5be45f5f5081ef",
     # promptfoo LLM red-team / eval. Opt-in scanner; requires provider
     # API keys + network at scan time. Pinned to an immutable version tag
     # + digest (Renovate-managed), like every other image here — the


### PR DESCRIPTION
## Description
CI is red on every open PR: `test_zap_image_resolves` fails because upstream re-pushed the `ghcr.io/zaproxy/zaproxy:2.17.0` tag and the pinned index digest (`8d387b1a…`) no longer verifies against the registry. This re-pins to the tag's current index digest (`781a2bda…`).

## Changes Made
- [ ] Added new scanner/workflow
- [x] Modified existing scanner/workflow
- [ ] Updated documentation
- [x] Fixed bug
- [ ] Other (please specify)

### Details
- **Affected scanner**: zap (container image pin only, `argus/containers.py`).
- Old pin: `2.17.0@sha256:8d387b1a…` — `docker manifest inspect` now returns "manifest verification failed for digest".
- New pin: `2.17.0@sha256:781a2bdaea47324e7bab583e2263f21d257b0aee61ed51521a5be45f5f5081ef` — verified with `docker manifest inspect` and matches what `docker buildx imagetools inspect ghcr.io/zaproxy/zaproxy:2.17.0` reports as the tag's current index digest.
- No behavior change; same upstream version tag.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results
- `argus/tests/test_e2e_dast.py::TestZapImageResolution::test_zap_image_resolves` (the exact CI failure) passes locally against the new pin.
- `argus/tests/test_containers.py`: 25 passed.

## Security Considerations
- [ ] No security impact
- [ ] Security enhancement
- [x] Potential security implications (explain below)

### Security Details
An upstream re-push of a release tag is exactly what digest pinning exists to catch — the pin did its job by failing closed. The refreshed digest was taken directly from the registry's current resolution of the `2.17.0` tag (ZAP rebuilds release images periodically for base-image updates). Renovate manages this pin and would have proposed the same digest on its next run.

## AI Context Updates (.ai/)
- [x] N/A - No .ai/ updates needed (single digest refresh, no structure/command/decision change)

## Checklist
- [x] Code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

### For New Scanners/Actions (if applicable)
N/A

## Related Issues
Unblocks CI for #383, #384, #386.

## Screenshots/Logs (if applicable)
```
$ docker manifest inspect ghcr.io/zaproxy/zaproxy:2.17.0@sha256:8d387b1a…
manifest verification failed for digest sha256:8d387b1a…
$ docker manifest inspect ghcr.io/zaproxy/zaproxy:2.17.0@sha256:781a2bda…
(succeeds)
```
