### PR TITLE
fix(opengrep): switch scanner image to alpine via the musllinux binary

### DIFF
--- a/docker/Dockerfile.opengrep
+++ b/docker/Dockerfile.opengrep
@@ -13,22 +13,26 @@ RUN apk add --no-cache curl && \
     fi && \
     curl -fsSL --retry 5 --retry-delay 2 --retry-connrefused --connect-timeout 10 \
       -o /tmp/opengrep \
-      "https://github.com/opengrep/opengrep/releases/download/v${OPENGREP_VERSION}/opengrep_manylinux_${ARCH}" && \
+      "https://github.com/opengrep/opengrep/releases/download/v${OPENGREP_VERSION}/opengrep_musllinux_${ARCH}" && \
     install -m 0755 /tmp/opengrep /usr/local/bin/opengrep && \
     rm -f /tmp/opengrep
 
-FROM python:3.14.6-slim@sha256:cea0e6040540fb2b965b6e7fb5ffa00871e632eef63719f0ea54bca189ce14a6
+# musllinux build → alpine base, matching every other Argus image. The
+# previous debian-slim base carried the full Debian package surface
+# (perl, util-linux, ncurses, …) whose no-fix-yet CVEs dominated our own
+# base-image findings.
+FROM python:3.14.6-alpine@sha256:26730869004e2b9c4b9ad09cab8625e81d256d1ce97e72df5520e806b1709f92
 
 LABEL org.opencontainers.image.source="https://github.com/huntridge-labs/argus"
 LABEL org.opencontainers.image.description="Argus OpenGrep SAST Scanner"
 LABEL org.opencontainers.image.licenses="AGPL-3.0"
 
 # Patch OS-level vulnerabilities before anything else
-RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
+RUN apk upgrade --no-cache
 
 COPY --from=builder /usr/local/bin/opengrep /usr/local/bin/opengrep
 
-RUN useradd -m -u 1000 argus
+RUN adduser -D -u 1000 argus
 
 USER argus
 WORKDIR /workspace


### PR DESCRIPTION
## Description
Moves the opengrep scanner image from `python:3.14.6-slim` (Debian) to `python:3.14.6-alpine`, using opengrep's `musllinux` release binary instead of `manylinux`. The slim base was the only Debian image in the fleet and carried all 22 of this repo's active high/critical base-image findings in Argus Cloud (3 critical — perl, util-linux, ncurses, gzip, acl), none of which have Debian fixes yet (`affected` / `fix_deferred` per trivy against the newest slim digest).

## Changes Made
- [ ] Added new scanner/workflow
- [x] Modified existing scanner/workflow
- [ ] Updated documentation
- [x] Fixed bug
- [ ] Other (please specify)

### Details
- **Affected scanner**: opengrep (container image only; no SDK code changes).
- Builder stage fetches `opengrep_musllinux_${ARCH}` (official upstream release asset, same version 1.26.0) instead of `opengrep_manylinux_${ARCH}`.
- Final stage: `python:3.14.6-alpine@sha256:26730869…` — the same pinned base every other Argus image uses.
- `apt-get upgrade` → `apk upgrade --no-cache`, `useradd` → `adduser -D`, matching the other alpine Dockerfiles.
- `argus.yml` `containers:` builds this Dockerfile at scan time, so the base-image findings clear on the next default-branch scan after merge — no release needed.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results
- Image builds; `opengrep --version` → 1.26.0 on alpine (musl binary runs).
- Behavior parity: the SDK's exact invocation (`opengrep --json --output … --config … /workspace`) against a `subprocess shell=True` bait file returns **identical findings** from the new alpine image and the currently published slim image.
- Trivy vuln scan of the new image: **0 high/critical** (the slim image: 23 CVE/package pairs at high/critical).

## Security Considerations
- [ ] No security impact
- [x] Security enhancement
- [ ] Potential security implications (explain below)

### Security Details
Eliminates the entire Debian package CVE surface from the image rather than suppressing it — smaller image, fewer packages, same scanner behavior. The binary is still pulled from the official opengrep release with retry-hardened fetch; the version pin is unchanged.

## AI Context Updates (.ai/)
- [x] N/A - No .ai/ updates needed (image internals; component structure unchanged)

## Checklist
- [x] Code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

### For New Scanners/Actions (if applicable)
N/A

## Related Issues
Part of clearing the Argus Cloud grade for huntridge-labs/argus (22 of 29 active high/critical findings, incl. all 3 criticals).

## Screenshots/Logs (if applicable)
```
new alpine image:  findings: [('subprocess-shell-true', '/workspace/og_smoke.py')]
published slim:    findings: [('subprocess-shell-true', '/workspace/og_smoke.py')]
trivy (new image): high/critical total: 0
```
