### PR TITLE
fix(containers): re-pin clamav digest after upstream tag re-push

### DIFF
--- a/argus/containers.py
+++ b/argus/containers.py
@@ -30,7 +30,7 @@ OFFICIAL_IMAGES = {
     "grype": "anchore/grype:v0.117.0@sha256:ddf9e9f204049f3a4a0955ef70873cabab6a31432125ad4f20a490b54950a253",
     "syft": "anchore/syft:v1.51.0@sha256:678bfa565b60f747aac0f8e964fe5588a24445b8d0a480e91f6efd70020dfbb0",
     "gitleaks": "zricethezav/gitleaks:v8.30.1@sha256:c00b6bd0aeb3071cbcb79009cb16a60dd9e0a7c60e2be9ab65d25e6bc8abbb7f",
-    "clamav": "clamav/clamav:1.5.4@sha256:0e85467cb0d6e7d860a45035707741cd5ffc032ffefc6002a3510c75b6d07027",
+    "clamav": "clamav/clamav:1.5.4@sha256:1fdfd24c6f0a0fb60788481487459a6d4eda8a9b448641594e04db8410d34422",
     "checkov": "bridgecrew/checkov:3.3.11@sha256:e5e308e713725e73f517e4cb85b39d467f1e047204c174fb15eb444c27ffb745",
     # KICS (Checkmarx) multi-format IaC scanner. The upstream
     # ``checkmarx/kics`` repo tags ``:latest`` mutably (no semver release


### PR DESCRIPTION
## Description
`clamav/clamav:1.5.4` was rebuilt upstream on 2026-09-07, replacing the digest behind the unchanged tag. Our `tag@digest` pin no longer verifies, so the **Check container image manifests** step fails. That step is gated to `matrix.python-version == '3.13'`, which is why exactly one job (`Unit Tests (Python 3.13)`) is red on every open PR with no code change behind it.

This re-pins the digest. It unblocks #414, #415, #416, #417, #419 and #383.

## Changes Made
- [x] Fixed bug
- [ ] Added new scanner/workflow
- [ ] Modified existing scanner/workflow
- [ ] Updated documentation
- [ ] Other (please specify)

### Details
- Affects `argus/containers.py` only — the `clamav` entry of `OFFICIAL_IMAGES`.
- Digest `sha256:0e85467c…` → `sha256:1fdfd24c…`, tag stays `1.5.4`.
- No breaking changes; no behaviour change beyond which image layer set is pulled.

This is the failure mode already documented in `.ai/errors.yaml` as `MANIFEST_VERIFICATION_FAILED_FOR_DIGEST_THIRD_PARTY_TAG_REPUSHED_UNDER_US`, and the remediation steps there were followed.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Tested with different scanner combinations

### Test Results
`check_container_images` in **strict** mode (without `--tolerate-registry-errors`, i.e. the release gate's setting):

```
Checking 21 container image manifest(s)...
  ✅ clamav   clamav/clamav:1.5.4@sha256:1fdfd24c6f0a0fb60788481487459a6d4eda8a9b448641594e04db8410d34422
  … (all 21)
All images resolve.
```

Related suites:

```
argus/tests/test_containers.py
tests/unit/test_check_container_images.py
tests/unit/test_check_tool_currency.py
86 passed in 0.10s
```

Also green locally: `check_tool_currency.py --consistency-only` ("All tracked pins current and consistent"), `check_version_refs`.

## Security Considerations
- [ ] No security impact
- [ ] Security enhancement
- [x] Potential security implications (explain below)

### Security Details
A moved tag is indistinguishable at first glance from a hostile re-push, so the new manifest was checked against the old one before trusting it. The old digest is still content-addressable, so both were fetched and compared directly rather than reasoning from absence:

| Check | Result |
|---|---|
| Pusher | `clambotgen84202` — the same bot account behind every other tag in the repo |
| Blast radius | Whole tag set re-pushed in one sweep on 2026-09-07 (`latest`, `stable`, `1.5`, `1.5.4`, `*_base`, debian variants), consistent with a routine rebuild rather than a targeted single-tag swap |
| Media type | Unchanged — `application/vnd.oci.image.index.v1+json` |
| Index entries | Unchanged — 2 (`linux/amd64` + attestation) |
| Layer count | Unchanged — 7 |
| Base layer | Byte-identical |
| Virus DB layer | 112,833,544 → 112,836,124 bytes (~2.5KB), the signature of a CVD refresh |
| Image config | Identical except `created`: entrypoint `/init`, exposed ports `3310/tcp` + `7357/tcp`, env, and the `clamav-bugs@external.cisco.com` maintainer label all unchanged |

Pin posture is unchanged — still `tag@sha256:digest`, which is what made the drift visible in the first place.

## AI Context Updates (.ai/)
- [x] N/A - No .ai/ updates needed

`.ai/errors.yaml` already documents this failure mode and its remediation; no new entry is warranted for an instance of an already-catalogued error. No components, commands, or design decisions changed.

## Checklist
- [x] Code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [ ] Changelog updated (if applicable)
- [x] All tests pass
- [ ] Reviewed by at least one maintainer
- [x] **Reviewed CONTRIBUTING.md guidelines**
