### PR TITLE
fix(ci): retry transient GitHub failures in the tool-currency check

### DIFF
--- a/scripts/ci/check_tool_currency.py
+++ b/scripts/ci/check_tool_currency.py
@@ -44,8 +44,10 @@ import json
 import re
 import subprocess
 import sys
+import time
 import urllib.error
 import urllib.request
+from collections.abc import Callable
 from dataclasses import dataclass, field
 
 # Tools pinned in BOTH argus/containers.py and docker/Dockerfile.cli.
@@ -86,6 +88,15 @@ IMAGE_RE = re.compile(
     r'(?:@sha256:(?P<digest>[a-f0-9]{64}))?"'
 )
 ARG_RE = re.compile(r"^ARG (?P<name>[A-Z0-9_]+)_VERSION=(?P<version>[\w.-]+)", re.M)
+
+# Statuses worth a second attempt. GitHub answers a tripped secondary rate
+# limit with 403 (occasionally 429) and load-sheds with 5xx — all transient.
+# A 404 means the repo was renamed or deleted, so retrying only burns quota;
+# that one surfaces on the first attempt so the rename gets fixed here.
+RETRYABLE_STATUS: frozenset[int] = frozenset({403, 429, 500, 502, 503, 504})
+FETCH_ATTEMPTS = 3
+BACKOFF_BASE_SECONDS = 2.0
+MAX_BACKOFF_SECONDS = 30.0
 
 
 @dataclass
@@ -141,17 +152,67 @@ def check_consistency(images: dict[str, str], args_versions: dict[str, str]) -> 
     return out
 
 
-def fetch_releases(repo: str) -> list[dict]:
-    """Return upstream releases, newest first. Raises on transport failure."""
+def _retry_delay(error: Exception | None, attempt: int) -> float:
+    """Seconds to wait before the next attempt.
+
+    Honours ``Retry-After`` when GitHub sends it — on a secondary rate limit it
+    tells us exactly how long to back off, and guessing shorter just trips the
+    limit again. Falls back to exponential backoff, capped so a wedged upstream
+    cannot stall the job.
+    """
+    headers = getattr(error, "headers", None)
+    if headers is not None:
+        retry_after = headers.get("Retry-After")
+        if retry_after:
+            try:
+                return min(float(retry_after), MAX_BACKOFF_SECONDS)
+            except (TypeError, ValueError):
+                pass
+    return min(BACKOFF_BASE_SECONDS**attempt, MAX_BACKOFF_SECONDS)
+
+
+def fetch_releases(
+    repo: str,
+    *,
+    attempts: int = FETCH_ATTEMPTS,
+    sleep: Callable[[float], None] = time.sleep,
+) -> list[dict]:
+    """Return upstream releases, newest first. Raises on transport failure.
+
+    Retries transient failures. A single 403 from a tripped secondary rate
+    limit used to drop the tool straight into the "Not checked" bucket, and
+    that bucket reads as "nothing to do" — the report filed for #382 listed
+    checkov and trivy as unchecked while both endpoints were in fact healthy,
+    so the run silently under-stated how many pins were behind. Retrying is
+    what makes "not checked" mean the upstream is genuinely unreachable.
+    """
     url = f"https://api.github.com/repos/{repo}/releases?per_page=30"
-    request = urllib.request.Request(
-        url, headers={"Accept": "application/vnd.github+json", "User-Agent": "argus-ci"}
-    )
+    # Resolved once: _gh_token() may shell out to `gh auth token`, which has no
+    # business running per attempt.
     token = _gh_token()
-    if token:
-        request.add_header("Authorization", f"Bearer {token}")
-    with urllib.request.urlopen(request, timeout=20) as response:
-        return json.load(response)
+    last_error: Exception | None = None
+    for attempt in range(1, max(1, attempts) + 1):
+        request = urllib.request.Request(
+            url, headers={"Accept": "application/vnd.github+json", "User-Agent": "argus-ci"}
+        )
+        if token:
+            request.add_header("Authorization", f"Bearer {token}")
+        try:
+            with urllib.request.urlopen(request, timeout=20) as response:
+                return json.load(response)
+        except urllib.error.HTTPError as exc:
+            # HTTPError subclasses URLError subclasses OSError, so it must be
+            # caught first for the status check to get a look at all.
+            if exc.code not in RETRYABLE_STATUS:
+                raise
+            last_error = exc
+        except (urllib.error.URLError, OSError, ValueError) as exc:
+            # ValueError covers a truncated body failing json.load, which is
+            # as transient as the socket error that caused it.
+            last_error = exc
+        if attempt < max(1, attempts):
+            sleep(_retry_delay(last_error, attempt))
+    raise last_error if last_error is not None else OSError(f"no attempt made for {repo}")
 
 
 def _gh_token() -> str | None:
