### PR TITLE
fix(containers): refresh clamav 1.5.4 digest after upstream tag re-push

### DIFF
--- a/.ai/errors.yaml
+++ b/.ai/errors.yaml
@@ -872,21 +872,36 @@ errors:
       it. clamav/clamav:1.5.3 is rebuilt by Cisco''s bot to refresh the bundled
       virus database, which replaces the digest behind an unchanged tag. Our pin
       is <tag>@sha256:<digest> — correct posture, and exactly what makes the
-      drift visible — but the old digest stops resolving the moment it is
-      superseded. Renovate does re-pin digests via the containers.py custom
-      manager, however it is scheduled "before 9am on Monday", so drift landing
-      any other day leaves main red for up to a week.
+      drift visible.
+
+      The old digest does NOT stop resolving: registry storage is content
+      addressed, so fetching the superseded manifest BY DIGEST still returns
+      200 long after the tag has moved. What breaks is the combined
+      <tag>@<digest> reference — docker resolves the tag, then verifies the
+      result against the pinned digest, and the two now disagree. Hence
+      "manifest verification failed for digest", not "manifest unknown".
+
+      Renovate does re-pin digests via the containers.py custom manager
+      (.github/renovate.json customManagers[0], group container-images), and it
+      is scheduled every weekday morning — but minimumReleaseAge is 7 days, so
+      it will not propose a digest until the re-push is a week old, and the
+      group sets automerge:false. That cooldown, not the schedule, is why a
+      re-push can leave main red for up to a week.
 
       '
     solution:
       steps:
-      - 'Resolve the live digest: docker buildx imagetools inspect <image>:<tag> (or docker manifest inspect) and read the index Digest.'
+      - 'Resolve the live digest: docker buildx imagetools inspect <image>:<tag> (or docker manifest inspect) and read the index Digest. With no docker daemon available, GET the registry manifest with an anonymous token and read the docker-content-digest response header.'
       - 'Cross-check provenance before trusting it — do not just take whatever the registry now serves. For Docker Hub: curl -s https://hub.docker.com/v2/repositories/<ns>/<repo>/tags/<tag> and confirm digest, last_updated, and last_updater_username look like the vendor''s normal release path.'
       - Re-pin in argus/containers.py, then run python -m scripts.ci.check_container_images and require "All images resolve" across the whole manifest, not just the one you touched.
-      note: 'A digest that stops resolving is indistinguishable at the registry
-        from a yanked-for-compromise image, so confirm the pusher before
-        bumping. Treating the re-pin as routine housekeeping is how a poisoned
-        re-push would get waved through.
+      note: 'Still confirm the pusher before bumping — a moved tag is exactly
+        what a supply-chain attack would also look like, and treating the
+        re-pin as routine housekeeping is how a poisoned re-push gets waved
+        through. But note the superseded image is still addressable by its old
+        digest, so you can inspect both and diff them (platforms, entry count,
+        media type, layer digests) rather than reasoning from absence. A
+        vendor rebuild and a hostile re-push differ in what the new manifest
+        CONTAINS, not in whether the old one is reachable.
 
         '
       reference: argus/containers.py + scripts/ci/check_container_images.py + .github/renovate.json (customManagers, container-images group)

