### PR TITLE
fix(ci): only report a pin stale when upstream is actually newer

### DIFF
--- a/scripts/ci/check_tool_currency.py
+++ b/scripts/ci/check_tool_currency.py
@@ -15,8 +15,10 @@ Two independent checks:
 ``currency``
     Compares each pin against the newest upstream release that is already
     older than ``--min-age-days``, i.e. one we are allowed to adopt under the
-    supply-chain policy in ``.github/renovate.json``. Needs the network and
-    depends on upstream release cadence, so by default it reports without
+    supply-chain policy in ``.github/renovate.json``. Reports only when that
+    release is strictly NEWER than the pin — a pin sitting ahead of it is
+    normal (see ``is_newer``), not something to "update". Needs the network
+    and depends on upstream release cadence, so by default it reports without
     failing — a tool releasing upstream is not a reason to redden ``main``.
 
 Why this exists: ``osv-scanner`` sat 46 days behind and ``tflint`` 17 days
@@ -116,6 +118,37 @@ class Report:
 def normalise(version: str) -> str:
     """Strip a leading ``v`` so ``v1.2.3`` and ``1.2.3`` compare equal."""
     return version[1:] if version.startswith("v") else version
+
+
+def is_newer(candidate: str, pinned: str) -> bool | None:
+    """Is ``candidate`` a real upgrade over ``pinned``?
+
+    ``True`` / ``False`` for an orderable pair, ``None`` when the two
+    cannot be ordered at all (a non-semver tag like ``latest``, or a
+    missing ``packaging``).
+
+    Ordering matters here, not inequality. Our pin routinely sits AHEAD
+    of the newest *eligible* upstream release for two ordinary reasons:
+    ``newest_eligible`` skips anything inside the cooling window, and some
+    publishers ship Docker tags with no matching GitHub release at all
+    (``bridgecrew/checkov`` 3.3.10 and 3.3.11). Treating "differs" as
+    "behind" turned both into a STALE line advising a DOWNGRADE — e.g.
+    "pinned 3.3.11, 3.3.9 available". Same wrong-direction bug that
+    ``argus/update_check.py`` fixed at issue #174-1.1.c.
+
+    Note string comparison is not a shortcut here: ``"3.3.9" > "3.3.11"``
+    is True lexicographically and False numerically.
+    """
+    try:
+        from packaging.version import InvalidVersion, parse
+    except ImportError:
+        # Declared in pyproject.toml [project].dependencies; only an
+        # exotic env reaches this. Report unknown rather than guess.
+        return None
+    try:
+        return parse(normalise(candidate)) > parse(normalise(pinned))
+    except InvalidVersion:
+        return None
 
 
 def parse_images(source: str) -> dict[str, str]:
