### PR TITLE
fix(deps): raise the requests floor to >=2.33.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,11 +64,16 @@ dependencies = [
 # Floors bumped past known-CVE versions across the network-facing
 # stack. anthropic + openai keep major versions (1.x SDK floor for
 # openai; anthropic stays in 0.x). httpx[socks] bumped to close the
-# CVE-2024-* line. requests bumped past CVE-2024-35195.
+# CVE-2024-* line. requests is at 2.33.0 to clear CVE-2024-47081
+# (.netrc credential leak to a malicious URL, fixed 2.32.4) and
+# CVE-2026-25645 (insecure temp-file reuse in extract_zipped_paths,
+# fixed 2.33.0); the previous >=2.32.3 floor predated both. This is a
+# direct dependency — imported by argus/scn/ai.py and the scn-detector
+# action scripts — so the floor is ours to hold (#396).
 ai = [
     "anthropic>=0.45",
     "openai>=1.50",
-    "requests>=2.32.3",
+    "requests>=2.33.0",
     "httpx[socks]>=0.27",
 ]
 # Shell tab completion

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,8 +15,11 @@ pyyaml>=6.0.2
 # Container name sanitization
 python-slugify>=8.0.4
 
-# SCN Detector dependencies (closes CVE-2024-35195)
-requests>=2.32.3
+# SCN Detector dependencies. Floor at 2.33.0 to clear CVE-2024-47081
+# (.netrc credential leak, fixed 2.32.4) and CVE-2026-25645 (insecure
+# temp-file reuse in extract_zipped_paths, fixed 2.33.0). Keep in sync
+# with the ai extra in pyproject.toml.
+requests>=2.33.0
 
 # MCP server (optional at runtime, required for full test coverage)
 # Floor at 2.0: argus/mcp.py builds its server with mcp.server.MCPServer,


### PR DESCRIPTION
## Description

Raises the `requests` floor from `>=2.32.3` to `>=2.33.0`. Last of the five advisories the dispatch
job filed on 2026-08-13 (#394-#398) — and the only one that was both real and not already fixed.

## Changes Made
- [x] Modified existing scanner/workflow — `ai` extra + SCN-detector requirement
- [ ] Added new scanner/workflow
- [ ] Updated documentation
- [ ] Fixed bug
- [ ] Other

### Details

`requests` is a **direct dependency**, not something arriving through another package, so the floor
is ours to hold rather than something to wait on an upstream for:

```
$ git grep -n "import requests" origin/main -- argus/ .github/actions/
argus/scn/ai.py:18
.github/actions/scn-detector/scripts/ai_classifier.py:15
.github/actions/scn-detector/scripts/ai_providers.py:17
.github/actions/scn-detector/scripts/create_scn_issue.py:17
```

The old `>=2.32.3` floor predated two advisories:

| CVE | Summary | Fixed in |
|---|---|---|
| CVE-2024-47081 | `.netrc` credentials leaked to a malicious URL | 2.32.4 |
| CVE-2026-25645 | Insecure temp-file reuse in `extract_zipped_paths()` | 2.33.0 |

Both declarations move together — the `ai` extra in `pyproject.toml` and the SCN-detector line in
`requirements.txt`. A split floor is exactly how these two drift apart.

No breaking changes.

## Testing
- [x] Manual testing performed
- [ ] Unit tests added/updated (no new code paths — a dependency floor)
- [ ] Integration tests added/updated
- [ ] Tested with different scanner combinations

### Test Results

```
$ .venv-pr/bin/pip install -e ".[ai,mcp,browser]"
requests 2.34.2

$ pytest -q --no-cov
4258 passed, 127 skipped, 26 deselected in 33.46s
```

## Security Considerations
- [x] Security enhancement
- [ ] No security impact
- [ ] Potential security implications

### Security Details

Both advisories are local and low-severity — `AV:L` / `UI:R`, so they need a malicious input plus
user interaction, not remote reach. #396 rated this Low and that is the right call. The reason to
land it anyway is CVE-2024-47081: it is a credential-disclosure bug, and the old floor permitted it.

Verified against OSV rather than taken from the issue body:

```
$ curl -s -X POST https://api.osv.dev/v1/query \
    -d '{"package":{"name":"requests","ecosystem":"PyPI"},"version":"2.32.3"}'
  affected by: ["GHSA-9hjg-9r4m-mvj7","GHSA-gc5v-m9x4-r6x2","PYSEC-2026-1872","PYSEC-2026-2275"]

$ ... "version":"2.33.0"
  2.33.0 is clean
```

Floored at 2.33.0 rather than the current 2.34.2 deliberately: the floor's job is to exclude
known-vulnerable versions, not to track latest. Renovate handles currency.

## AI Context Updates (.ai/)
- [x] N/A — No `.ai/` updates needed. The triage procedure this came out of was already recorded in
  `.ai/workflows.yaml` + `.ai/errors.yaml` by #399; this PR just applies it.
- [ ] `.ai/architecture.yaml` updated
- [ ] `.ai/workflows.yaml` updated
- [ ] `.ai/decisions.yaml` updated
- [ ] `.ai/errors.yaml` updated

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (inline comments record which CVE each floor closes)
- [ ] Changelog updated — handled by release-it
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

### Round-up: where the five advisories landed

| Issue | Package | Disposition |
|---|---|---|
| #394 | starlette | Closed — sub-dependency; fastapi's unbounded `>=0.46.0` already resolves to 1.6.0 |
| #395 | python-multipart | Closed — never loaded (no form endpoints); stale pin removed in #399 |
| #396 | requests | **This PR** — real, direct dependency, floor was stale |
| #397 | fastapi | Closed — cited CVE does not exist; current floor clears all real advisories |
| #398 | mcp | Closed — already fixed on main by the mcp 2.x migration (`4cfebc93`) |

Closes #396
