### PR TITLE
chore(deps): bump the promptfoo image to 0.122.0

### DIFF
--- a/argus/containers.py
+++ b/argus/containers.py
@@ -47,7 +47,7 @@ OFFICIAL_IMAGES = {
     # API keys + network at scan time. Pinned to an immutable version tag
     # + digest (Renovate-managed), like every other image here — the
     # publisher's ``:latest`` is mutable and silently drifts.
-    "promptfoo": "ghcr.io/promptfoo/promptfoo:0.121.19@sha256:50d3a796710e4db7a5ede90bf27dc28146ef022a7ebb83914c5105608396fd96",
+    "promptfoo": "ghcr.io/promptfoo/promptfoo:0.122.0@sha256:53d9faa8813d9eecdc91a65dbb3dbdd87dd9e9aab9a9900c5a2cda3276909206",
     "hadolint": "hadolint/hadolint:v2.15.1@sha256:32dac94127fd60b7b7e3fbfc65e1383b9b5e25c9bfd7b8536de7a539fe68a12d",
     # lint-shell via shellcheck. The koalaman/shellcheck-alpine image is
     # the official multi-arch distribution (~3 MB). shellcheck is GPL-3.0


### PR DESCRIPTION
## Description

Bumps the promptfoo scanner image from `0.121.19` to `0.122.0`. This is the one real finding left in
#382 after the retry fix (#401) got the currency check reading all eleven tools again.

## Changes Made
- [x] Modified existing scanner/workflow — the `promptfoo` pin in `argus/containers.py`
- [ ] Added new scanner/workflow
- [ ] Updated documentation
- [ ] Fixed bug
- [ ] Other

### Details

One line. `argus/containers.py` is the only pin site — promptfoo is not in `DUAL_PINNED`, so there is
no `ARG PROMPTFOO_VERSION` in `Dockerfile.cli` to keep in sync.

**Why this is being landed by hand instead of by Renovate.** Renovate already has the bump staged on
`renovate/container-images`, and the dashboard (#200) lists it under "awaiting pending status checks".
It cannot land, because the group holds every member until the *youngest* clears the 7-day gate:

| Group member | Version | Age | Adoptable? |
|---|---|---|---|
| **promptfoo** | **0.122.0** | **8d** | **yes** |
| osv-scanner | v2.5.0 | 6d | no |
| syft | v1.51.0 | 3d | no |
| grype | v0.117.0 | 2d | no |

grype and syft release frequently, so the group's clock keeps resetting and an already-adoptable
member can lag indefinitely. That is exactly the pattern `check_tool_currency.py` was written to
catch — its own docstring cites `osv-scanner` at 46 days behind and `tflint` at 17. Landing this one
directly lets Renovate rebase and keep the other three queued until they age in.

**No issue filed.** It is already tracked in two places: #382 (the currency report) and #200
(Renovate's dashboard). A third would be noise.

## Testing
- [x] Manual testing performed
- [ ] Unit tests added/updated (a pin change; existing tests cover the scanner and the pin format)
- [ ] Integration tests added/updated
- [ ] Tested with different scanner combinations

### Test Results

**Digest resolved from the registry**, not copied out of the report:

```
0.121.19 -> sha256:50d3a796710e4db7a5ede90bf27dc28146ef022a7ebb83914c5105608396fd96   (matches the old pin)
0.122.0  -> sha256:53d9faa8813d9eecdc91a65dbb3dbdd87dd9e9aab9a9900c5a2cda3276909206   (this PR)
```

**The one breaking change in 0.122.0 does not reach us.** Release notes say "drop Node.js 20
support". Irrelevant here — the image ships its own runtime, and it is Node v24.19.0:

```
$ docker run --rm --entrypoint promptfoo <new digest> --version   ->  0.122.0
$ docker run --rm --entrypoint node     <new digest> --version   ->  v24.19.0
```

**The CLI contract the scanner depends on is unchanged.** `_build_promptfoo_args` emits exactly three
flags, and `eval --help` on the new image still documents all three: `-c, --config`, `-o, --output`,
`--no-progress-bar`. The `container_entrypoint = "promptfoo"` override is still required and still
works.

**Output schema verified by running a real eval, not by trusting the changelog.** promptfoo's `echo`
provider needs no API keys, so the new image could be exercised end to end and its output fed to this
repo's own parser:

```
$ docker run ... <new digest> eval -c /promptfooconfig.yaml -o /output/results.json --no-progress-bar
  ✓ 1 passed (50.00%)   ✗ 1 failed (50.00%)

$ python -c "PromptfooScanner().parse_results(Path('results.json'))"
  parse_results returned 1 finding(s), no exception
   - severity=medium title='LLM eval assertion failed'
```

Schema shape intact: top-level `results.results` list, per-record `gradingResult`, and
`componentResults` as a list. The one failing assertion became one MEDIUM finding; the passing one
correctly produced nothing.

**Repo checks:**

```
$ python scripts/ci/check_tool_currency.py --consistency-only
All tracked pins current and consistent.                  # exit 0

$ python scripts/ci/check_tool_currency.py --format=markdown
Every tracked pin is current. Nothing to do.              # was: promptfoo behind

$ python scripts/ci/check_container_images.py --tolerate-registry-errors
✅ promptfoo   ghcr.io/promptfoo/promptfoo:0.122.0@sha256:53d9faa...    # exit 0

$ pytest argus/tests/scanners/test_promptfoo.py argus/tests/test_containers.py
79 passed
```

## Security Considerations
- [x] Security enhancement
- [ ] No security impact
- [ ] Potential security implications

### Security Details

0.122.0 is largely a dependency-security release for promptfoo itself — patches for `undici`,
`socket.io-parser`, and XML entity handling, plus updated Anthropic and OpenTelemetry packages. Those
land inside the scanner image we execute, so keeping the pin current is the point.

Exposure is inherently narrow: promptfoo is an **opt-in** scanner that only runs when a user supplies
provider API keys and grants network access at scan time. The pin remains an immutable
`version@sha256:digest` ref, so this changes which digest we execute, not how it is trusted.

## AI Context Updates (.ai/)
- [x] N/A — No `.ai/` updates needed. A version pin, not a component, command, or structural change.
- [ ] `.ai/architecture.yaml` updated
- [ ] `.ai/workflows.yaml` updated
- [ ] `.ai/decisions.yaml` updated
- [ ] `.ai/errors.yaml` updated

## Checklist
- [x] Code follows project style guidelines
- [ ] Documentation updated — N/A, no version numbers in `docs/scanners.md` for this image
- [ ] Changelog updated — handled by release-it
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

### Worth a separate look

The grouping behaviour above is structural, not a one-off: any fast-releasing member of
`container-images` can hold an adoptable sibling back indefinitely, and the backstop will keep filing
it. Options are to split the fast movers into their own group, or drop the grouping for images and
accept more PRs. That is a noise-versus-latency policy call, so I have not touched
`.github/renovate.json` here.

Refs #382