@@ -276,7 +309,8 @@ def check_currency(
         if eligible is None:
             continue
         tag, age = eligible
-        if normalise(tag) != normalise(pinned):
+        newer = is_newer(tag, pinned)
+        if newer:
             stale.append(
                 Finding(
                     "stale",
@@ -285,6 +319,18 @@ def check_currency(
                     f"(>= {min_age_days}d gate) — {repo}",
                 )
             )
+        elif newer is None and normalise(tag) != normalise(pinned):
+            unknown.append(
+                Finding(
+                    "unknown",
+                    key,
+                    f"pinned {pinned}, newest eligible upstream is {tag} — "
+                    f"versions not comparable, currency unverified — {repo}",
+                )
+            )
+        # newer is False: the pin is at or ahead of the newest release we
+        # are allowed to adopt. Not stale, and not worth a line — see
+        # is_newer() for why being ahead is the normal case.
     return stale, unknown
 
 

--- a/tests/unit/test_check_tool_currency.py
+++ b/tests/unit/test_check_tool_currency.py
@@ -359,3 +359,93 @@ class TestRender:
     def test_markdown_says_so_when_clean(self):
         out = ctc.render(ctc.Report(), "markdown", 7)
         assert "Nothing to do" in out
+
+
+class TestIsNewer:
+    """Ordering, not inequality.
+
+    ``check_currency`` used to flag a pin whenever the newest eligible
+    upstream tag merely *differed* from it, which reports a DOWNGRADE as
+    an update whenever the pin is ahead of that tag. Same wrong-direction
+    bug ``argus/update_check.py`` documents at issue #174-1.1.c.
+    """
+
+    def test_newer_upstream_is_newer(self):
+        assert ctc.is_newer("3.3.13", "3.3.11") is True
+
+    def test_older_upstream_is_not_newer(self):
+        assert ctc.is_newer("3.3.9", "3.3.11") is False
+
+    def test_equal_is_not_newer(self):
+        assert ctc.is_newer("3.3.11", "3.3.11") is False
+
+    def test_v_prefix_does_not_affect_ordering(self):
+        assert ctc.is_newer("v1.51.0", "1.50.0") is True
+        assert ctc.is_newer("v1.50.0", "1.50.0") is False
+
+    def test_double_digit_segments_compare_numerically(self):
+        """String comparison would put 3.3.9 above 3.3.11."""
+        assert ctc.is_newer("3.3.9", "3.3.11") is False
+        assert ctc.is_newer("3.3.11", "3.3.9") is True
+
+    def test_unorderable_versions_return_none(self):
+        assert ctc.is_newer("stable", "1.2.3") is None
+        assert ctc.is_newer("1.2.3", "latest") is None
+
+
+class TestCurrencyDirection:
+    """The checkov false positive, and the guard against re-introducing it.
+
+    ``bridgecrew/checkov`` publishes some Docker tags (3.3.10, 3.3.11) with
+    no matching GitHub release, and ``newest_eligible`` additionally skips
+    anything inside the cooling window. Both make it normal for our pin to
+    sit AHEAD of the newest eligible release. Reporting that as STALE told
+    a reader to "update" 3.3.11 to 3.3.9.
+    """
+
+    def test_pin_ahead_of_newest_eligible_is_not_stale(self, monkeypatch):
+        monkeypatch.setattr(ctc, "UPSTREAM_REPOS", {"checkov": "bridgecrewio/checkov"})
+        monkeypatch.setattr(
+            ctc,
+            "fetch_releases",
+            # 3.3.13/3.3.12 are inside the cooling window; 3.3.10 and 3.3.11
+            # are Docker-only tags and have no release at all.
+            lambda repo: [_release("3.3.13", 1), _release("3.3.12", 2), _release("3.3.9", 23)],
+        )
+
+        stale, unknown = ctc.check_currency({"checkov": "3.3.11"}, 7, NOW)
+
+        assert stale == [], f"pin ahead of upstream reported as stale: {stale}"
+        assert unknown == []
+
+    def test_genuinely_behind_pin_is_still_reported(self, monkeypatch):
+        """The guard must not silence the case the checker exists for."""
+        monkeypatch.setattr(ctc, "UPSTREAM_REPOS", {"osv-scanner": "google/osv-scanner"})
+        monkeypatch.setattr(
+            ctc, "fetch_releases", lambda repo: [_release("v2.5.1", 8), _release("v2.4.0", 60)]
+        )
+
+        stale, unknown = ctc.check_currency({"osv-scanner": "v2.4.0"}, 7, NOW)
+
+        assert [f.tool for f in stale] == ["osv-scanner"]
+        assert "v2.5.1" in stale[0].detail
+        assert unknown == []
+
+    def test_unorderable_pair_is_unknown_not_stale(self, monkeypatch):
+        """Can't order them -> say so. Don't assert a direction we don't have."""
+        monkeypatch.setattr(ctc, "UPSTREAM_REPOS", {"kics": "Checkmarx/kics"})
+        monkeypatch.setattr(ctc, "fetch_releases", lambda repo: [_release("stable", 30)])
+
+        stale, unknown = ctc.check_currency({"kics": "1.7.13"}, 7, NOW)
+
+        assert stale == []
+        assert [f.tool for f in unknown] == ["kics"]
+        assert "not comparable" in unknown[0].detail
+
+    def test_equal_pin_stays_silent_and_is_not_unknown(self, monkeypatch):
+        monkeypatch.setattr(ctc, "UPSTREAM_REPOS", {"syft": "anchore/syft"})
+        monkeypatch.setattr(ctc, "fetch_releases", lambda repo: [_release("v1.51.0", 10)])
+
+        stale, unknown = ctc.check_currency({"syft": "v1.51.0"}, 7, NOW)
+
+        assert stale == [] and unknown == []


### PR DESCRIPTION
## Description

`check_tool_currency.py` reported a pin as stale whenever the newest eligible
upstream tag merely **differed** from it:

```python
if normalise(tag) != normalise(pinned):
```

Inequality is not ordering. So a pin sitting *ahead* of that tag was reported as
behind, naming an older version as the upgrade. Against the real repo pins today:

```
STALE  checkov: pinned 3.3.11, 3.3.9 available and 23d old (>= 7d gate) — bridgecrewio/checkov
```

3.3.9 is **older** than what we pin. Anyone acting on that line downgrades a
security scanner, and this report is written into a GitHub issue on a schedule
(#382), so it is read by people who were not in the room when it was generated.

### Why the pin is legitimately ahead

Two independent, entirely normal reasons — this is not a mis-pin:

1. `newest_eligible()` **deliberately** skips releases inside the
   `minimumReleaseAge` cooling window, so the comparison target is routinely
   older than what we already run.
2. Some publishers ship Docker tags with no matching GitHub release at all.
   `bridgecrew/checkov` has GitHub releases for 3.3.9, 3.3.12 and 3.3.13 but
   **none for 3.3.10 or 3.3.11** — and 3.3.11 is what #411 pinned, from Docker Hub.

The checker pins from `containers.py` (Docker) but resolves "latest" from GitHub
releases. Those two sources are not in lockstep, and the code assumed they were.

> String comparison would not have fixed this either: `"3.3.9" > "3.3.11"` is
> `True` lexicographically and `False` numerically. There is a test for that.

## Changes Made
- [x] Fixed bug
- [x] Unit tests added/updated

### Details

**`scripts/ci/check_tool_currency.py`**

New `is_newer(candidate, pinned)` orders with `packaging.version` (already a hard
dependency, and already used this way in `argus/update_check.py`). It returns
`None` when the pair cannot be ordered — a non-semver tag like `latest`/`stable`,
or a missing `packaging`.

`check_currency()` now branches on the result:

| `is_newer` | Behaviour |
|---|---|
| `True` | stale — unchanged from before |
| `False` | silent; the pin is at or ahead of the newest adoptable release |
| `None` | **unknown**, not stale |

Routing the unorderable case to the existing `unknown` bucket matters. That
bucket already renders as *"Could not verify — currency UNKNOWN, not confirmed
current"*, which is exactly true here. It means the guard cannot silently drop a
tool off the backstop; we either order it or we say we could not.

This is the same wrong-direction bug `argus/update_check.py` fixed at
issue #174-1.1.c. That one suppresses entirely on failure, because a bad
`1.1.0 → 1.0.1` arrow actively misleads an end user. Here the audience is a
maintainer reading a triage report, so an explicit "not comparable" line is more
useful than silence — hence `unknown` rather than suppression.

Module docstring updated to state the ordering rule.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed

### Test Results

10 regression tests added to `tests/unit/test_check_tool_currency.py`
(`TestIsNewer`, `TestCurrencyDirection`). **8 of them fail on the pre-fix code**,
including a direct reproduction of the checkov shape:

```
FAILED TestCurrencyDirection::test_pin_ahead_of_newest_eligible_is_not_stale
FAILED TestIsNewer::test_double_digit_segments_compare_numerically
... 8 failed, 35 passed
```

After the fix: **43 passed**.

Verified against the real repo pins, not just fixtures:

```
BEFORE (main)
  STALE  checkov: pinned 3.3.11, 3.3.9 available and 23d old (>= 7d gate)

AFTER
  All tracked pins current and consistent.     exit=0
```

**And confirmed the guard does not silence real staleness** — the failure mode
that would make this change actively harmful. Temporarily reverting the
osv-scanner pin to `v2.4.0` with the fix applied:

```
STALE  osv-scanner: pinned v2.4.0, v2.5.1 available and 8d old (>= 7d gate) — google/osv-scanner
```

Still caught. `--consistency-only` unaffected (exit 0).

`ruff check` clean; `pre-commit run --files <both files>` all hooks pass.

Full suite: no new failures. The pre-existing local failures
(`test_mcp_architecture_resource.py`, `scripts/docsite/tests/test_architecture.py`)
are identical before and after this change and are unrelated environment/drift
issues on `main`.

## Security Considerations
- [x] Security enhancement

### Security Details

The bad line advised downgrading a security scanner. `check_tool_currency.py`
exists to stop pins silently rotting — the docstring cites `osv-scanner` sitting
46 days behind — so a report that points the wrong way undermines the one control
that catches it. It also erodes trust in the whole report: a reader who sees one
obviously-wrong STALE line has reason to skim past a real one.

No change to what is pinned, fetched, or executed. `--fail-on-stale` semantics are
unchanged for genuinely-behind pins.

## AI Context Updates (.ai/)
- [x] N/A - No .ai/ updates needed

Bug fix in a CI script with regression coverage. No component, command, or design
change; the rationale lives in the `is_newer()` docstring and the module docstring
where the next reader will actually hit it.

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (if applicable) — module + function docstrings
- [x] Changelog updated (if applicable) — n/a, release tooling owns this
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**

## Related Issues

Fixes the false positive noted in #382. That issue's body still contains the old
bogus line until `tool-currency.yml` regenerates it.
