### PR TITLE
chore(deps): floor four transitive npm deps past high-severity advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  brace-expansion@<1.1.18: 1.1.18
+  fast-uri@<3.1.5: 3.1.5
+  ip-address@<10.3.1: 10.3.1
+  js-yaml@>=4.0.0 <4.3.1: 4.3.1
+
 importers:
 
   .:
@@ -485,8 +491,8 @@ packages:
     resolution: {integrity: sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==}
     engines: {node: '>=10'}
 
-  brace-expansion@1.1.15:
-    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -823,8 +829,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.3:
-    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -972,8 +978,8 @@ packages:
     resolution: {integrity: sha512-UjOaSel/iddGZJ5xP/Eixh6dY1XghiBw4XK13rCCIJcJfyhhoul/7KhLLUGtebEj6GDYM6Vnx/mVsjx2L/mFIA==}
     engines: {node: '>=12.0.0'}
 
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+  ip-address@10.3.1:
+    resolution: {integrity: sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==}
     engines: {node: '>= 12'}
 
   is-arrayish@0.2.1:
@@ -1065,12 +1071,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
-    hasBin: true
-
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   json-parse-even-better-errors@2.3.1:
@@ -2004,7 +2006,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.3
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -2069,7 +2071,7 @@ snapshots:
       widest-line: 3.1.0
       wrap-ansi: 7.0.0
 
-  brace-expansion@1.1.15:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -2271,7 +2273,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -2281,7 +2283,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -2410,7 +2412,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.3: {}
+  fast-uri@3.1.5: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
@@ -2589,7 +2591,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  ip-address@10.2.0: {}
+  ip-address@10.3.1: {}
 
   is-arrayish@0.2.1: {}
 
@@ -2653,12 +2655,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.2.0:
-    dependencies:
-      argparse: 2.0.1
-    optional: true
-
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -2729,7 +2726,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.15
+      brace-expansion: 1.1.18
 
   minimist@1.2.8: {}
 
@@ -2988,7 +2985,7 @@ snapshots:
 
   socks@2.8.9:
     dependencies:
-      ip-address: 10.2.0
+      ip-address: 10.3.1
       smart-buffer: 4.2.0
 
   source-map@0.6.1:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,3 +7,12 @@
 # doesn't need to build anything for argus's purposes. Deny.
 allowBuilds:
   core-js-pure: false
+
+# Security floors for transitive deps of the release tooling — each pins
+# the minimum patched version for a high-severity advisory (see the GHSA
+# ids). Remove an entry once the parent dep's own range moves past it.
+overrides:
+  "brace-expansion@<1.1.18": 1.1.18 # GHSA-3jxr-9vmj-r5cp / -mh99 / -rgw5 (DoS)
+  "fast-uri@<3.1.5": 3.1.5 # GHSA-7p8r-x3mc-p8w7, GHSA-v2hh-gcrm-f6hx
+  "ip-address@<10.3.1": 10.3.1 # GHSA-mwp4-54f8-5fhr (+ 2 moderate)
+  "js-yaml@>=4.0.0 <4.3.1": 4.3.1 # GHSA-52cp-r559-cp3m, GHSA-5p4m-2wfm-xmqj


### PR DESCRIPTION
## Description
Clears all 7 high-severity OSV findings Argus Cloud reports against `pnpm-lock.yaml` (plus one high and two moderates pnpm audit flags beyond them). All are transitive deps of the release tooling — release-it / commitlint pull them in; nothing ships to users.

## Changes Made
- [ ] Added new scanner/workflow
- [ ] Modified existing scanner/workflow
- [ ] Updated documentation
- [ ] Fixed bug
- [x] Other (please specify): dependency security floors

### Details
Security floors added as `overrides` in `pnpm-workspace.yaml` (pnpm 11 ignores the legacy `pnpm` field in package.json):
- `brace-expansion` 1.1.15 → **1.1.18** — GHSA-3jxr-9vmj-r5cp, GHSA-mh99-v99m-4gvg, GHSA-rgw5-rvv9-x895 (DoS)
- `fast-uri` 3.1.3 → **3.1.5** — GHSA-7p8r-x3mc-p8w7, GHSA-v2hh-gcrm-f6hx (host confusion)
- `ip-address` 10.2.0 → **10.3.1** — GHSA-mwp4-54f8-5fhr (+2 moderate)
- `js-yaml` 4.2.0/4.3.0 → **4.3.1** — GHSA-52cp-r559-cp3m, GHSA-5p4m-2wfm-xmqj (quadratic CPU)

Each override is range-scoped (`pkg@<fixed`) so it stops applying once parent deps move past the floor on their own. No direct dependency changes; no breaking changes.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results
- `pnpm audit`: **No known vulnerabilities found** (was 8 high / 2 moderate).
- Full `pnpm install` succeeds; `release-it --version` (v21.0.1) and `commitlint --version` (21.2.1) run against the updated lockfile.

## Security Considerations
- [ ] No security impact
- [x] Security enhancement
- [ ] Potential security implications (explain below)

### Security Details
Removes all known high-severity advisories from the JS dependency tree. All bumped versions are patch releases published well past the repo's 24h `minimum-release-age` window.

## AI Context Updates (.ai/)
- [x] N/A - No .ai/ updates needed

## Checklist
- [x] Code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

### For New Scanners/Actions (if applicable)
N/A

## Related Issues
Part of clearing the Argus Cloud grade for huntridge-labs/argus (7 of 29 active high/critical findings).

## Screenshots/Logs (if applicable)
N/A
