### PR TITLE
chore(deps): update trivy 0.74.0, opengrep 1.27.1, checkov 3.3.11 as one consistent set

### DIFF
--- a/argus/containers.py
+++ b/argus/containers.py
@@ -26,12 +26,12 @@ from pathlib import Path
 # release, Renovate rewrites BOTH the version segment and the digest
 # segment in a single PR.
 OFFICIAL_IMAGES = {
-    "trivy": "aquasec/trivy:0.73.0@sha256:7cced7cae583819fc7806d4cbc0dbbc7cad18b99f7d3e235192e6da8c091045c",
+    "trivy": "aquasec/trivy:0.74.0@sha256:62b1e65e8869bc4b4c6aa4fa2b21595256c7c2f6018a9d9ad61caf87187c1969",
     "grype": "anchore/grype:v0.117.0@sha256:ddf9e9f204049f3a4a0955ef70873cabab6a31432125ad4f20a490b54950a253",
     "syft": "anchore/syft:v1.51.0@sha256:678bfa565b60f747aac0f8e964fe5588a24445b8d0a480e91f6efd70020dfbb0",
     "gitleaks": "zricethezav/gitleaks:v8.30.1@sha256:c00b6bd0aeb3071cbcb79009cb16a60dd9e0a7c60e2be9ab65d25e6bc8abbb7f",
     "clamav": "clamav/clamav:1.5.4@sha256:0e85467cb0d6e7d860a45035707741cd5ffc032ffefc6002a3510c75b6d07027",
-    "checkov": "bridgecrew/checkov:3.3.9@sha256:12a62da01af22654883aee3b9da18ba4297f123f5122663bf65235db37934144",
+    "checkov": "bridgecrew/checkov:3.3.11@sha256:e5e308e713725e73f517e4cb85b39d467f1e047204c174fb15eb444c27ffb745",
     # KICS (Checkmarx) multi-format IaC scanner. The upstream
     # ``checkmarx/kics`` repo tags ``:latest`` mutably (no semver release
     # tag per build), so the digest pin below is the content-hash gate

--- a/docker/Dockerfile.cli
+++ b/docker/Dockerfile.cli
@@ -8,12 +8,12 @@
 # ---------------------------------------------------------------------------
 FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b AS builder
 
-ARG TRIVY_VERSION=0.73.0
+ARG TRIVY_VERSION=0.74.0
 ARG GRYPE_VERSION=0.117.0
 ARG SYFT_VERSION=1.51.0
 ARG GITLEAKS_VERSION=8.30.1
 ARG ACTIONLINT_VERSION=1.7.12
-ARG OPENGREP_VERSION=1.26.0
+ARG OPENGREP_VERSION=1.27.1
 ARG TARGETARCH
 
 RUN apk add --no-cache curl tar

--- a/docker/Dockerfile.opengrep
+++ b/docker/Dockerfile.opengrep
@@ -1,6 +1,6 @@
 FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b AS builder
 
-ARG OPENGREP_VERSION=1.26.0
+ARG OPENGREP_VERSION=1.27.1
 ARG TARGETARCH
 
 # Fetch to a temp file with retries (transient GitHub 5xx/timeout/conn-reset are


### PR DESCRIPTION
## Description

Renovate split a single `trivy` version bump across two PRs, and the
`check_tool_currency.py --consistency-only` gate fails on either half alone.
This PR combines both halves so the gate passes, superseding #406 and #407.

`trivy` is pinned in two places, by design:

| Location | Purpose |
|---|---|
| `OFFICIAL_IMAGES` in `argus/containers.py` | the container-fallback path |
| `ARG TRIVY_VERSION` in `docker/Dockerfile.cli` | baked into the CLI image |

Renovate updates those through two separate groups (`container-images` and
`tool-versions`), so one can land without the other — and a scan would then get
a different trivy version depending on which path it took. That is exactly what
`--consistency-only` exists to catch, and it did:

```
MISMATCH  trivy: containers.py pins 0.74.0 but Dockerfile.cli pins ARG TRIVY_VERSION=0.73.0
```

#406 (`container-images`) carried the `containers.py` half. #407 (`tool-versions`)
carried the `Dockerfile.cli` half. Each was red on `Unit Tests (Python 3.13)` on
its own and neither could merge first.

## Changes Made
- [x] Other (please specify)

Dependency pin updates only — no source or behaviour changes.

### Details

Rebased #407's branch onto current `main` (which now carries the clamav digest
refresh from #410) and folded #406's `containers.py` half on top:

| Tool | From | To | Pinned in |
|---|---|---|---|
| trivy | 0.73.0 | 0.74.0 | `containers.py` **and** `Dockerfile.cli` (dual) |
| opengrep | 1.26.0 | 1.27.1 | `Dockerfile.cli`, `Dockerfile.opengrep` |
| checkov | 3.3.9 | 3.3.11 | `containers.py` only |

`checkov` and `opengrep` are not dual-pinned; they ride along from the same
Renovate groups. `DUAL_PINNED` in `scripts/ci/check_tool_currency.py` is
`trivy`, `grype`, `syft`, `gitleaks` — only trivy moved here.

No breaking changes. No version strings touched.

## Testing
- [x] Manual testing performed

### Test Results

The gate that was failing now passes on this branch:

```
$ python3 scripts/ci/check_tool_currency.py --consistency-only
All tracked pins current and consistent.
exit=0
```

`pre-commit run --files argus/containers.py` — all hooks pass. CI on this PR is
the authoritative signal, in particular `Unit Tests (Python 3.13)`, which is the
leg that was red on both #406 and #407.

## Security Considerations
- [x] Potential security implications (explain below)

### Security Details

This changes which image bytes `argus scan` pulls for trivy and checkov, so it is
a supply-chain change. Both digests were verified against the registry **before**
adoption rather than taken on trust from the Renovate diff:

| Image | Pinned digest | Live `docker-content-digest` | Pushed | Pusher |
|---|---|---|---|---|
| `aquasec/trivy:0.74.0` | `sha256:62b1e65e…` | matches | 2026-08-14 | `aquasec` |
| `bridgecrew/checkov:3.3.11` | `sha256:e5e308e7…` | matches | 2026-08-13 | `saarett` |

`saarett` is the pusher on every recent `bridgecrew/checkov` tag (3.3.10, 3.3.11,
3.3.12, 3.3.13, `latest`), and `aquasec` is the vendor's own account — both are
the normal release path, not an anomaly.

Note `checkov` is already at 3.3.13 upstream, but `minimumReleaseAge: 7 days`
makes 3.3.11 (2026-08-13) the newest adoptable version as of today. The pin is
correct under the repo's own supply-chain policy rather than merely current.

Reviewers should confirm the live digests independently rather than trusting the
table above.

## AI Context Updates (.ai/)
- [x] N/A - No .ai/ updates needed

Dependency pin bumps only — no components, commands, design decisions, or new
error patterns. The dual-pin split failure mode is already documented in
`scripts/ci/check_tool_currency.py`'s module docstring.

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (if applicable) — n/a
- [x] Changelog updated (if applicable) — n/a, release tooling owns this
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues

Supersedes #406 and #407 — both should be closed in favour of this PR. Renovate
will not re-open them while these versions are pinned.