@@ -203,7 +264,13 @@ def check_currency(
         try:
             releases = fetch_releases(repo)
         except (urllib.error.URLError, OSError, ValueError) as exc:
-            unknown.append(Finding("unknown", key, f"could not query {repo}: {exc}"))
+            unknown.append(
+                Finding(
+                    "unknown",
+                    key,
+                    f"could not query {repo} after {FETCH_ATTEMPTS} attempt(s): {exc}",
+                )
+            )
             continue
         eligible = newest_eligible(releases, min_age_days, now)
         if eligible is None:
@@ -234,7 +301,15 @@ def render(report: Report, fmt: str, min_age_days: int) -> str:
             ]
             lines += [f"- **{f.tool}** — {f.detail}" for f in report.stale] + [""]
         if report.unknown:
-            lines += ["### Not checked", ""]
+            lines += [
+                "### Could not verify — currency UNKNOWN, not confirmed current",
+                "",
+                (
+                    "These pins were not compared against upstream. Treat them "
+                    "as unchecked, not as up to date."
+                ),
+                "",
+            ]
             lines += [f"- {f.tool} — {f.detail}" for f in report.unknown] + [""]
         if not (report.mismatches or report.stale or report.unknown):
             lines += ["Every tracked pin is current. Nothing to do."]

--- a/tests/unit/test_check_tool_currency.py
+++ b/tests/unit/test_check_tool_currency.py
@@ -17,6 +17,11 @@ behaviours that made it useful on its first run:
 from __future__ import annotations
 
 import datetime as dt
+import io
+import json
+import urllib.error
+
+import pytest
 
 from scripts.ci import check_tool_currency as ctc
 
@@ -165,6 +170,127 @@ class TestCheckCurrency:
         assert stale == []
         assert [f.tool for f in unknown] == ["syft"]
 