--- a/argus/containers.py
+++ b/argus/containers.py
@@ -30,7 +30,7 @@ OFFICIAL_IMAGES = {
     "grype": "anchore/grype:v0.117.0@sha256:ddf9e9f204049f3a4a0955ef70873cabab6a31432125ad4f20a490b54950a253",
     "syft": "anchore/syft:v1.51.0@sha256:678bfa565b60f747aac0f8e964fe5588a24445b8d0a480e91f6efd70020dfbb0",
     "gitleaks": "zricethezav/gitleaks:v8.30.1@sha256:c00b6bd0aeb3071cbcb79009cb16a60dd9e0a7c60e2be9ab65d25e6bc8abbb7f",
-    "clamav": "clamav/clamav:1.5.4@sha256:78810772a92b4a9168115bc6b2e0ffd702640893b9577f8c3d0432762d2655c4",
+    "clamav": "clamav/clamav:1.5.4@sha256:0e85467cb0d6e7d860a45035707741cd5ffc032ffefc6002a3510c75b6d07027",
     "checkov": "bridgecrew/checkov:3.3.9@sha256:12a62da01af22654883aee3b9da18ba4297f123f5122663bf65235db37934144",
     # KICS (Checkmarx) multi-format IaC scanner. The upstream
     # ``checkmarx/kics`` repo tags ``:latest`` mutably (no semver release


### PR DESCRIPTION
## Description

`Unit Tests (Python 3.13)` is failing on **every open PR** — and would abort the
next release — because the pinned `clamav` digest no longer matches its tag.

```
Checking 21 container image manifest(s)...
  ❌ clamav   clamav/clamav:1.5.4@sha256:78810772a92b4a9168115bc6b2e0ffd702640893b9577f8c3d0432762d2655c4
     manifest verification failed for digest sha256:78810772a92b4a9168115bc6b2e0ffd702640893b9577f8c3d0432762d2655c4
1 image(s) failed manifest check
```

20 of 21 images resolve. No commit caused this — Cisco's bot re-pushed the
`1.5.4` tag upstream to refresh the bundled virus database.

This is the failure mode already catalogued in `.ai/errors.yaml` as
`MANIFEST_VERIFICATION_FAILED_FOR_DIGEST_THIRD_PARTY_TAG_REPUSHED_UNDER_US`, and
the same situation as #387 (`fix(zap): refresh 2.17.0 image digest after upstream
tag re-push`).

### What is actually broken

Our pin is `<tag>@sha256:<digest>` — the correct posture, and precisely what makes
this drift visible instead of silently pulling different bytes.

The old digest has **not** been yanked. Registry storage is content addressed, so
the superseded manifest still resolves when fetched **by digest**. What breaks is
the *combined* reference: `docker manifest inspect` resolves the tag, then
verifies the result against the pinned digest, and the two now disagree. That is
why the error is `manifest verification failed for digest` and not
`manifest unknown`.

| | pinned `sha256:78810772…` | live `sha256:0e85467c…` |
|---|---|---|
| Fetch by digest | HTTP 200 | HTTP 200 |
| `mediaType` | `application/vnd.oci.image.index.v1+json` | `application/vnd.oci.image.index.v1+json` |
| Platforms | `linux/amd64` | `linux/amd64` |
| Index entries | 2 | 2 |

### Provenance check — done before bumping, not after

`.ai/errors.yaml` is right that a moved tag is also what a supply-chain attack
looks like, so this was verified rather than waved through:

- **Live digest**, from the registry's `docker-content-digest` header for tag
  `1.5.4`: `sha256:0e85467cb0d6e7d860a45035707741cd5ffc032ffefc6002a3510c75b6d07027`
- **Docker Hub metadata**: `last_updated 2026-08-24T01:46:05Z`,
  `last_updater_username: clambotgen84202` — the vendor's normal automated
  release path for virus-DB refreshes.
- **Shape comparison**: old and new manifests are both OCI image indexes with
  identical structure (see table above). Consistent with a routine rebuild, not
  a substituted image.

Because the old image is still addressable, this could be diffed directly rather
than inferred from absence.

## Changes Made
- [x] Fixed bug
- [x] Updated documentation

### Details

**`argus/containers.py`** — one line, `clamav` re-pinned from `sha256:78810772…`
to `sha256:0e85467c…`. The tag (`1.5.4`) is unchanged; this is a digest refresh,
not a version bump. The old digest appears nowhere else in the repo.

**`.ai/errors.yaml`** — corrects two claims in the existing entry that the
registry contradicts, so the next person to hit this is not sent down the wrong
path:

1. *"the old digest stops resolving the moment it is superseded"* — it does not,
   as shown above. Replaced with the actual tag-vs-digest mechanism, including why
   the error reads `manifest verification failed` rather than `manifest unknown`.
2. *"it is scheduled 'before 9am on Monday'"* — `.github/renovate.json` schedules
   `after 6am and before 9am every weekday`. The week-long red window is caused by
   **`minimumReleaseAge: 7 days`** (plus `automerge: false` on the
   `container-images` group), not by the schedule. Corrected, since someone
   waiting for a Monday that already passed would wait a long time.

Also added a docker-free way to resolve the live digest to the remediation steps
(anonymous registry token + read the `docker-content-digest` header), since the
existing steps assume a working daemon.

The provenance warning is kept — sharpened, not softened: a vendor rebuild and a
hostile re-push differ in what the new manifest *contains*, not in whether the old
one is reachable.

## Testing
- [x] Manual testing performed

### Test Results

Full suite locally: **4184 passed, 142 skipped**, coverage **89.39%** (threshold 80%).
`tests/unit/test_check_container_images.py` and `argus/tests/test_containers.py`:
43 passed.

Digest verification was done against the Docker Hub registry API directly (see the
table above) because no Docker daemon was available locally. **CI runs the real
`docker manifest inspect` check**, so the authoritative signal is
`Check container image manifests` on this PR reporting `All images resolve` across
all 21 images — not just the one line touched. That is step 3 of the documented
remediation, and it is the thing to confirm before merging.

## Security Considerations
- [x] Potential security implications (explain below)

### Security Details

This changes which image bytes every `argus scan clamav` run pulls, for every SDK
user, so it is a supply-chain change and is deliberately isolated in its own PR
rather than folded into unrelated work.

Mitigating factors, all verified above: the tag is unchanged, the pusher is the
vendor's own bot on its normal release path, the timestamp matches a routine
virus-DB refresh, and old and new manifests have identical structure. The
superseded image remains addressable for comparison.

Reviewers should independently confirm the live digest before approving rather
than taking the value in this diff on trust.

## AI Context Updates (.ai/)
- [x] `.ai/errors.yaml` updated (two factual corrections + a docker-free
      remediation step)
- [x] `.ai/architecture.yaml`, `.ai/workflows.yaml`, `.ai/decisions.yaml`,
      `.ai/context.yaml` — confirmed not needed (no structural, command, or design
      change)

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated
- [x] All tests pass
- [ ] Reviewed by at least one maintainer

## Why not just wait for Renovate

`.github/renovate.json` does manage this pin — `customManagers[0]` regexes
`argus/containers.py`, group `container-images`, `pinDigests: true`. But:

- `minimumReleaseAge: 7 days` means Renovate will not propose the new digest until
  roughly **2026-08-31**;
- `automerge: false` on that group means a human merge is required even then;
- the open container-images PR **#406** was last updated 2026-08-21, *before* the
  re-push, and bumps only trivy and checkov — **it does not contain this fix**.

So nothing currently queued resolves it, and CI stays red for about a week
meanwhile.

## Impact

Unblocks the `Unit Tests (Python 3.13)` leg on all open PRs — #409, #406, #407,
#408, #383, #366, #254 — and clears the release gate at `release.yml:376`, which
runs this same check **without** `--tolerate-registry-errors` and hard-fails
before building the wheel and publishing to PyPI.

Version strings are untouched; this is a digest refresh only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
