### PR TITLE
chore(deps): bump osv-scanner to v2.5.1

### DIFF
--- a/argus/containers.py
+++ b/argus/containers.py
@@ -38,7 +38,7 @@ OFFICIAL_IMAGES = {
     # that protects us between Renovate-driven bumps — same pattern as
     # the eslint entry.
     "kics": "checkmarx/kics:latest@sha256:3e5a268eb8adda2e5a483c9359ddfc4cd520ab856a7076dc0b1d8784a37e2602",
-    "osv-scanner": "ghcr.io/google/osv-scanner:v2.4.0@sha256:5116601dedc01c1c580eb92371883ec052fc4c13c3fbc109d621a63ac416d475",
+    "osv-scanner": "ghcr.io/google/osv-scanner:v2.5.1@sha256:8108ae94eadea5a02c9bec6e646909d5b790b44bd62d7f5b7f0b1d6d0ffc7734",
     # Upstream re-pushed the 2.17.0 tag (2026-08); the old index digest
     # no longer verifies against the registry. Pin refreshed to the
     # tag's current index digest, verified via `docker manifest inspect`.


### PR DESCRIPTION
## Description

Bumps the `osv-scanner` container pin from `v2.4.0` to `v2.5.1`. Our own
`tool-currency.yml` backstop has been flagging this since 2026-08-05 in #382,
and Renovate has not landed it in over two months.

```
STALE  osv-scanner: pinned v2.4.0, v2.5.1 available and 8d old (>= 7d gate) — google/osv-scanner
```

`v2.4.0` shipped 2026-06-18. `v2.5.1` shipped 2026-08-17, so it is well past the
`minimumReleaseAge: 7 days` supply-chain gate.

**This bump was tested rather than assumed.** `v2.5.0` is not a routine patch: it
migrated scanning, filtering and matching to the `osv-scalibr` pipeline
end-to-end and changed PURL type resolution in the `osvscannerjson` extractor.
A version change here has broken our parsing before (#95, "osv-scanner v2
compatibility"), and because `argus/scanners/osv.py` reads its JSON entirely
through `.get()` with defaults, a shape change would **not** raise. It would
silently yield zero findings, which in a vulnerability scanner is a false
negative rather than a crash. So the output was diffed directly instead of
trusting the release notes.

## Changes Made
- [x] Other (please specify)

One-line container pin update. No source changes.

### Details

`argus/containers.py` only — `osv-scanner` is single-pinned (it is not in
`DUAL_PINNED`, so there is no `Dockerfile.cli` counterpart to keep in step):

```
- ghcr.io/google/osv-scanner:v2.4.0@sha256:5116601d...
+ ghcr.io/google/osv-scanner:v2.5.1@sha256:8108ae94...
```

No other reference to `v2.4.0` exists in the repo. Bundled `osv-scalibr` moves
0.4.5 → 0.5.2.

## Testing
- [x] Manual testing performed

### Test Results

Both images were run against an identical multi-ecosystem corpus of
known-vulnerable pinned packages (PyPI: flask 0.12.2, django 2.2.0, pyyaml 5.1,
requests 2.19.1, jinja2 2.10, werkzeug 0.11.11 / npm: lodash 4.17.11, minimist
1.2.0 / Go: gopkg.in/yaml.v2 2.2.2), using the exact argv
`argus/scanners/osv.py` builds.

| Check | v2.4.0 | v2.5.1 | Result |
|---|---|---|---|
| Source mode raw JSON | 1,285,272 B | 1,285,272 B | **byte-identical** |
| SBOM mode raw JSON (`-L`, CycloneDX) | 1,116,642 B | 1,116,642 B | **byte-identical** |
| Sources / packages / vulns | 4 / 11 / 169 | 4 / 11 / 169 | same |
| Ecosystems detected | Go, PyPI, npm | Go, PyPI, npm | same |
| Findings via `OsvScanner.parse_results()` | 169 | 169 | **byte-identical** |
| Severity split | C11 H33 M43 L6 U76 | C11 H33 M43 L6 U76 | same |
| Image `Entrypoint` | `[/osv-scanner]` | `[/osv-scanner]` | unchanged |
| `--version` format | `osv-scanner version: 2.4.0` | `osv-scanner version: 2.5.1` | unchanged |

Both scanner code paths are covered: source mode (`scan source --recursive`) and
SBOM mode (`scan -L <sbom>`), the latter against a real CycloneDX SBOM generated
by our pinned syft. The SBOM path is the one #95 had to fix, so it was tested
explicitly rather than by inference.

The `tool_version()` regex `v?(\d+\.\d+(?:\.\d+)?[\w.-]*)` still extracts
`2.5.1` correctly, which matters because the engine raises on a tool-version
mismatch by default.

Repo checks:

```
python3 scripts/ci/check_tool_currency.py --consistency-only
  -> All tracked pins current and consistent.

python3 -m scripts.ci.check_container_images
  -> All images resolve.   (21/21, including the new osv-scanner digest)

python3 scripts/ci/check_tool_currency.py
  -> the osv-scanner STALE line is gone
```

Full suite green. `argus/tests/scanners/test_osv.py`, `test_containers.py` and
`tests/unit/test_check_container_images.py`: 65 passed.

## Security Considerations
- [x] Security enhancement

### Security Details

This moves every `argus scan osv` run onto two months of upstream vulnerability
matching fixes, including one that is a direct false-negative class: v2.5.0
fixed osv-scanner reporting already-fixed advisories as unfixed for RHEL-family
RPM packages with epochs, and v2.5.1 fixed package namespaces being dropped when
querying the osv.dev API. Running two months behind on a vulnerability scanner
is itself the risk being closed here.

Digest verified against the registry before adoption rather than taken from the
diff:

```
ghcr.io/google/osv-scanner:v2.5.1
  live docker-content-digest: sha256:8108ae94eadea5a02c9bec6e646909d5b790b44bd62d7f5b7f0b1d6d0ffc7734
  matches the digest pinned here
```

As a control, the same method resolved `v2.4.0` to `sha256:5116601d...`, which
matches the digest already on `main` — confirming the resolution method rather
than just asserting the new value.

Reviewers should confirm the live digest independently.

## AI Context Updates (.ai/)
- [x] N/A - No .ai/ updates needed

A pin bump changes no component, command, or design decision, and `.ai/` does not
record per-tool versions or digests.

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (if applicable) — n/a
- [x] Changelog updated (if applicable) — n/a, release tooling owns this
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues

Addresses the `osv-scanner` entry in #382 (Scanner pin currency report).