+    def test_unknown_detail_says_it_retried(self, monkeypatch):
+        """The report must not imply a single failed poke was the whole effort."""
+
+        def boom(repo):
+            raise OSError("forbidden")
+
+        monkeypatch.setattr(ctc, "UPSTREAM_REPOS", {"trivy": "aquasecurity/trivy"})
+        monkeypatch.setattr(ctc, "fetch_releases", boom)
+
+        _, unknown = ctc.check_currency({"trivy": "0.72.0"}, 7, NOW)
+
+        assert "attempt(s)" in unknown[0].detail
+
+
+def _http_error(code: int, *, retry_after: str | None = None) -> urllib.error.HTTPError:
+    headers = {"Retry-After": retry_after} if retry_after is not None else {}
+    return urllib.error.HTTPError(
+        "https://api.github.com/x", code, "boom", headers, None  # type: ignore[arg-type]
+    )
+
+
+class TestFetchReleasesRetry:
+    """#382 filed a report listing checkov and trivy as unchecked while both
+    endpoints were healthy — a transient 403 was enough to give up. Retrying is
+    what makes the "could not verify" bucket mean something.
+    """
+
+    def _patch_urlopen(self, monkeypatch, outcomes):
+        """Serve ``outcomes`` in order; raise them if exceptions, return if not."""
+        calls = []
+
+        def fake_urlopen(request, timeout=None):
+            outcome = outcomes[len(calls)]
+            calls.append(request)
+            if isinstance(outcome, Exception):
+                raise outcome
+
+            class _Response:
+                def __enter__(self):
+                    return io.BytesIO(json.dumps(outcome).encode())
+
+                def __exit__(self, *exc):
+                    return False
+
+            return _Response()
+
+        monkeypatch.setattr(ctc.urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setattr(ctc, "_gh_token", lambda: None)
+        return calls
+
+    def test_retries_a_transient_403_then_succeeds(self, monkeypatch):
+        releases = [_release("0.122.0", 21)]
+        calls = self._patch_urlopen(monkeypatch, [_http_error(403), releases])
+        slept: list[float] = []
+
+        got = ctc.fetch_releases("aquasecurity/trivy", sleep=slept.append)
+
+        assert got == releases
+        assert len(calls) == 2
+        assert slept == [ctc.BACKOFF_BASE_SECONDS**1]
+
+    def test_retries_5xx_and_transport_errors(self, monkeypatch):
+        releases = [_release("v1.0.0", 30)]
+        calls = self._patch_urlopen(
+            monkeypatch, [_http_error(503), urllib.error.URLError("reset"), releases]
+        )
+
+        got = ctc.fetch_releases("anchore/syft", sleep=lambda _: None)
+
+        assert got == releases and len(calls) == 3
+
+    def test_does_not_retry_a_404(self, monkeypatch):
+        """A renamed repo is a config bug — surface it instead of burning quota."""
+        calls = self._patch_urlopen(monkeypatch, [_http_error(404)])
+        slept: list[float] = []
+
+        with pytest.raises(urllib.error.HTTPError) as excinfo:
+            ctc.fetch_releases("gone/away", sleep=slept.append)
+
+        assert excinfo.value.code == 404
+        assert len(calls) == 1 and slept == []
+
+    def test_raises_the_last_error_once_attempts_run_out(self, monkeypatch):
+        calls = self._patch_urlopen(monkeypatch, [_http_error(403)] * 3)
+
+        with pytest.raises(urllib.error.HTTPError):
+            ctc.fetch_releases("aquasecurity/trivy", attempts=3, sleep=lambda _: None)
+
+        assert len(calls) == 3
+
+    def test_token_is_resolved_once_not_per_attempt(self, monkeypatch):
+        """_gh_token may shell out to `gh auth token`; keep it out of the loop."""
+        self._patch_urlopen(monkeypatch, [_http_error(403), _http_error(403), []])
+        token_calls: list[int] = []
+        monkeypatch.setattr(ctc, "_gh_token", lambda: (token_calls.append(1), "tok")[1])
+
+        ctc.fetch_releases("anchore/grype", sleep=lambda _: None)
+
+        assert len(token_calls) == 1
+
+
+class TestRetryDelay:
+    def test_honours_retry_after(self):
+        assert ctc._retry_delay(_http_error(403, retry_after="9"), 1) == 9.0
+
+    def test_falls_back_to_exponential_backoff(self):
+        assert ctc._retry_delay(_http_error(403), 1) == 2.0
+        assert ctc._retry_delay(_http_error(403), 3) == 8.0
+
+    def test_caps_the_wait(self):
+        assert ctc._retry_delay(_http_error(403, retry_after="99999"), 1) == (
+            ctc.MAX_BACKOFF_SECONDS
+        )
+        assert ctc._retry_delay(_http_error(403), 99) == ctc.MAX_BACKOFF_SECONDS
+
+    def test_ignores_a_junk_retry_after(self):
+        assert ctc._retry_delay(_http_error(403, retry_after="soon"), 1) == 2.0
+
+    def test_tolerates_an_error_with_no_headers(self):
+        assert ctc._retry_delay(OSError("reset"), 1) == 2.0
+
 
 class TestExitCodes:
     def _write(self, tmp_path, containers: str, dockerfile: str) -> list[str]:
@@ -218,8 +344,17 @@ class TestRender:
 
         assert "### Inconsistent pins (blocking)" in out
         assert "past the 7-day gate" in out
-        assert "### Not checked" in out
+        assert "Could not verify" in out
         assert "syft" in out and "tflint" in out and "zap" in out
+
+    def test_unverified_pins_are_not_presented_as_current(self):
+        """An unknown-only report used to read like a pass under "Not checked"."""
+        report = ctc.Report(unknown=[ctc.Finding("unknown", "checkov", "403")])
+
+        out = ctc.render(report, "markdown", 7)
+
+        assert "Nothing to do" not in out
+        assert "not as up to date" in out
 
     def test_markdown_says_so_when_clean(self):
         out = ctc.render(ctc.Report(), "markdown", 7)


### PR DESCRIPTION
## Description

The currency report filed for #382 listed **checkov and trivy as "Not checked"** with HTTP 403 while
both endpoints were healthy — they answer `200` even unauthenticated:

```
$ for r in bridgecrewio/checkov aquasecurity/trivy promptfoo/promptfoo; do
    curl -s -o /dev/null -w "$r -> %{http_code}\n" "https://api.github.com/repos/$r/releases/latest"
  done
bridgecrewio/checkov -> 200
aquasecurity/trivy   -> 200
promptfoo/promptfoo  -> 200
```

A single tripped secondary rate limit was enough to give up on a tool. Because the heading read
"Not checked" in a report whose other sections were empty, the run **looked like a pass** — while 2
of 11 tracked tools had not been compared to upstream at all. The job's whole purpose is noticing
stale pins, so a silent skip defeats it.

## Changes Made
- [x] Fixed bug
- [ ] Added new scanner/workflow
- [x] Modified existing scanner/workflow — `scripts/ci/check_tool_currency.py`
- [ ] Updated documentation
- [ ] Other

### Details

**`fetch_releases` now retries transient failures.** 403 and 429 (secondary rate limit), 5xx (load
shedding), transport errors, and a truncated body failing `json.load`. It honours `Retry-After` when
GitHub sends it — guessing shorter just trips the limit again — and otherwise backs off
exponentially with a 30s cap so a wedged upstream cannot stall the job.

**A 404 still raises on the first attempt.** That means a renamed or deleted repo. Retrying would
burn quota while hiding a config bug in `UPSTREAM_REPOS` that should be fixed in this file.
`HTTPError` subclasses `URLError` subclasses `OSError`, so it is caught first for the status check to
get a look at all.

Two supporting changes:

- `_gh_token()` is resolved once rather than per attempt. It can shell out to `gh auth token`, which
  has no business running inside a retry loop.
- The report section is renamed from `### Not checked` to
  `### Could not verify — currency UNKNOWN, not confirmed current`, and now states outright that
  these pins are unchecked rather than up to date. The old wording is what made the gap easy to miss.

No behaviour change to `--consistency-only`, the offline gate in `test-unit.yml`.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Integration tests added/updated
- [ ] Tested with different scanner combinations

### Test Results

12 new tests. `urlopen` is faked and `sleep` is injected, so nothing sleeps or hits the network:

```
tests/unit/test_check_tool_currency.py .................................  33 passed
tests/unit/                                                    427 passed, 5 skipped
```

Covering: retry-then-succeed on 403; retry on 5xx and transport errors; **no** retry on 404; raising
the last error once attempts run out; token resolved once not per attempt; `Retry-After` honoured,
capped, and junk values ignored; errors with no headers tolerated; and that an unknown-only report no
longer renders as "Nothing to do".

End to end against the live API — all 11 tools now resolve, including the two that 403'd:

```
$ python scripts/ci/check_tool_currency.py --format=markdown
## Scanner pin currency

### Behind upstream (past the 7-day gate)

- **promptfoo** — pinned 0.121.19, 0.122.0 available and 8d old (>= 7d gate) — promptfoo/promptfoo

$ python scripts/ci/check_tool_currency.py --consistency-only
All tracked pins current and consistent.   # exit 0
```

The "Could not verify" section is now absent entirely, and the one genuine finding — promptfoo
lagging — is the only thing reported. **That promptfoo bump is still outstanding and not part of this
PR.**

`ruff check` on both touched files reports the same 7 pre-existing findings as `main`; this PR adds
none.

## Security Considerations
- [x] Security enhancement
- [ ] No security impact
- [ ] Potential security implications

### Security Details

Indirect but real. This job is a backstop for Renovate on **scanner tool pins** — the versions of
trivy, grype, checkov and friends that Argus actually runs. Its stated reason for existing is that
`osv-scanner` sat 46 days behind and `tflint` 17 days behind while nothing in the repo noticed. A
check that silently drops tools on a transient 403 reintroduces exactly that blind spot, and trivy
and checkov are two of the highest-value pins to keep current.

No change to what is trusted or executed. Retry bounds are capped (3 attempts, 30s max wait) so this
cannot become a hang or a quota-exhaustion loop against the GitHub API.

## AI Context Updates (.ai/)
- [x] N/A — No `.ai/` updates needed. No component, command, or structural change; this fixes the
  reliability of an existing CI script.
- [ ] `.ai/architecture.yaml` updated
- [ ] `.ai/workflows.yaml` updated
- [ ] `.ai/decisions.yaml` updated
- [ ] `.ai/errors.yaml` updated

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (docstrings explain why each status is or is not retried)
- [ ] Changelog updated — handled by release-it
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

Refs #382
